### PR TITLE
chore(xtest): Adds support for xtesting experimental features

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         default: main
+      feature-flags:
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "30 6 * * *"
 jobs:
@@ -202,7 +206,7 @@ jobs:
 
       - name: Run attribute based configuration tests
         run: |-
-          pytest test_abac.py
+          pytest test_abac.py --feature-flags ${{ toJSON(inputs.feature-flags || 'standard') }}
         working-directory: otdftests/xtest
 
 ###### TODO: move these unbound tests to v2 platform

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -1,8 +1,9 @@
+import abac
 import os
 import pytest
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     parser.addoption(
         "--large",
         action="store_true",
@@ -14,9 +15,10 @@ def pytest_addoption(parser):
     parser.addoption("--sdks-decrypt", help="select which sdks to run for decrypt only")
     parser.addoption("--sdks-encrypt", help="select which sdks to run for encrypt only")
     parser.addoption("--containers", help="which container formats to test")
+    parser.addoption("--feature-flags", help="which experimental features to test")
 
 
-def pytest_generate_tests(metafunc):
+def pytest_generate_tests(metafunc) -> None:
     if "size" in metafunc.fixturenames:
         metafunc.parametrize(
             "size", ["large" if metafunc.config.getoption("large") else "small"]
@@ -43,10 +45,17 @@ def pytest_generate_tests(metafunc):
         else:
             containers = ["nano", "ztdf"]
         metafunc.parametrize("container", containers)
+    if "feature_flag" in metafunc.fixturenames:
+        if metafunc.config.getoption("--feature-flags"):
+            flags = metafunc.config.getoption("--feature-flags").split()
+            feature_flags = set(["standard"] + flags)
+        else:
+            feature_flags = set(["standard"])
+        metafunc.parametrize("feature_flag", feature_flags)
 
 
 @pytest.fixture
-def pt_file(tmp_dir, size):
+def pt_file(tmp_dir: str, size) -> str:
     pt_file = f"{tmp_dir}test-plain-{size}.txt"
     length = (5 * 2**30) if size == "large" else 128
     with open(pt_file, "w") as f:
@@ -56,9 +65,46 @@ def pt_file(tmp_dir, size):
 
 
 @pytest.fixture
-def tmp_dir():
+def tmp_dir() -> str:
     dname = "tmp/"
     isExist = os.path.exists(dname)
     if not isExist:
         os.makedirs(dname)
     return dname
+
+
+@pytest.fixture
+def kas_public_keys(feature_flag: str) -> abac.PublicKey:
+    def load_cached_kas_keys() -> abac.PublicKey:
+        keyset: list[abac.KasPublicKey] = []
+        with open("../../platform/kas-cert.pem", "r") as rsaFile:
+            keyset.append(
+                abac.KasPublicKey(
+                    alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048,
+                    kid="r1",
+                    pem=rsaFile.read(),
+                )
+            )
+        with open("../../platform/kas-ec-cert.pem", "r") as ecFile:
+            keyset.append(
+                abac.KasPublicKey(
+                    alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1,
+                    kid="e1",
+                    pem=ecFile.read(),
+                )
+            )
+        return abac.PublicKey(
+            cached=abac.KasPublicKeySet(
+                keys=keyset,
+            )
+        )
+
+    def load_local_kas_key() -> abac.PublicKey:
+        with open("../../platform/kas-cert.pem", "r") as rsaFile:
+            return abac.PublicKey(
+                local=rsaFile.read(),
+            )
+
+    if feature_flag == "cached_key":
+        return load_cached_kas_keys()
+    return load_local_kas_key()

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -42,39 +42,9 @@ def test_scs_create():
     assert len(sc.subject_sets) == 1
 
 
-def load_cached_kas_keys() -> abac.PublicKey:
-    keyset: list[abac.KasPublicKey] = []
-    with open("../../platform/kas-cert.pem", "r") as rsaFile:
-        keyset.append(
-            abac.KasPublicKey(
-                alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048,
-                kid="r1",
-                pem=rsaFile.read(),
-            )
-        )
-    with open("../../platform/kas-ec-cert.pem", "r") as ecFile:
-        keyset.append(
-            abac.KasPublicKey(
-                alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1,
-                kid="e1",
-                pem=ecFile.read(),
-            )
-        )
-    return abac.PublicKey(
-        cached=abac.KasPublicKeySet(
-            keys=keyset,
-        )
-    )
-
-
-def load_local_kas_key() -> abac.PublicKey:
-    with open("../../platform/kas-cert.pem", "r") as rsaFile:
-        return abac.PublicKey(
-            local=rsaFile.read(),
-        )
-
-
-def test_autoconfigure_one_attribute(tmp_dir, pt_file):
+def test_autoconfigure_one_attribute(
+    tmp_dir: str, pt_file: str, kas_public_keys: abac.PublicKey
+):
     # Create a new attribute in a random namespace
     random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
     ns = otdfctl.namespace_create(random_ns)
@@ -107,7 +77,7 @@ def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_local_kas_key(),
+        kas_public_keys,
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
@@ -160,7 +130,9 @@ def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     assert filecmp.cmp(pt_file, rt_file_3)
 
 
-def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
+def test_autoconfigure_two_kas_or(
+    tmp_dir: str, pt_file: str, kas_public_keys: abac.PublicKey
+) -> None:
     # Create a new attribute in a random namespace
     random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
     ns = otdfctl.namespace_create(random_ns)
@@ -196,13 +168,13 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_local_kas_key(),
+        kas_public_keys,
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8282/kas",
-        load_local_kas_key(),
+        kas_public_keys,
     )
     otdfctl.grant_assign_value(kas_entry_beta, beta)
 
@@ -274,7 +246,9 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
     assert filecmp.cmp(pt_file, rt_file_3)
 
 
-def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
+def test_autoconfigure_double_kas_and(
+    tmp_dir: str, pt_file: str, kas_public_keys: abac.PublicKey
+) -> None:
     # Create a new attribute in a random namespace
     random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
     ns = otdfctl.namespace_create(random_ns)
@@ -313,13 +287,13 @@ def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_local_kas_key(),
+        kas_public_keys,
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alef)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8282/kas",
-        load_local_kas_key(),
+        kas_public_keys,
     )
     otdfctl.grant_assign_value(kas_entry_beta, bet)
 

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -67,6 +67,13 @@ def load_cached_kas_keys() -> abac.PublicKey:
     )
 
 
