### PR TITLE
chore(xtest): Canonical kas path is /kas

### DIFF
--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -73,7 +73,7 @@ def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     assert sm.attribute_value.value == "alpha"
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8080", "../../platform/kas-cert.pem"
+        "http://localhost:8080/kas", "../../platform/kas-cert.pem"
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
@@ -154,12 +154,12 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
     assert sm.attribute_value.value == "alpha"
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8080", "../../platform/kas-cert.pem"
+        "http://localhost:8080/kas", "../../platform/kas-cert.pem"
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8282", "../../platform/kas-cert.pem"
+        "http://localhost:8282/kas", "../../platform/kas-cert.pem"
     )
     otdfctl.grant_assign_value(kas_entry_beta, beta)
 
@@ -183,7 +183,7 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
         manifest.encryptionInformation.keyAccess[0].sid
         == manifest.encryptionInformation.keyAccess[1].sid
     )
-    assert set(["http://localhost:8080", "http://localhost:8282"]) == set(
+    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
 
@@ -213,7 +213,7 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
         manifest.encryptionInformation.keyAccess[0].sid
         == manifest.encryptionInformation.keyAccess[1].sid
     )
-    assert set(["http://localhost:8080", "http://localhost:8282"]) == set(
+    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
 
@@ -262,12 +262,12 @@ def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
     assert sm2.attribute_value.value == "bet"
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8080", "../platform/kas-cert.pem"
+        "http://localhost:8080/kas", "../platform/kas-cert.pem"
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alef)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8282", "../platform/kas-cert.pem"
+        "http://localhost:8282/kas", "../platform/kas-cert.pem"
     )
     otdfctl.grant_assign_value(kas_entry_beta, bet)
 
@@ -291,7 +291,7 @@ def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
         manifest.encryptionInformation.keyAccess[0].sid
         != manifest.encryptionInformation.keyAccess[1].sid
     )
-    assert set(["http://localhost:8080", "http://localhost:8282"]) == set(
+    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
 
@@ -321,7 +321,7 @@ def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
         manifest.encryptionInformation.keyAccess[0].sid
         != manifest.encryptionInformation.keyAccess[1].sid
     )
-    assert set(["http://localhost:8080", "http://localhost:8282"]) == set(
+    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
 


### PR DESCRIPTION
I guess?