### PR TITLE
feat: Assertion verification tests with signing keys

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   scriptcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: 🦪 ✔ 🧼🧼🧼

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -30,9 +30,9 @@ jobs:
       packages: read
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'assertion-verification-cli' }}"
-      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'add-assertion-verification-key' }}"
-      JAVA_REF: "${{ inputs.java-ref || 'add-assertion-verification' }}"
+      JS_REF: "${{ inputs.js-ref || 'main' }}"
+      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
+      JAVA_REF: "${{ inputs.java-ref || 'main' }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -30,9 +30,9 @@ jobs:
       packages: read
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'assertion-verification-cli' }}"
+      JS_REF: "${{ inputs.js-ref || 'main' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'add-assertion-verification-key' }}"
-      JAVA_REF: "${{ inputs.java-ref || 'add-assertion-verification' }}"
+      JAVA_REF: "${{ inputs.java-ref || 'main' }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -32,7 +32,7 @@ jobs:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
       JS_REF: "${{ inputs.js-ref || 'main' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'add-assertion-verification-key' }}"
-      JAVA_REF: "${{ inputs.java-ref || 'main' }}"
+      JAVA_REF: "${{ inputs.java-ref || 'add-assertion-verification' }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           repository: opentdf/tests
           path: otdftests # use different name bc other repos might have tests directories
-      - name: Set up Node 20
+      - name: Set up Node 22
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: https://npm.pkg.github.com
       - name: Set up Python 3.10
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -30,7 +30,7 @@ jobs:
       packages: read
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'main' }}"
+      JS_REF: "${{ inputs.js-ref || 'fix-assertionverification-keys' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
     steps:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -30,9 +30,9 @@ jobs:
       packages: read
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'main' }}"
+      JS_REF: "${{ inputs.js-ref || 'assertion-verification-cli' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'add-assertion-verification-key' }}"
-      JAVA_REF: "${{ inputs.java-ref || 'main' }}"
+      JAVA_REF: "${{ inputs.java-ref || 'add-assertion-verification' }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -30,7 +30,7 @@ jobs:
       packages: read
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'fix-assertionverification-keys' }}"
+      JS_REF: "${{ inputs.js-ref || 'main' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
     steps:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -30,7 +30,7 @@ jobs:
       packages: read
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'main' }}"
+      JS_REF: "${{ inputs.js-ref || 'assertion-verification-cli' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'add-assertion-verification-key' }}"
       JAVA_REF: "${{ inputs.java-ref || 'add-assertion-verification' }}"
     steps:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   cross-client-test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
       JS_REF: "${{ inputs.js-ref || 'main' }}"
-      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
+      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'add-assertion-verification-key' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/xtest/assertions.py
+++ b/xtest/assertions.py
@@ -5,7 +5,7 @@ from typing import Literal, Union, Dict
 Type = Literal["handling", "other"]
 Scope = Literal["payload", "tdo"]
 AppliesTo = Literal["encrypted", "unencrypted"]
-BindingMethod = Literal["jws"]
+BindingMethod = Literal["jws", "JWS"]
 
 
 class Statement(BaseModel):

--- a/xtest/assertions.py
+++ b/xtest/assertions.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Literal, Union, Optional, Dict
+from typing import Literal, Union, Dict
 
 
 Type = Literal["handling", "other"]
@@ -18,6 +18,7 @@ class Binding(BaseModel):
     method: BindingMethod
     signature: str
 
+
 class AssertionKey(BaseModel):
     alg: str
     key: str
@@ -31,6 +32,7 @@ class Assertion(BaseModel):
     statement: Statement
     binding: Binding | None = None
     signingKey: AssertionKey | None = None
+
 
 class AssertionVerificationKeys(BaseModel):
     keys: Dict[str, AssertionKey]

--- a/xtest/assertions.py
+++ b/xtest/assertions.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Literal, Union
+from typing import Literal, Union, Optional, Dict
 
 
 Type = Literal["handling", "other"]
@@ -18,6 +18,10 @@ class Binding(BaseModel):
     method: BindingMethod
     signature: str
 
+class AssertionKey(BaseModel):
+    alg: str
+    key: str
+
 
 class Assertion(BaseModel):
     id: str
