### PR TITLE
version bump

### DIFF
--- a/opentdf.Tiltfile
+++ b/opentdf.Tiltfile
@@ -11,8 +11,8 @@ min_tilt_version("0.30")
 EXTERNAL_URL = "http://localhost:65432"
 
 # Versions of things backend to pull (attributes, kas, etc)
-BACKEND_CHART_TAG = os.environ.get("BACKEND_LATEST_VERSION", "1.1.1")
-FRONTEND_CHART_TAG = os.environ.get("FRONTEND_LATEST_VERSION", "1.1.1")
+BACKEND_CHART_TAG = os.environ.get("BACKEND_LATEST_VERSION", "1.2.0")
+FRONTEND_CHART_TAG = os.environ.get("FRONTEND_LATEST_VERSION", "1.2.0")
 
 CONTAINER_REGISTRY = os.environ.get("CONTAINER_REGISTRY", "ghcr.io")
 POSTGRES_PASSWORD = "myPostgresPassword"


### PR DESCRIPTION
update tests to run on latest pinned version of frontend and backend charts (1.2.0)