### PR TITLE
refactor(xtest): let abac tests use fixtures

### DIFF
--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -1,5 +1,9 @@
 import os
 import pytest
+import random
+import string
+
+import abac
 
 
 def pytest_addoption(parser):
@@ -62,3 +66,206 @@ def tmp_dir():
     if not isExist:
         os.makedirs(dname)
     return dname
+
+
+_otdfctl = abac.OpentdfCommandLineTool()
+
+
+@pytest.fixture
+def otdfctl():
+    return _otdfctl
+
+
+@pytest.fixture
+def temporary_namespace(otdfctl: abac.OpentdfCommandLineTool):
+    # Create a new attribute in a random namespace
+    random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
+    ns = otdfctl.namespace_create(random_ns)
+    return ns
+
+
+PLATFORM_DIR = "../../platform"
+
+
+def load_cached_kas_keys() -> abac.PublicKey:
+    keyset: list[abac.KasPublicKey] = []
+    with open(f"{PLATFORM_DIR}/kas-cert.pem", "r") as rsaFile:
+        keyset.append(
+            abac.KasPublicKey(
+                alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048,
+                kid="r1",
+                pem=rsaFile.read(),
+            )
+        )
+    with open(f"{PLATFORM_DIR}/kas-ec-cert.pem", "r") as ecFile:
+        keyset.append(
+            abac.KasPublicKey(
+                alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1,
+                kid="e1",
+                pem=ecFile.read(),
+            )
+        )
+    return abac.PublicKey(
+        cached=abac.KasPublicKeySet(
+            keys=keyset,
+        )
+    )
+
+
+@pytest.fixture
+def kas_url1():
+    return os.getenv("KASURL", "http://localhost:8080/kas")
+
+
+@pytest.fixture
+def kas_url2():
+    return os.getenv("KASURL2", "http://localhost:8282/kas")
+
+
+@pytest.fixture
+def attribute_single_kas_grant(
+    otdfctl: abac.OpentdfCommandLineTool,
+    kas_url1: str,
+    temporary_namespace: abac.Namespace,
+):
+    anyof = otdfctl.attribute_create(
+        temporary_namespace, "letra", abac.AttributeRule.ANY_OF, ["alpha"]
+    )
+    assert anyof.values
+    (alpha,) = anyof.values
+    assert alpha.value == "alpha"
+
+    # Then assign it to all clientIds = opentdf-sdk
+    sc = otdfctl.scs_create(
+        [
+            abac.SubjectSet(
+                condition_groups=[
+                    abac.ConditionGroup(
+                        boolean_operator=abac.ConditionBooleanTypeEnum.OR,
+                        conditions=[
+                            abac.Condition(
+                                subject_external_selector_value=".clientId",
+                                operator=abac.SubjectMappingOperatorEnum.IN,
+                                subject_external_values=["opentdf", "opentdf-sdk"],
+                            )
+                        ],
+                    )
+                ]
+            )
+        ],
+    )
+    sm = otdfctl.scs_map(sc, alpha)
+    assert sm.attribute_value.value == "alpha"
+    # Now assign it to the current KAS
+    kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
+        kas_url1,
+        load_cached_kas_keys(),
+    )
+    otdfctl.grant_assign_value(kas_entry_alpha, alpha)
+    return anyof
+
+
+@pytest.fixture
+def attribute_two_kas_grant_or(
+    otdfctl: abac.OpentdfCommandLineTool,
+    kas_url1: str,
+    kas_url2: str,
+    temporary_namespace: abac.Namespace,
+):
+    anyof = otdfctl.attribute_create(
+        temporary_namespace, "letra", abac.AttributeRule.ANY_OF, ["alpha", "beta"]
+    )
+    assert anyof.values
+    alpha, beta = anyof.values
+    assert alpha.value == "alpha"
+    assert beta.value == "beta"
+
+    # Then assign it to all clientIds = opentdf-sdk
+    sc = otdfctl.scs_create(
+        [
+            abac.SubjectSet(
+                condition_groups=[
+                    abac.ConditionGroup(
+                        boolean_operator=abac.ConditionBooleanTypeEnum.OR,
+                        conditions=[
+                            abac.Condition(
+                                subject_external_selector_value=".clientId",
+                                operator=abac.SubjectMappingOperatorEnum.IN,
+                                subject_external_values=["opentdf", "opentdf-sdk"],
+                            )
+                        ],
+                    )
+                ]
+            )
+        ],
+    )
+    sm = otdfctl.scs_map(sc, alpha)
+    assert sm.attribute_value.value == "alpha"
+    # Now assign it to the current KAS
+    kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
+        kas_url1,
+        load_cached_kas_keys(),
+    )
+    otdfctl.grant_assign_value(kas_entry_alpha, alpha)
+
+    kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
+        kas_url2,
+        load_cached_kas_keys(),
+    )
+    otdfctl.grant_assign_value(kas_entry_beta, beta)
+    return anyof
+
+
+@pytest.fixture
+def attribute_two_kas_grant_and(
+    otdfctl: abac.OpentdfCommandLineTool,
+    kas_url1: str,
+    kas_url2: str,
+    temporary_namespace: abac.Namespace,
+):
+    allof = otdfctl.attribute_create(
+        temporary_namespace, "ot", abac.AttributeRule.ALL_OF, ["alef", "bet", "gimmel"]
+    )
+    assert allof.values
+    alef, bet, gimmel = allof.values
+    assert alef.value == "alef"
+    assert bet.value == "bet"
+    assert gimmel.value == "gimmel"
+
+    # Then assign it to all clientIds = opentdf-sdk
+    sc = otdfctl.scs_create(
+        [
+            abac.SubjectSet(
+                condition_groups=[
+                    abac.ConditionGroup(
+                        boolean_operator=abac.ConditionBooleanTypeEnum.OR,
+                        conditions=[
+                            abac.Condition(
+                                subject_external_selector_value=".clientId",
+                                operator=abac.SubjectMappingOperatorEnum.IN,
+                                subject_external_values=["opentdf", "opentdf-sdk"],
+                            )
+                        ],
+                    )
+                ]
+            )
+        ],
+    )
+    sm1 = otdfctl.scs_map(sc, alef)
+    assert sm1.attribute_value.value == "alef"
+    sm2 = otdfctl.scs_map(sc, bet)
+    assert sm2.attribute_value.value == "bet"
+    # Now assign it to the current KAS
+    kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
+        kas_url1,
+        load_cached_kas_keys(),
+    )
+    otdfctl.grant_assign_value(kas_entry_alpha, alef)
+
+    kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
+        kas_url2,
+        load_cached_kas_keys(),
+    )
+    otdfctl.grant_assign_value(kas_entry_beta, bet)
+
+    return allof

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -49,7 +49,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("container", containers)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def pt_file(tmp_dir, size):
     pt_file = f"{tmp_dir}test-plain-{size}.txt"
     length = (5 * 2**30) if size == "large" else 128