@@ -26,3 +30,7 @@ class Assertion(BaseModel):
     appliesToState: AppliesTo
     statement: Statement
     binding: Binding | None = None
+    signingKey: AssertionKey | None = None
+
+class AssertionVerificationKeys(BaseModel):
+    keys: Dict[str, AssertionKey]

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -603,9 +603,11 @@ def ns_and_value_kas_grants_and(
 
     return allof
 
+
 @pytest.fixture(scope="module")
 def hs256_key():
     return base64.b64encode(secrets.token_bytes(32)).decode("ascii")
+
 
 @pytest.fixture(scope="module")
 def rs256_keys():

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -4,6 +4,10 @@ import random
 import string
 import base64
 import secrets
+import assertions
+import json
+
+from pydantic_core import to_jsonable_python
 
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
@@ -635,3 +639,102 @@ def rs256_keys():
     public_pem_str = public_pem.decode("utf-8")
 
     return private_pem_str, public_pem_str
+
+
+def write_assertion_to_file(
+    file_name: str, assertion_list: list[assertions.Assertion] = []
+):
+    as_file = f"{tmp_dir}test-assertion-{file_name}.json"
+    assertion_json = json.dumps(to_jsonable_python(assertion_list, exclude_none=True))
+    with open(as_file, "w") as f:
+        f.write(assertion_json)
+    return as_file
+
+
+@pytest.fixture(scope="module")
+def assertion_file_no_keys():
+    assertion_list = [
+        assertions.Assertion(
+            appliesToState="encrypted",
+            id="424ff3a3-50ca-4f01-a2ae-ef851cd3cac0",
+            scope="tdo",
+            statement=assertions.Statement(
+                format="json+stanag5636",
+                schema="urn:nato:stanag:5636:A:1:elements:json",
+                value='{"ocl":{"pol":"62c76c68-d73d-4628-8ccc-4c1e18118c22","cls":"SECRET","catl":[{"type":"P","name":"Releasable To","vals":["usa"]}],"dcr":"2024-10-21T20:47:36Z"},"context":{"[@base](https://github.com/base)":"urn:nato:stanag:5636:A:1:elements:json"}}',
+            ),
+            type="handling",
+        )
+    ]
+    return write_assertion_to_file("assertion_1_no_signing_key", assertion_list)
+
+
+@pytest.fixture(scope="module")
+def assertion_file_rs_and_hs_keys(hs256_key, rs256_keys):
+    rs256_private, _ = rs256_keys
+    assertion_list = [
+        assertions.Assertion(
+            appliesToState="encrypted",
+            id="assertion1",
+            scope="tdo",
+            statement=assertions.Statement(
+                format="json+stanag5636",
+                schema="urn:nato:stanag:5636:A:1:elements:json",
+                value='{"ocl":{"pol":"62c76c68-d73d-4628-8ccc-4c1e18118c22","cls":"SECRET","catl":[{"type":"P","name":"Releasable To","vals":["usa"]}],"dcr":"2024-10-21T20:47:36Z"},"context":{"[@base](https://github.com/base)":"urn:nato:stanag:5636:A:1:elements:json"}}',
+            ),
+            type="handling",
+            signingKey=assertions.AssertionKey(
+                alg="HS256",
+                key=hs256_key,
+            ),
+        ),
+        assertions.Assertion(
+            appliesToState="encrypted",
+            id="assertion2",
+            scope="tdo",
+            statement=assertions.Statement(
+                format="json+stanag5636",
+                schema="urn:nato:stanag:5636:A:1:elements:json",
+                value='{"ocl":{"pol":"62c76c68-d73d-4628-8ccc-4c1e18118c22","cls":"SECRET","catl":[{"type":"P","name":"Releasable To","vals":["usa"]}],"dcr":"2024-10-21T20:47:36Z"},"context":{"[@base](https://github.com/base)":"urn:nato:stanag:5636:A:1:elements:json"}}',
+            ),
+            type="handling",
+            signingKey=assertions.AssertionKey(
+                alg="RS256",
+                key=rs256_private,
+            ),
+        ),
+    ]
+    return write_assertion_to_file("assertion1_hs_assertion2_rs", assertion_list)
+
+
+def write_assertion_verification_keys_to_file(
+    file_name: str,
+    assertion_verificaiton_keys: assertions.AssertionVerificationKeys = None,
+):
+    as_file = f"{tmp_dir}test-assertion-verification-{file_name}.json"
+    assertion_verification_json = json.dumps(
+        to_jsonable_python(assertion_verificaiton_keys, exclude_none=True)
+    )
+    with open(as_file, "w") as f:
+        f.write(assertion_verification_json)
+    return as_file
+
+
+@pytest.fixture(scope="module")
+def assertion_verification_file_rs_and_hs_keys(hs256_key, rs256_keys):
+    _, rs256_public = rs256_keys
+    assertion_verification = assertions.AssertionVerificationKeys(
+        keys={
+            "assertion1": assertions.AssertionKey(
+                alg="HS256",
+                key=hs256_key,
+            ),
+            "assertion2": assertions.AssertionKey(
+                alg="RS256",
+                key=rs256_public,
+            ),
+        }
+    )
+    return write_assertion_verification_keys_to_file(
+        "assertion1_hs_assertion2_rs", assertion_verification
+    )

--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -3,7 +3,7 @@
 
 # Common shell wrapper used to interface to SDK implementation.
 #
-# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <fmt> <mimeType> <attrs>
+# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <fmt> <mimeType> <attrs> <assertions> <assertionverificationkeys>
 #
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
@@ -24,6 +24,10 @@ if [ "$1" == "supports" ]; then
       "${cmd[@]}" help encrypt | grep with-assertions
       exit $?
       ;;
+    assertion_verification)
+      "${cmd[@]}" help decrypt | grep with-assertion-verification-keys
+      exit $?
+      ;;
     *)
       echo "Unknown feature: $2"
       exit 2
