### PR TITLE
chore(xtest): Adds ztdf manifest assertions

### DIFF
--- a/xtest/abac.py
+++ b/xtest/abac.py
@@ -205,11 +205,13 @@ class OpentdfCommandLineTool:
         assert code == 0
         return KasGrantAttribute.model_validate_json(out)
 
-    def grant_assign_value(self, kas: KasEntry, attr: Attribute) -> KasGrantAttribute:
+    def grant_assign_value(
+        self, kas: KasEntry, val: AttributeValue
+    ) -> KasGrantAttribute:
         cmd = self.otdfctl + "policy kas-grants update".split()
         cmd += [
             f"--kas-id={kas.id}",
-            f"--value-id={attr.id}",
+            f"--value-id={val.id}",
         ]
         logger.info(f"grant-update [{' '.join(cmd)}]")
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -239,11 +241,11 @@ class OpentdfCommandLineTool:
         assert code == 0
         return KasGrantAttribute.model_validate_json(out)
 
-    def grant_unassign_value(self, kas: KasEntry, attr: Attribute) -> KasGrantValue:
+    def grant_unassign_value(self, kas: KasEntry, val: AttributeValue) -> KasGrantValue:
         cmd = self.otdfctl + "policy kas-grants remove".split()
         cmd += [
             f"--kas-id={kas.id}",
-            f"--value-id={attr.id}",
+            f"--value-id={val.id}",
         ]
         logger.info(f"grant-update [{' '.join(cmd)}]")
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE)

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -41,7 +41,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("decrypt_sdk", decrypt_sdks)
     if "container" in metafunc.fixturenames:
         if metafunc.config.getoption("--containers"):
-            containers = metafunc.config.getoption("--container").split()
+            containers = metafunc.config.getoption("--containers").split()
         else:
             containers = ["nano", "ztdf"]
         metafunc.parametrize("container", containers)

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -1,5 +1,8 @@
 import logging
 import subprocess
+import zipfile
+
+from pydantic import BaseModel
 
 logger = logging.getLogger("xtest")
 logging.basicConfig()
@@ -11,6 +14,76 @@ sdk_paths = {
     "java": "sdk/java/cli.sh",
     "js": "sdk/js/cli/cli.sh",
 }
+
+
+class PolicyBinding(BaseModel):
+    alg: str
+    hash: str
+
+
+class KeyAccessObject(BaseModel):
+    type: str
+    url: str
+    protocol: str
+    wrappedKey: str
+    policyBinding: str | PolicyBinding
+    encryptedMetadata: str | None = None
+    kid: str | None = None
+    sid: str | None = None
+    tdf_spec_version: str | None = None
+
+
+class EncryptionMethod(BaseModel):
+    algorithm: str
+    iv: str | None = None
+    isStreamable: bool | None = False
+
+
+class IntegritySignature(BaseModel):
+    alg: str | None = "HS256"
+    sig: str
+
+
+class IntegritySegment(BaseModel):
+    hash: str
+    segmentSize: int | None = None
+    encryptedSegmentSize: int | None = None
+
+
+class Integrity(BaseModel):
+    rootSignature: IntegritySignature
+    segmentHashAlg: str
+    segmentSizeDefault: int | None = 0
+    encryptedSegmentSizeDefault: int | None = 0
+    segments: list[IntegritySegment] | None = None
+
+
+class PayloadReference(BaseModel):
+    type: str
+    url: str
+    protocol: str
+    isEncrypted: bool
+    mimeType: str | None = None
+    tdf_spec_version: str | None = None
+
+
+class EncryptionInformation(BaseModel):
+    type: str
+    policy: str
+    keyAccess: list[KeyAccessObject]
+    method: EncryptionMethod
+    integrityInformation: Integrity
+
+
+class Manifest(BaseModel):
+    encryptionInformation: EncryptionInformation
+    payload: PayloadReference
+
+
+def manifest(tdf_file: str) -> Manifest:
+    with zipfile.ZipFile(tdf_file, "r") as tdfz:
+        with tdfz.open("0.manifest.json") as manifestEntry:
+            return Manifest.model_validate_json(manifestEntry.read())
 
 
 def encrypt(

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -96,6 +96,12 @@ def test_autoconfigure_one_attribute(tmp_dir, pt_file):
         fmt="ztdf",
         attr_values=[f"https://{random_ns}/attr/letra/value/alpha"],
     )
+    manifest = tdfs.manifest(ct_file)
+    assert len(manifest.encryptionInformation.keyAccess) == 2
+    assert (
+        manifest.encryptionInformation.keyAccess[0].sid
+        == manifest.encryptionInformation.keyAccess[1].sid
+    )
 
     rt_file = f"{tmp_dir}test-abac.untdf"
     tdfs.decrypt("go", ct_file, rt_file, "ztdf")
@@ -160,6 +166,12 @@ def test_autoconfigure_double_kas(tmp_dir, pt_file):
             f"https://{random_ns}/attr/ot/value/alef",
             f"https://{random_ns}/attr/ot/value/bet",
         ],
+    )
+    manifest = tdfs.manifest(ct_file)
+    assert len(manifest.encryptionInformation.keyAccess) == 2
+    assert (
+        manifest.encryptionInformation.keyAccess[0].sid
+        != manifest.encryptionInformation.keyAccess[1].sid
     )
 
     rt_file = f"{tmp_dir}test-abac-double.untdf"

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -228,6 +228,9 @@ def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
         manifest.encryptionInformation.keyAccess[0].sid
         != manifest.encryptionInformation.keyAccess[1].sid
     )
+    assert set(["http://localhost:8080", "http://localhost:8282"]) == set(
+        [kao.url for kao in manifest.encryptionInformation.keyAccess]
+    )
 
     rt_file = f"{tmp_dir}test-abac-double.untdf"
     tdfs.decrypt("go", ct_file, rt_file, "ztdf")

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -157,6 +157,9 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
         manifest.encryptionInformation.keyAccess[0].sid
         == manifest.encryptionInformation.keyAccess[1].sid
     )
+    assert set(["http://localhost:8080", "http://localhost:8282"]) == set(
+        [kao.url for kao in manifest.encryptionInformation.keyAccess]
+    )
 
     rt_file = f"{tmp_dir}test-abac-or.untdf"
     tdfs.decrypt("go", ct_file, rt_file, "ztdf")

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -47,7 +47,7 @@ def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
     ns = otdfctl.namespace_create(random_ns)
     anyof = otdfctl.attribute_create(ns, "letra", abac.AttributeRule.ANY_OF, ["alpha"])
-    alpha = anyof.values
+    (alpha,) = anyof.values
     assert alpha.value == "alpha"
 
     # Then assign it to all clientIds = opentdf-sdk

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -17,6 +17,9 @@ def test_ztdf(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, container):
         tdfs.encrypt(
             encrypt_sdk, pt_file, ct_file, mime_type="text/plain", fmt=container
         )
+        if container == "ztdf":
+            manifest = tdfs.manifest(ct_file)
+            assert manifest.payload.isEncrypted
         cipherTexts[container_id] = ct_file
     ct_file = cipherTexts[container_id]
     assert os.path.isfile(ct_file)


### PR DESCRIPTION
- Validates that manifests are well formed using pydantic written from the spec
- In abac tests, validates that the KAOs have the format expected for shares and splits