+def load_local_kas_key() -> abac.PublicKey:
+    with open("../../platform/kas-cert.pem", "r") as rsaFile:
+        return abac.PublicKey(
+            local=rsaFile.read(),
+        )
+
+
 def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     # Create a new attribute in a random namespace
     random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
@@ -100,7 +107,7 @@ def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_cached_kas_keys(),
+        load_local_kas_key(),
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
@@ -189,13 +196,13 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_cached_kas_keys(),
+        load_local_kas_key(),
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8282/kas",
-        load_cached_kas_keys(),
+        load_local_kas_key(),
     )
     otdfctl.grant_assign_value(kas_entry_beta, beta)
 
@@ -306,13 +313,13 @@ def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_cached_kas_keys(),
+        load_local_kas_key(),
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alef)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8282/kas",
-        load_cached_kas_keys(),
+        load_local_kas_key(),
     )
     otdfctl.grant_assign_value(kas_entry_beta, bet)
 

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -67,13 +67,6 @@ def load_cached_kas_keys() -> abac.PublicKey:
     )
 
 
-def load_local_kas_key() -> abac.PublicKey:
-    with open("../../platform/kas-cert.pem", "r") as rsaFile:
-        return abac.PublicKey(
-            local=rsaFile.read(),
-        )
-
-
 def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     # Create a new attribute in a random namespace
     random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
@@ -107,7 +100,7 @@ def test_autoconfigure_one_attribute(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_local_kas_key(),
+        load_cached_kas_keys(),
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
@@ -196,13 +189,13 @@ def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_local_kas_key(),
+        load_cached_kas_keys(),
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alpha)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8282/kas",
-        load_local_kas_key(),
+        load_cached_kas_keys(),
     )
     otdfctl.grant_assign_value(kas_entry_beta, beta)
 
@@ -313,13 +306,13 @@ def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8080/kas",
-        load_local_kas_key(),
+        load_cached_kas_keys(),
     )
     otdfctl.grant_assign_value(kas_entry_alpha, alef)
 
     kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
         "http://localhost:8282/kas",
-        load_local_kas_key(),
+        load_cached_kas_keys(),
     )
     otdfctl.grant_assign_value(kas_entry_beta, bet)
 


### PR DESCRIPTION
- Adds `feature-flags` input parameter, optional space-separated list of new features to test
- Currently, only `cached_key` is enabled, which when set enabled the new `cached` field in the kas registry