@@ -42,19 +46,18 @@ if [ "$4" == "nano" ]; then
   args+=(--tdf-type "$4")
 fi
 
-if [ -n "$5" ]; then
-  args+=(--mime-type "$5")
-fi
-
-if [ -n "$6" ]; then
-  args+=(--attr "$6")
-fi
-
-if [ -n "$7" ]; then
-  args+=(--with-assertions "$7")
-fi
-
 if [ "$1" == "encrypt" ]; then
+  if [ -n "$5" ]; then
+    args+=(--mime-type "$5")
+  fi
+
+  if [ -n "$6" ]; then
+    args+=(--attr "$6")
+  fi
+
+  if [ -n "$7" ]; then
+    args+=(--with-assertions "$7")
+  fi
   if [ "$USE_ECDSA_BINDING" == "true" ]; then
     args+=(--ecdsa-binding)
   fi
@@ -67,6 +70,9 @@ if [ "$1" == "encrypt" ]; then
     mv "${3}.tdf" "${3}"
   fi
 elif [ "$1" == "decrypt" ]; then
+  if [ -n "$8" ]; then
+    args+=(--with-assertion-verification-keys "$5")
+  fi
   echo "${cmd[@]}" decrypt "${args[@]}" "$2"
   "${cmd[@]}" decrypt "${args[@]}" "$2"
 else

--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -25,7 +25,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     assertion_verification)
-      "${cmd[@]}" help decrypt | grep with-assertion-verification-keys
+      "${cmd[@]}" help decrypt | grep nooopppee
       exit $?
       ;;
     *)

--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -25,7 +25,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     assertion_verification)
-      "${cmd[@]}" help decrypt | grep nooopppee
+      "${cmd[@]}" help decrypt | grep with-assertion-verification-keys
       exit $?
       ;;
     *)

--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -71,7 +71,7 @@ if [ "$1" == "encrypt" ]; then
   fi
 elif [ "$1" == "decrypt" ]; then
   if [ -n "$8" ]; then
-    args+=(--with-assertion-verification-keys "$5")
+    args+=(--with-assertion-verification-keys "$8")
   fi
   echo "${cmd[@]}" decrypt "${args[@]}" "$2"
   "${cmd[@]}" decrypt "${args[@]}" "$2"

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -23,6 +23,10 @@ if [ "$1" == "supports" ]; then
       java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep with-assertions
       exit $?
       ;;
