### PR TITLE
chore(xtest): autoconf js clients use ns grants

### DIFF
--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR"/../../../test.env
 
 if [ "$1" == "supports" ]; then
   case "$2" in
-    autoconfigure)
+    autoconfigure | ns_grants)
       npx @opentdf/cli help | grep autoconfigure
       exit $?
       ;;

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -135,6 +135,7 @@ def supports(sdk: sdk_type, feature: feature_type) -> bool:
     elif feature == "ns_grants":
         if sdk in ["go"]:
             return True
+        do_check = sdk == "js"
     else:
         raise ValueError(f"unknown feature {feature}")
     if not do_check:

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -149,6 +149,6 @@ def supports(sdk: sdk_type, feature: feature_type) -> bool:
     logger.info(f"sup [{' '.join(c)}]")
     try:
         subprocess.check_call(c)
-    except:
+    except subprocess.CalledProcessError:
         return False
     return True


### PR DESCRIPTION
I'm adding support for ns grants at the same time as autoconfigure