### PR TITLE
feat: Check err output for tamper errors

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -29,8 +29,8 @@ jobs:
       contents: read
       packages: read
     env:
-      PLATFORM_REF: "${{ inputs.platform-ref || 'fix-kas-rewrap-error-handling' }}"
-      JS_REF: "${{ inputs.js-ref || 'fix-rewrap-response-typo' }}"
+      PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
+      JS_REF: "${{ inputs.js-ref || 'main' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
     steps:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -29,8 +29,8 @@ jobs:
       contents: read
       packages: read
     env:
-      PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'main' }}"
+      PLATFORM_REF: "${{ inputs.platform-ref || 'fix-kas-rewrap-error-handling' }}"
+      JS_REF: "${{ inputs.js-ref || 'fix-rewrap-response-typo' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
     steps:

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -122,7 +122,7 @@ def test_tdf_with_unbound_policy(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert b"wrap" in exc.output
-        # assert b"tamper" in exc.output
+        assert (b"tamper" in exc.output or b"InvalidFileError" in exc.output)
 
 
 def test_tdf_with_altered_root_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -122,6 +122,7 @@ def test_tdf_with_unbound_policy(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert b"wrap" in exc.output
+        # assert b"tamper" in exc.output
 
 
 def test_tdf_with_altered_root_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
@@ -135,6 +136,7 @@ def test_tdf_with_altered_root_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert b"root" in exc.output
+        assert (b"tamper" in exc.output or b"IntegrityError" in exc.output)
 
 
 def test_tdf_with_altered_seg_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
@@ -148,6 +150,7 @@ def test_tdf_with_altered_seg_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert b"signature" in exc.output
+        assert (b"tamper" in exc.output or b"IntegrityError" in exc.output)
 
 
 def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -122,7 +122,7 @@ def test_tdf_with_unbound_policy(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert b"wrap" in exc.output
-        assert (b"tamper" in exc.output or b"InvalidFileError" in exc.output)
+        assert b"tamper" in exc.output or b"InvalidFileError" in exc.output
 
 
 def test_tdf_with_altered_root_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
@@ -136,7 +136,7 @@ def test_tdf_with_altered_root_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert b"root" in exc.output
-        assert (b"tamper" in exc.output or b"IntegrityError" in exc.output)
+        assert b"tamper" in exc.output or b"IntegrityError" in exc.output
 
 
 def test_tdf_with_altered_seg_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
@@ -150,7 +150,7 @@ def test_tdf_with_altered_seg_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert b"signature" in exc.output
-        assert (b"tamper" in exc.output or b"IntegrityError" in exc.output)
+        assert b"tamper" in exc.output or b"IntegrityError" in exc.output
 
 
 def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):


### PR DESCRIPTION
Check the error output for tamper errors to ensure they are categorized as tamper