+    assertion_verification)
+      java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep with-assertion-verification-keys
+      exit $?
+      ;;
     *)
       echo "Unknown feature: $2"
       exit 2

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -24,7 +24,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     assertion_verification)
-      java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep nopeeee
+      java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep with-assertion-verification-keys
       exit $?
       ;;
     *)

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -24,7 +24,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     assertion_verification)
-      java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep with-assertion-verification-keys
+      java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep nopeeee
       exit $?
       ;;
     *)

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -3,7 +3,7 @@
 
 # Common shell wrapper used to interface to SDK implementation.
 #
-# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <nano>
+# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <fmt> <mimeType> <attrs> <assertions> <assertionverificationkeys>
 #
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -66,5 +66,9 @@ if [ -n "$7" ]; then
   args+=(--with-assertions "$7")
 fi
 
+if [ -n "$8" ]; then
+  args+=(--with-assertion-verification-keys "$8")
+fi
+
 echo java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" -f "$2" ">" "$3"
 java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" -f "$2" >"$3"

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -62,5 +62,9 @@ if [ -n "$6" ]; then
   args+=(--attr "$6")
 fi
 
+if [ -n "$7" ]; then
+  args+=(--with-assertions "$7")
+fi
+
 echo java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" -f "$2" ">" "$3"
 java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" -f "$2" >"$3"

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -23,7 +23,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     assertion_verification)
-      npx $CTL help | grep assertion-verification
+      npx $CTL help | grep assertionVerificationKeys
       exit $?
       ;;
     autoconfigure | ns_grants)
@@ -59,6 +59,10 @@ fi
 
 if [ -n "$7" ]; then
   args+=(--assertions "$7")
+fi
+
+if [ -n "$8" ]; then
+  args+=(--assertionVerificationKeys "$8")
 fi
 
 if [ "$1" == "encrypt" ]; then

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -23,7 +23,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     assertion_verification)
-      npx $CTL help | grep assertionVerificationKeys
+      npx $CTL help | grep nopeeee
       exit $?
       ;;
     autoconfigure | ns_grants)

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -3,7 +3,7 @@
 
 # Common shell wrapper used to interface to SDK implementation.
 #
-# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <nano>
+# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <fmt> <mimeType> <attrs> <assertions> <assertionverificationkeys>
 #
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 XTEST_DIR=$(cd -- "$SCRIPT_DIR"/../../../ &>/dev/null && pwd)

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -69,7 +69,6 @@ if [ "$1" == "encrypt" ]; then
   if npx $CTL help | grep autoconfigure; then
     args+=(--policyEndpoint "$PLATFORMURL" --autoconfigure true)
   fi
-
   if [ -n "$USE_ECDSA_BINDING" ]; then
     if [ "$USE_ECDSA_BINDING" == "true" ]; then
       args+=(--policyBinding ecdsa)

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -22,6 +22,10 @@ if [ "$1" == "supports" ]; then
       npx $CTL help | grep assertions
       exit $?
       ;;