@@ -59,7 +59,7 @@ def pt_file(tmp_dir, size):
     return pt_file
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def tmp_dir():
     dname = "tmp/"
     isExist = os.path.exists(dname)
@@ -71,12 +71,12 @@ def tmp_dir():
 _otdfctl = abac.OpentdfCommandLineTool()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def otdfctl():
     return _otdfctl
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def temporary_namespace(otdfctl: abac.OpentdfCommandLineTool):
     # Create a new attribute in a random namespace
     random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
@@ -112,17 +112,17 @@ def load_cached_kas_keys() -> abac.PublicKey:
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def kas_url1():
     return os.getenv("KASURL", "http://localhost:8080/kas")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def kas_url2():
     return os.getenv("KASURL2", "http://localhost:8282/kas")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def attribute_single_kas_grant(
     otdfctl: abac.OpentdfCommandLineTool,
     kas_url1: str,
@@ -165,7 +165,7 @@ def attribute_single_kas_grant(
     return anyof
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def attribute_two_kas_grant_or(
     otdfctl: abac.OpentdfCommandLineTool,
     kas_url1: str,
@@ -216,7 +216,7 @@ def attribute_two_kas_grant_or(
     return anyof
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def attribute_two_kas_grant_and(
     otdfctl: abac.OpentdfCommandLineTool,
     kas_url1: str,

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -131,11 +131,11 @@ def attribute_single_kas_grant(
     temporary_namespace: abac.Namespace,
 ):
     anyof = otdfctl.attribute_create(
-        temporary_namespace, "letra", abac.AttributeRule.ANY_OF, ["alpha"]
+        temporary_namespace, "letter", abac.AttributeRule.ANY_OF, ["a"]
     )
     assert anyof.values
     (alpha,) = anyof.values
-    assert alpha.value == "alpha"
+    assert alpha.value == "a"
 
     # Then assign it to all clientIds = opentdf-sdk
     sc = otdfctl.scs_create(
@@ -157,7 +157,7 @@ def attribute_single_kas_grant(
         ],
     )
     sm = otdfctl.scs_map(sc, alpha)
-    assert sm.attribute_value.value == "alpha"
+    assert sm.attribute_value.value == "a"
     # Now assign it to the current KAS
     kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
         kas_url1,

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -23,7 +23,9 @@ def pytest_addoption(parser):
 def pytest_generate_tests(metafunc):
     if "size" in metafunc.fixturenames:
         metafunc.parametrize(
-            "size", ["large" if metafunc.config.getoption("large") else "small"]
+            "size",
+            ["large" if metafunc.config.getoption("large") else "small"],
+            scope="session",
         )
     if "encrypt_sdk" in metafunc.fixturenames:
         if metafunc.config.getoption("--sdks-encrypt"):

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -1,351 +1,127 @@
 import filecmp
-import random
-import string
+import pytest
 
-import abac
 import tdfs
 
 
-otdfctl = abac.OpentdfCommandLineTool()
+cipherTexts = {}
 
 
-def load_cached_kas_keys() -> abac.PublicKey:
-    keyset: list[abac.KasPublicKey] = []
-    with open("../../platform/kas-cert.pem", "r") as rsaFile:
-        keyset.append(
-            abac.KasPublicKey(
-                alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_RSA_2048,
-                kid="r1",
-                pem=rsaFile.read(),
-            )
-        )
-    with open("../../platform/kas-ec-cert.pem", "r") as ecFile:
-        keyset.append(
-            abac.KasPublicKey(
-                alg=abac.KAS_PUBLIC_KEY_ALG_ENUM_EC_SECP256R1,
-                kid="e1",
-                pem=ecFile.read(),
-            )
-        )
-    return abac.PublicKey(
-        cached=abac.KasPublicKeySet(
-            keys=keyset,
-        )
-    )
-
-
-def test_autoconfigure_one_attribute(tmp_dir, pt_file):
-    # Create a new attribute in a random namespace
-    random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
-    ns = otdfctl.namespace_create(random_ns)
-    anyof = otdfctl.attribute_create(ns, "letra", abac.AttributeRule.ANY_OF, ["alpha"])
-    assert anyof.values
-    (alpha,) = anyof.values
-    assert alpha.value == "alpha"
-
-    # Then assign it to all clientIds = opentdf-sdk
-    sc = otdfctl.scs_create(
-        [
-            abac.SubjectSet(
-                condition_groups=[
-                    abac.ConditionGroup(
-                        boolean_operator=abac.ConditionBooleanTypeEnum.OR,
-                        conditions=[
-                            abac.Condition(
-                                subject_external_selector_value=".clientId",
-                                operator=abac.SubjectMappingOperatorEnum.IN,
-                                subject_external_values=["opentdf", "opentdf-sdk"],
-                            )
-                        ],
-                    )
-                ]
-            )
-        ],
-    )
-    sm = otdfctl.scs_map(sc, alpha)
-    assert sm.attribute_value.value == "alpha"
-    # Now assign it to the current KAS
-    kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8080/kas",
-        load_cached_kas_keys(),
-    )
-    otdfctl.grant_assign_value(kas_entry_alpha, alpha)
-
+def test_autoconfigure_one_attribute(
+    attribute_single_kas_grant, encrypt_sdk, decrypt_sdk, tmp_dir, pt_file
+):
+    global counter
     # We have a grant for alpha to localhost kas. Now try to use it...
 
-    # Encrypt go
-    ct_file = f"{tmp_dir}test-abac-one.tdf"
-    tdfs.encrypt(
-        "go",
-        pt_file,
-        ct_file,
-        mime_type="text/plain",
-        fmt="ztdf",
-        attr_values=[f"https://{random_ns}/attr/letra/value/alpha"],
-    )
+    if encrypt_sdk not in ["go", "java"]:
+        pytest.skip(f"sdk doesn't yet support autoconfigure [{encrypt_sdk}]")
+
+    sample_name = f"test-abac-one-{encrypt_sdk}"
+    if sample_name in cipherTexts:
+        ct_file = cipherTexts[sample_name]
+    else:
+        ct_file = f"{tmp_dir}{sample_name}.tdf"
+        cipherTexts[sample_name] = ct_file
+        tdfs.encrypt(
+            encrypt_sdk,
+            pt_file,
+            ct_file,
+            mime_type="text/plain",
+            fmt="ztdf",
+            attr_values=[attribute_single_kas_grant.values[0].fqn],
+        )
+        cipherTexts[sample_name] = ct_file
     manifest = tdfs.manifest(ct_file)
     assert len(manifest.encryptionInformation.keyAccess) == 1
 
-    rt_file = f"{tmp_dir}test-abac-one.untdf"
-    rt_file_2 = f"{tmp_dir}test-abac-one-2.untdf"
-    rt_file_3 = f"{tmp_dir}test-abac-one-3.untdf"
-    tdfs.decrypt("go", ct_file, rt_file, "ztdf")
+    rt_file = f"{tmp_dir}test-abac-one-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
-    tdfs.decrypt("java", ct_file, rt_file_2, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_2)
-    tdfs.decrypt("js", ct_file, rt_file_3, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_3)
-
-    # Encrypt java
-    ct_file = f"{tmp_dir}test-abac-one-2.tdf"
-    tdfs.encrypt(
-        "java",
-        pt_file,
-        ct_file,
-        mime_type="text/plain",
-        fmt="ztdf",
-        attr_values=[f"https://{random_ns}/attr/letra/value/alpha"],
-    )
-    manifest = tdfs.manifest(ct_file)
-    assert len(manifest.encryptionInformation.keyAccess) == 1
-
-    rt_file = f"{tmp_dir}test-abac-one-3.untdf"
-    rt_file_2 = f"{tmp_dir}test-abac-one-4.untdf"
-    rt_file_3 = f"{tmp_dir}test-abac-one-5.untdf"
-    tdfs.decrypt("go", ct_file, rt_file, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file)
-    tdfs.decrypt("java", ct_file, rt_file_2, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_2)
-    tdfs.decrypt("js", ct_file, rt_file_3, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_3)
 
 
-def test_autoconfigure_two_kas_or(tmp_dir, pt_file):
-    # Create a new attribute in a random namespace
-    random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
-    ns = otdfctl.namespace_create(random_ns)
-    anyof = otdfctl.attribute_create(
-        ns, "letra", abac.AttributeRule.ANY_OF, ["alpha", "beta"]
-    )
-    assert anyof.values
-    alpha, beta = anyof.values
-    assert alpha.value == "alpha"
-    assert beta.value == "beta"
+def test_autoconfigure_two_kas_or(
+    attribute_two_kas_grant_or,
+    encrypt_sdk,
+    decrypt_sdk,
+    tmp_dir,
+    pt_file,
+    kas_url1: str,
+    kas_url2: str,
+):
+    if encrypt_sdk not in ["go", "java"]:
+        pytest.skip(f"sdk doesn't yet support autoconfigure [{encrypt_sdk}]")
 
-    # Then assign it to all clientIds = opentdf-sdk
-    sc = otdfctl.scs_create(
-        [
-            abac.SubjectSet(
-                condition_groups=[
-                    abac.ConditionGroup(
-                        boolean_operator=abac.ConditionBooleanTypeEnum.OR,
-                        conditions=[
-                            abac.Condition(
-                                subject_external_selector_value=".clientId",
-                                operator=abac.SubjectMappingOperatorEnum.IN,
-                                subject_external_values=["opentdf", "opentdf-sdk"],
-                            )
-                        ],
-                    )
-                ]
-            )
-        ],
-    )
-    sm = otdfctl.scs_map(sc, alpha)
-    assert sm.attribute_value.value == "alpha"
-    # Now assign it to the current KAS
-    kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8080/kas",
-        load_cached_kas_keys(),
-    )
-    otdfctl.grant_assign_value(kas_entry_alpha, alpha)
-
-    kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8282/kas",
-        load_cached_kas_keys(),
-    )
-    otdfctl.grant_assign_value(kas_entry_beta, beta)
-
-    # We have a grant for alpha to localhost kas. Now try to use it...
-    # encrypt go
-    ct_file = f"{tmp_dir}test-abac-or.tdf"
-    tdfs.encrypt(
-        "go",
-        pt_file,
-        ct_file,
-        mime_type="text/plain",
-        fmt="ztdf",
-        attr_values=[
-            f"https://{random_ns}/attr/letra/value/alpha",
-            f"https://{random_ns}/attr/letra/value/beta",
-        ],
-    )
+    sample_name = f"test-abac-two-{encrypt_sdk}"
+    if sample_name in cipherTexts:
+        ct_file = cipherTexts[sample_name]
+    else:
+        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        tdfs.encrypt(
+            encrypt_sdk,
+            pt_file,
+            ct_file,
+            mime_type="text/plain",
+            fmt="ztdf",
+            attr_values=[
+                attribute_two_kas_grant_or.values[0].fqn,
+                attribute_two_kas_grant_or.values[1].fqn,
+            ],
+        )
+        cipherTexts[sample_name] = ct_file
     manifest = tdfs.manifest(ct_file)
     assert len(manifest.encryptionInformation.keyAccess) == 2
     assert (
         manifest.encryptionInformation.keyAccess[0].sid
         == manifest.encryptionInformation.keyAccess[1].sid
     )
-    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
+    assert set([kas_url1, kas_url2]) == set(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
 
-    rt_file = f"{tmp_dir}test-abac-or.untdf"
-    rt_file_2 = f"{tmp_dir}test-abac-or-2.untdf"
-    rt_file_3 = f"{tmp_dir}test-abac-or-3.untdf"
-    tdfs.decrypt("go", ct_file, rt_file, "ztdf")
+    rt_file = f"{tmp_dir}test-abac-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
-    tdfs.decrypt("java", ct_file, rt_file_2, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_2)
-    tdfs.decrypt("js", ct_file, rt_file_3, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_3)
-
-    # encrypt java
-    ct_file = f"{tmp_dir}test-abac-or-2.tdf"
-    tdfs.encrypt(
-        "java",
-        pt_file,
-        ct_file,
-        mime_type="text/plain",
-        fmt="ztdf",
-        attr_values=[
-            f"https://{random_ns}/attr/letra/value/alpha",
-            f"https://{random_ns}/attr/letra/value/beta",
-        ],
-    )
-    manifest = tdfs.manifest(ct_file)
-    assert len(manifest.encryptionInformation.keyAccess) == 2
-    assert (
-        manifest.encryptionInformation.keyAccess[0].sid
-        == manifest.encryptionInformation.keyAccess[1].sid
-    )
-    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
-        [kao.url for kao in manifest.encryptionInformation.keyAccess]
-    )
-
-    rt_file = f"{tmp_dir}test-abac-or-3.untdf"
-    rt_file_2 = f"{tmp_dir}test-abac-or-4.untdf"
-    rt_file_3 = f"{tmp_dir}test-abac-or-5.untdf"
-    tdfs.decrypt("go", ct_file, rt_file, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file)
-    tdfs.decrypt("java", ct_file, rt_file_2, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_2)
-    tdfs.decrypt("js", ct_file, rt_file_3, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_3)
 
 
-def test_autoconfigure_double_kas_and(tmp_dir, pt_file):
-    # Create a new attribute in a random namespace
-    random_ns = "".join(random.choices(string.ascii_lowercase, k=8)) + ".com"
-    ns = otdfctl.namespace_create(random_ns)
-    allof = otdfctl.attribute_create(
-        ns, "ot", abac.AttributeRule.ALL_OF, ["alef", "bet", "gimmel"]
-    )
-    assert allof.values
-    alef, bet, gimmel = allof.values
-    assert alef.value == "alef"
-    assert bet.value == "bet"
-    assert gimmel.value == "gimmel"
+def test_autoconfigure_double_kas_and(
+    attribute_two_kas_grant_and,
+    encrypt_sdk,
+    decrypt_sdk,
+    tmp_dir,
+    pt_file,
+    kas_url1: str,
+    kas_url2: str,
+):
+    if encrypt_sdk not in ["go", "java"]:
+        pytest.skip(f"sdk doesn't yet support autoconfigure [{encrypt_sdk}]")
 
-    # Then assign it to all clientIds = opentdf-sdk
-    sc = otdfctl.scs_create(
-        [
-            abac.SubjectSet(
-                condition_groups=[
-                    abac.ConditionGroup(
-                        boolean_operator=abac.ConditionBooleanTypeEnum.OR,
-                        conditions=[
-                            abac.Condition(
-                                subject_external_selector_value=".clientId",
-                                operator=abac.SubjectMappingOperatorEnum.IN,
-                                subject_external_values=["opentdf", "opentdf-sdk"],
-                            )
-                        ],
-                    )
-                ]
-            )
-        ],
-    )
-    sm1 = otdfctl.scs_map(sc, alef)
-    assert sm1.attribute_value.value == "alef"
-    sm2 = otdfctl.scs_map(sc, bet)
-    assert sm2.attribute_value.value == "bet"
-    # Now assign it to the current KAS
-    kas_entry_alpha = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8080/kas",
-        load_cached_kas_keys(),
-    )
-    otdfctl.grant_assign_value(kas_entry_alpha, alef)
+    sample_name = f"test-abac-three-and-{encrypt_sdk}"
+    if sample_name in cipherTexts:
+        ct_file = cipherTexts[sample_name]
+    else:
+        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        tdfs.encrypt(
+            encrypt_sdk,
+            pt_file,
+            ct_file,
+            mime_type="text/plain",
+            fmt="ztdf",
+            attr_values=[
+                attribute_two_kas_grant_and.values[0].fqn,
+                attribute_two_kas_grant_and.values[1].fqn,
+            ],
+        )
+        cipherTexts[sample_name] = ct_file
 
-    kas_entry_beta = otdfctl.kas_registry_create_if_not_present(
-        "http://localhost:8282/kas",
-        load_cached_kas_keys(),
-    )
-    otdfctl.grant_assign_value(kas_entry_beta, bet)
-
-    # We have a grant for alpha to localhost kas. Now try to use it...
-    # encrypt go
-    ct_file = f"{tmp_dir}test-abac-double.tdf"
-    tdfs.encrypt(
-        "go",
-        pt_file,
-        ct_file,
-        mime_type="text/plain",
-        fmt="ztdf",
-        attr_values=[
-            f"https://{random_ns}/attr/ot/value/alef",
-            f"https://{random_ns}/attr/ot/value/bet",
-        ],
-    )
     manifest = tdfs.manifest(ct_file)
     assert len(manifest.encryptionInformation.keyAccess) == 2
     assert (
         manifest.encryptionInformation.keyAccess[0].sid
         != manifest.encryptionInformation.keyAccess[1].sid
     )
-    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
+    assert set([kas_url1, kas_url2]) == set(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
-
-    rt_file = f"{tmp_dir}test-abac-double.untdf"
-    rt_file_2 = f"{tmp_dir}test-abac-double-2.untdf"
-    rt_file_3 = f"{tmp_dir}test-abac-double-3.untdf"
-    tdfs.decrypt("go", ct_file, rt_file, "ztdf")
+    rt_file = f"{tmp_dir}test-abac-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
-    tdfs.decrypt("java", ct_file, rt_file_2, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_2)
-    tdfs.decrypt("js", ct_file, rt_file_3, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_3)
-
-    # encrypt java
-    ct_file = f"{tmp_dir}test-abac-double-2.tdf"
-    tdfs.encrypt(
-        "java",
-        pt_file,
-        ct_file,
-        mime_type="text/plain",
-        fmt="ztdf",
-        attr_values=[
-            f"https://{random_ns}/attr/ot/value/alef",
-            f"https://{random_ns}/attr/ot/value/bet",
-        ],
-    )
-    manifest = tdfs.manifest(ct_file)
-    assert len(manifest.encryptionInformation.keyAccess) == 2
-    assert (
-        manifest.encryptionInformation.keyAccess[0].sid
-        != manifest.encryptionInformation.keyAccess[1].sid
-    )
-    assert set(["http://localhost:8080/kas", "http://localhost:8282/kas"]) == set(
-        [kao.url for kao in manifest.encryptionInformation.keyAccess]
-    )
-
-    rt_file = f"{tmp_dir}test-abac-double-3.untdf"
-    rt_file_2 = f"{tmp_dir}test-abac-double-4.untdf"
-    rt_file_3 = f"{tmp_dir}test-abac-double-5.untdf"
-    tdfs.decrypt("go", ct_file, rt_file, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file)
-    tdfs.decrypt("java", ct_file, rt_file_2, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_2)
-    tdfs.decrypt("js", ct_file, rt_file_3, "ztdf")
-    assert filecmp.cmp(pt_file, rt_file_3)


### PR DESCRIPTION
- Move attribute and grant creation to fixtures, and updates the abac tests to use them
- This simplifies the test bodies, as they now can focus on encrypt and decrypt
- skips js on encrypt tests for now, as they don't yet support abac configuration
- This means that running locally you can now use the `pytest --sdks go` argument, for example, to test just  the go SDK, and `pytest --encrypt-sdks java test_abac.py` to test all the SDKs for decrypt but just the java SDK for encrypt with abac-based configuration