### PR TITLE
chore(xtest): Adds checks for ecdsa

### DIFF
--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -47,7 +47,7 @@ def pytest_generate_tests(metafunc):
         if metafunc.config.getoption("--containers"):
             containers = metafunc.config.getoption("--containers").split()
         else:
-            containers = ["nano", "ztdf"]
+            containers = ["nano", "ztdf", "nano-with-ecdsa"]
         metafunc.parametrize("container", containers)
 
 

--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -10,6 +10,18 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # shellcheck source=../../test.env
 source "$SCRIPT_DIR"/../../test.env
 
+if [ "$1" == "supports" ]; then
+  case "$2" in
+    autoconfigure | nano_ecdsa | ns_grants)
+      exit 0
+      ;;
+    *)
+      echo "Unknown feature: $2"
+      exit 2
+      ;;
+  esac
+fi
+
 args=(
   -o "$3"
   --host "$PLATFORMURL"
@@ -35,6 +47,9 @@ if [ ! -f "$SCRIPT_DIR"/otdfctl ]; then
 fi
 
 if [ "$1" == "encrypt" ]; then
+  if [ "$USE_ECDSA_BINDING" == "true" ]; then
+    args+=(--ecdsa-binding)
+  fi
   echo "${cmd[@]}" encrypt "${args[@]}" "$2"
   if ! "${cmd[@]}" encrypt "${args[@]}" "$2"; then
     exit 1

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -40,6 +40,10 @@ args+=("$COMMAND")
 
 if [ "$1" == "encrypt" ]; then
   args+=(--kas-url=$KASURL)
+
+  if [ "$USE_ECDSA_BINDING" == "true" ]; then
+    args+=(--ecdsa-binding "true")
+  fi
 fi
 
 if [ -n "$5" ] && [ "$4" != "nano" ]; then

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -10,6 +10,22 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # shellcheck source=../../test.env
 source "$SCRIPT_DIR"/../../test.env
 
+if [ "$1" == "supports" ]; then
+  case "$2" in
+    autoconfigure | ns_grants)
+      exit 0
+      ;;
+    nano_ecdsa)
+      java -jar "$SCRIPT_DIR"/cmdline.jar help encryptnano | grep ecdsa-binding
+      exit $?
+      ;;
+    *)
+      echo "Unknown feature: $2"
+      exit 2
+      ;;
+  esac
+fi
+
 args=(
   "--client-id=$CLIENTID"
   "--client-secret=$CLIENTSECRET"

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -51,8 +51,6 @@ if [ "$1" == "encrypt" ]; then
   if [ -n "$USE_ECDSA_BINDING" ]; then
     if [ "$USE_ECDSA_BINDING" == "true" ]; then
       args+=(--policyBinding ecdsa)
-    else
-      args+=(--policyBinding gmac)
     fi
   fi
 

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -44,6 +44,14 @@ if [ "$1" == "encrypt" ]; then
     args+=(--policyEndpoint "$PLATFORMURL" --autoconfigure true)
   fi
 
+  if [ -n "$USE_ECDSA_BINDING" ]; then
+    if [ "$USE_ECDSA_BINDING" == "true" ]; then
+      args+=(--policyBinding ecdsa)
+    else
+      args+=(--policyBinding gmac)
+    fi
+  fi
+
   npx @opentdf/cli encrypt "$2" "${args[@]}"
 elif [ "$1" == "decrypt" ]; then
   npx @opentdf/cli decrypt "$2" "${args[@]}"

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -16,6 +16,10 @@ if [ "$1" == "supports" ]; then
       npx @opentdf/cli help | grep autoconfigure
       exit $?
       ;;
+    nano_ecdsa)
+      npx @opentdf/cli help | grep policyBinding
+      exit $?
+      ;;
     *)
       echo "Unknown feature: $2"
       exit 2

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -112,9 +112,14 @@ def encrypt(
     if attr_values:
         c += [",".join(attr_values)]
     logger.debug(f"enc [{' '.join(c)}]")
+
+    # Copy the current environment
     env = dict(os.environ)
-    if fmt == "nano" and use_ecdsa_binding:
-        env |= {"USE_ECDSA_BINDING": "true"}
+    if fmt == "nano":
+        if use_ecdsa_binding:
+           env |= {"USE_ECDSA_BINDING": "true"}
+        else:
+           env |= {"USE_ECDSA_BINDING": "false"}
     subprocess.check_call(c, env=env)
 
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -117,9 +117,9 @@ def encrypt(
     env = dict(os.environ)
     if fmt == "nano":
         if use_ecdsa_binding:
-           env |= {"USE_ECDSA_BINDING": "true"}
+            env |= {"USE_ECDSA_BINDING": "true"}
         else:
-           env |= {"USE_ECDSA_BINDING": "false"}
+            env |= {"USE_ECDSA_BINDING": "false"}
     subprocess.check_call(c, env=env)
 
 

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -1,6 +1,8 @@
 import filecmp
 import os
 
+import pytest
+
 import nano
 import tdfs
 
@@ -13,11 +15,24 @@ def test_tdf(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, container):
     global counter
     counter = (counter or 0) + 1
     c = counter
+    use_ecdsa = False
+    if container == "nano-with-ecdsa":
+        if not tdfs.supports(encrypt_sdk, "nano_ecdsa"):
+            pytest.skip(
+                f"{encrypt_sdk} sdk doesn't yet support ecdsa bindings for nanotdfs"
+            )
+        container = "nano"
+        use_ecdsa = True
     container_id = f"{encrypt_sdk}-{container}"
     if container_id not in cipherTexts:
         ct_file = f"{tmp_dir}test-{encrypt_sdk}-{c}.{container}"
         tdfs.encrypt(
-            encrypt_sdk, pt_file, ct_file, mime_type="text/plain", fmt=container
+            encrypt_sdk,
+            pt_file,
+            ct_file,
+            mime_type="text/plain",
+            fmt=container,
+            use_ecdsa_binding=use_ecdsa,
         )
         if container == "ztdf":
             manifest = tdfs.manifest(ct_file)
@@ -26,6 +41,7 @@ def test_tdf(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, container):
             with open(ct_file, "rb") as f:
                 envelope = nano.parse(f.read())
                 assert envelope.header.version.version == 12
+                assert envelope.header.binding_mode.use_ecdsa_binding == use_ecdsa
                 if envelope.header.kas.kid is not None:
                     # from xtest/platform/opentdf.yaml
                     expected_kid = b"ec1" + b"\0" * 5


### PR DESCRIPTION
Adds a new container type, nano-with-ecdsa, that is currently skipped for all except go sdk

<img width="615" alt="image" src="https://github.com/user-attachments/assets/830acbc7-263c-403f-af46-511451605ce3">