+    assertion_verification)
+      npx $CTL help | grep assertion-verification
+      exit $?
+      ;;
     autoconfigure | ns_grants)
       npx $CTL help | grep autoconfigure
       exit $?

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -23,7 +23,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     assertion_verification)
-      npx $CTL help | grep nopeeee
+      npx $CTL help | grep assertionVerificationKeys
       exit $?
       ;;
     autoconfigure | ns_grants)

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -213,7 +213,8 @@ def encrypt(
     subprocess.check_call(c, env=env)
 
 
-def decrypt(sdk, ct_file, rt_file, fmt="nano"):
+def decrypt(sdk, ct_file, rt_file, fmt="nano", 
+            assert_keys: tdfassertions.AssertionVerificationKeys | None = None):
     c = [
         sdk_paths[sdk],
         "decrypt",
@@ -221,6 +222,9 @@ def decrypt(sdk, ct_file, rt_file, fmt="nano"):
         rt_file,
         fmt,
     ]
+    if assert_keys:
+        # empty args for mimetype, attrs, and assertions
+        c += ["", "", "", json.dumps(to_jsonable_python(assert_keys, exclude_none=True))]
     logger.info(f"dec [{' '.join(c)}]")
     subprocess.check_output(c, stderr=subprocess.STDOUT)
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -184,7 +184,7 @@ def encrypt(
     mime_type="application/octet-stream",
     fmt="nano",
     attr_values: list[str] | None = None,
-    assert_value: list[tdfassertions.Assertion] | None = None,
+    assert_value="",
     use_ecdsa_binding=False,
 ):
     c = [
@@ -200,7 +200,7 @@ def encrypt(
     if assert_value:
         if not attr_values:
             c += [""]
-        c += [json.dumps(to_jsonable_python(assert_value, exclude_none=True))]
+        c += [assert_value]
     logger.debug(f"enc [{' '.join(c)}]")
 
     # Copy the current environment
@@ -218,7 +218,7 @@ def decrypt(
     ct_file,
     rt_file,
     fmt="nano",
-    assert_keys: tdfassertions.AssertionVerificationKeys | None = None,
+    assert_keys: str = "",
 ):
     c = [
         sdk_paths[sdk],
@@ -233,7 +233,7 @@ def decrypt(
             "",
             "",
             "",
-            json.dumps(to_jsonable_python(assert_keys, exclude_none=True)),
+            assert_keys,
         ]
     logger.info(f"dec [{' '.join(c)}]")
     subprocess.check_output(c, stderr=subprocess.STDOUT)

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -9,7 +9,6 @@ import zipfile
 import jsonschema
 
 from pydantic import BaseModel
-from pydantic_core import to_jsonable_python
 from typing import Literal, Optional, List, Union
 
 logger = logging.getLogger("xtest")

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -236,7 +236,7 @@ def decrypt(
             json.dumps(to_jsonable_python(assert_keys, exclude_none=True)),
         ]
     logger.info(f"dec [{' '.join(c)}]")
-    subprocess.check_output(c , stderr=subprocess.STDOUT)
+    subprocess.check_output(c, stderr=subprocess.STDOUT)
 
 
 def supports(sdk: sdk_type, feature: feature_type) -> bool:

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -213,8 +213,13 @@ def encrypt(
     subprocess.check_call(c, env=env)
 
 
-def decrypt(sdk, ct_file, rt_file, fmt="nano", 
-            assert_keys: tdfassertions.AssertionVerificationKeys | None = None):
+def decrypt(
+    sdk,
+    ct_file,
+    rt_file,
+    fmt="nano",
+    assert_keys: tdfassertions.AssertionVerificationKeys | None = None,
+):
     c = [
         sdk_paths[sdk],
         "decrypt",
@@ -224,7 +229,12 @@ def decrypt(sdk, ct_file, rt_file, fmt="nano",
     ]
     if assert_keys:
         # empty args for mimetype, attrs, and assertions
-        c += ["", "", "", json.dumps(to_jsonable_python(assert_keys, exclude_none=True))]
+        c += [
+            "",
+            "",
+            "",
+            json.dumps(to_jsonable_python(assert_keys, exclude_none=True)),
+        ]
     logger.info(f"dec [{' '.join(c)}]")
     subprocess.check_output(c, stderr=subprocess.STDOUT)
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -236,7 +236,7 @@ def decrypt(
             json.dumps(to_jsonable_python(assert_keys, exclude_none=True)),
         ]
     logger.info(f"dec [{' '.join(c)}]")
-    subprocess.check_output(c, stderr=subprocess.STDOUT)
+    subprocess.check_output(c)#, stderr=subprocess.STDOUT)
 
 
 def supports(sdk: sdk_type, feature: feature_type) -> bool:

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -236,7 +236,7 @@ def decrypt(
             json.dumps(to_jsonable_python(assert_keys, exclude_none=True)),
         ]
     logger.info(f"dec [{' '.join(c)}]")
-    subprocess.check_output(c)#, stderr=subprocess.STDOUT)
+    subprocess.check_output(c , stderr=subprocess.STDOUT)
 
 
 def supports(sdk: sdk_type, feature: feature_type) -> bool:

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -5,6 +5,7 @@ import subprocess
 import base64
 import string
 import random
+import secrets
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 from typing import Tuple
@@ -218,7 +219,7 @@ def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         encrypt_sdk,
         "ztdf",
         tmp_dir,
-        scenario="assertions-roundtrip",
+        scenario="assertions",
         az=[
             assertions.Assertion(
                 appliesToState="encrypted",
@@ -250,7 +251,7 @@ def generate_rs256_keys() -> Tuple[str, str]:
     # Serialize the private key to PEM format
     private_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     )
 
@@ -261,8 +262,8 @@ def generate_rs256_keys() -> Tuple[str, str]:
     )
 
     # Convert to string with escaped newlines
-    private_pem_str = private_pem.decode("utf-8").replace("\n", "\\n")
-    public_pem_str = public_pem.decode("utf-8").replace("\n", "\\n")
+    private_pem_str = private_pem.decode("utf-8")#.replace("\n", "\\n")
+    public_pem_str = public_pem.decode("utf-8")#.replace("\n", "\\n")
 
     return private_pem_str, public_pem_str
 
@@ -272,7 +273,7 @@ def test_tdf_assertions_with_keys(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not tdfs.supports(decrypt_sdk, "assertion_verification"):
         pytest.skip(f"{decrypt_sdk} sdk doesn't yet support assertion_verification")
-    hs256_key = base64.b64encode(os.urandom(32)).decode("utf-8")
+    hs256_key = base64.b64encode(secrets.token_bytes(32)).decode('ascii')
     rs256_private, rs256_public = generate_rs256_keys()
     ct_file = do_encrypt_with(
         pt_file,

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -262,8 +262,8 @@ def generate_rs256_keys() -> Tuple[str, str]:
     )
 
     # Convert to string with escaped newlines
-    private_pem_str = private_pem.decode("utf-8")#.replace("\n", "\\n")
-    public_pem_str = public_pem.decode("utf-8")#.replace("\n", "\\n")
+    private_pem_str = private_pem.decode("utf-8")
+    public_pem_str = public_pem.decode("utf-8")
 
     return private_pem_str, public_pem_str
 
@@ -273,7 +273,7 @@ def test_tdf_assertions_with_keys(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not tdfs.supports(decrypt_sdk, "assertion_verification"):
         pytest.skip(f"{decrypt_sdk} sdk doesn't yet support assertion_verification")
-    hs256_key = base64.b64encode(secrets.token_bytes(32)).decode('ascii')
+    hs256_key = base64.b64encode(secrets.token_bytes(32)).decode("ascii")
     rs256_private, rs256_public = generate_rs256_keys()
     ct_file = do_encrypt_with(
         pt_file,

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -238,7 +238,9 @@ def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
     assert filecmp.cmp(pt_file, rt_file)
 
 
-def test_tdf_assertions_with_keys(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, hs256_key, rs256_keys):
+def test_tdf_assertions_with_keys(
+    encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, hs256_key, rs256_keys
+):
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not tdfs.supports(decrypt_sdk, "assertion_verification"):

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -272,7 +272,7 @@ def test_tdf_assertions_with_keys(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not tdfs.supports(decrypt_sdk, "assertion_verification"):
         pytest.skip(f"{decrypt_sdk} sdk doesn't yet support assertion_verification")
-    hs256_key = base64.b64encode(os.urandom(32)).decode('utf-8')
+    hs256_key = base64.b64encode(os.urandom(32)).decode("utf-8")
     rs256_private, rs256_public = generate_rs256_keys()
     ct_file = do_encrypt_with(
         pt_file,

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -5,7 +5,6 @@ import subprocess
 import base64
 import string
 import random
-from typing import Tuple
 
 import pytest
 

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -207,6 +207,7 @@ def test_tdf_with_altered_seg_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
 
 ## ASSERTION TESTS
 
+
 def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
@@ -238,12 +239,10 @@ def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
     tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
+
 def generate_rs256_keys() -> Tuple[str, str]:
     # Generate an RSA private key
-    private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048
-    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
     # Generate the public key from the private key
     public_key = private_key.public_key()
@@ -252,18 +251,18 @@ def generate_rs256_keys() -> Tuple[str, str]:
     private_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption()
+        encryption_algorithm=serialization.NoEncryption(),
     )
 
     # Serialize the public key to PEM format
     public_pem = public_key.public_bytes(
         encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
 
     # Convert to string with escaped newlines
-    private_pem_str = private_pem.decode('utf-8').replace('\n', '\\n')
-    public_pem_str = public_pem.decode('utf-8').replace('\n', '\\n')
+    private_pem_str = private_pem.decode("utf-8").replace("\n", "\\n")
+    public_pem_str = public_pem.decode("utf-8").replace("\n", "\\n")
 
     return private_pem_str, public_pem_str
 
@@ -319,15 +318,15 @@ def test_tdf_assertions_with_keys(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
     rt_file = f"{tmp_dir}test-{fname}.untdf"
     assertion_verification_keys = assertions.AssertionVerificationKeys(
         keys={
-            "assertion1":assertions.AssertionKey(
-                    alg="HS256",
-                    key=hs256_key,
-                ),
+            "assertion1": assertions.AssertionKey(
+                alg="HS256",
+                key=hs256_key,
+            ),
             "assertion2": assertions.AssertionKey(
-                    alg="RS256",
-                    key=rs256_public,
-                ),
-            }
+                alg="RS256",
+                key=rs256_public,
+            ),
+        }
     )
     tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf", assertion_verification_keys)
     assert filecmp.cmp(pt_file, rt_file)

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -272,7 +272,7 @@ def test_tdf_assertions_with_keys(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not tdfs.supports(decrypt_sdk, "assertion_verification"):
         pytest.skip(f"{decrypt_sdk} sdk doesn't yet support assertion_verification")
-    hs256_key = os.urandom(32)
+    hs256_key = base64.b64encode(os.urandom(32)).decode('utf-8')
     rs256_private, rs256_public = generate_rs256_keys()
     ct_file = do_encrypt_with(
         pt_file,

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -24,7 +24,7 @@ def do_encrypt_with(
     container: str,
     tmp_dir: str,
     use_ecdsa: bool = False,
-    az: list[assertions.Assertion] = [],
+    az: str = "",
     scenario: str = "",
 ) -> str:
     global counter
@@ -90,7 +90,9 @@ def test_manifest_validity(encrypt_sdk, pt_file, tmp_dir):
     tdfs.validate_manifest_schema(ct_file)
 
 
-def test_manifest_validity_with_assertions(encrypt_sdk, pt_file, tmp_dir):
+def test_manifest_validity_with_assertions(
+    encrypt_sdk, pt_file, tmp_dir, assertion_file_no_keys
+):
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     ct_file = do_encrypt_with(
@@ -99,19 +101,7 @@ def test_manifest_validity_with_assertions(encrypt_sdk, pt_file, tmp_dir):
         "ztdf",
         tmp_dir,
         scenario="assertions",
-        az=[
-            assertions.Assertion(
-                appliesToState="encrypted",
-                id="424ff3a3-50ca-4f01-a2ae-ef851cd3cac0",
-                scope="tdo",
-                statement=assertions.Statement(
-                    format="json+stanag5636",
-                    schema="urn:nato:stanag:5636:A:1:elements:json",
-                    value='{"ocl":{"pol":"62c76c68-d73d-4628-8ccc-4c1e18118c22","cls":"SECRET","catl":[{"type":"P","name":"Releasable To","vals":["usa"]}],"dcr":"2024-10-21T20:47:36Z"},"context":{"[@base](https://github.com/base)":"urn:nato:stanag:5636:A:1:elements:json"}}',
-                ),
-                type="handling",
-            ),
-        ],
+        az=assertion_file_no_keys,
     )
     assert os.path.isfile(ct_file)
     tdfs.validate_manifest_schema(ct_file)
@@ -205,7 +195,9 @@ def test_tdf_with_altered_seg_sig(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
 ## ASSERTION TESTS
 
 
-def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
+def test_tdf_assertions(
+    encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, assertion_file_no_keys
+):
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not tdfs.supports(decrypt_sdk, "assertions"):
@@ -216,19 +208,7 @@ def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         "ztdf",
         tmp_dir,
         scenario="assertions",
-        az=[
-            assertions.Assertion(
-                appliesToState="encrypted",
-                id="424ff3a3-50ca-4f01-a2ae-ef851cd3cac0",
-                scope="tdo",
-                statement=assertions.Statement(
-                    format="json+stanag5636",
-                    schema="urn:nato:stanag:5636:A:1:elements:json",
-                    value='{"ocl":{"pol":"62c76c68-d73d-4628-8ccc-4c1e18118c22","cls":"SECRET","catl":[{"type":"P","name":"Releasable To","vals":["usa"]}],"dcr":"2024-10-21T20:47:36Z"},"context":{"[@base](https://github.com/base)":"urn:nato:stanag:5636:A:1:elements:json"}}',
-                ),
-                type="handling",
-            ),
-        ],
+        az=assertion_file_no_keys,
     )
     assert os.path.isfile(ct_file)
     fname = os.path.basename(ct_file).split(".")[0]
@@ -238,66 +218,34 @@ def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
 
 
 def test_tdf_assertions_with_keys(
-    encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, hs256_key, rs256_keys
+    encrypt_sdk,
+    decrypt_sdk,
+    pt_file,
+    tmp_dir,
+    assertion_file_rs_and_hs_keys,
+    assertion_verification_file_rs_and_hs_keys,
 ):
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not tdfs.supports(decrypt_sdk, "assertion_verification"):
         pytest.skip(f"{decrypt_sdk} sdk doesn't yet support assertion_verification")
-    rs256_private, rs256_public = rs256_keys
     ct_file = do_encrypt_with(
         pt_file,
         encrypt_sdk,
         "ztdf",
         tmp_dir,
         scenario="assertions-keys-roundtrip",
-        az=[
-            assertions.Assertion(
-                appliesToState="encrypted",
-                id="assertion1",
-                scope="tdo",
-                statement=assertions.Statement(
-                    format="json+stanag5636",
-                    schema="urn:nato:stanag:5636:A:1:elements:json",
-                    value='{"ocl":{"pol":"62c76c68-d73d-4628-8ccc-4c1e18118c22","cls":"SECRET","catl":[{"type":"P","name":"Releasable To","vals":["usa"]}],"dcr":"2024-10-21T20:47:36Z"},"context":{"[@base](https://github.com/base)":"urn:nato:stanag:5636:A:1:elements:json"}}',
-                ),
-                type="handling",
-                signingKey=assertions.AssertionKey(
-                    alg="HS256",
-                    key=hs256_key,
-                ),
-            ),
-            assertions.Assertion(
-                appliesToState="encrypted",
-                id="assertion2",
-                scope="tdo",
-                statement=assertions.Statement(
-                    format="json+stanag5636",
-                    schema="urn:nato:stanag:5636:A:1:elements:json",
-                    value='{"ocl":{"pol":"62c76c68-d73d-4628-8ccc-4c1e18118c22","cls":"SECRET","catl":[{"type":"P","name":"Releasable To","vals":["usa"]}],"dcr":"2024-10-21T20:47:36Z"},"context":{"[@base](https://github.com/base)":"urn:nato:stanag:5636:A:1:elements:json"}}',
-                ),
-                type="handling",
-                signingKey=assertions.AssertionKey(
-                    alg="RS256",
-                    key=rs256_private,
-                ),
-            ),
-        ],
+        az=assertion_file_rs_and_hs_keys,
     )
     assert os.path.isfile(ct_file)
     fname = os.path.basename(ct_file).split(".")[0]
     rt_file = f"{tmp_dir}test-{fname}.untdf"
-    assertion_verification_keys = assertions.AssertionVerificationKeys(
-        keys={
-            "assertion1": assertions.AssertionKey(
-                alg="HS256",
-                key=hs256_key,
-            ),
-            "assertion2": assertions.AssertionKey(
-                alg="RS256",
-                key=rs256_public,
-            ),
-        }
+
+    tdfs.decrypt(
+        decrypt_sdk,
+        ct_file,
+        rt_file,
+        "ztdf",
+        assertion_verification_file_rs_and_hs_keys,
     )
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf", assertion_verification_keys)
     assert filecmp.cmp(pt_file, rt_file)

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -1,4 +1,3 @@
-import assertions
 import filecmp
 import os
 import subprocess

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -218,7 +218,7 @@ def test_tdf_assertions(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         encrypt_sdk,
         "ztdf",
         tmp_dir,
-        scenario="assertions",
+        scenario="assertions-roundtrip",
         az=[
             assertions.Assertion(
                 appliesToState="encrypted",
@@ -279,7 +279,7 @@ def test_tdf_assertions_with_keys(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir):
         encrypt_sdk,
         "ztdf",
         tmp_dir,
-        scenario="assertions",
+        scenario="assertions-keys-roundtrip",
         az=[
             assertions.Assertion(
                 appliesToState="encrypted",


### PR DESCRIPTION
Adding tests for creating tdfs with assertions with provided keys, and decrypting those tdf and verifying those assertions with the provided assertion verification keys
tests both hs256 and rs256