### PR TITLE
chore(xtest): Prefer 3.10+ type annotations

### DIFF
--- a/xtest/assertions.py
+++ b/xtest/assertions.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Literal, Union, Dict
+from typing import Literal
 
 
 Type = Literal["handling", "other"]
@@ -11,7 +11,7 @@ BindingMethod = Literal["jws", "JWS"]
 class Statement(BaseModel):
     format: str
     schema: str
-    value: Union[str, dict]
+    value: dict | str
 
 
 class Binding(BaseModel):
@@ -35,4 +35,4 @@ class Assertion(BaseModel):
 
 
 class AssertionVerificationKeys(BaseModel):
-    keys: Dict[str, AssertionKey]
+    keys: dict[str, AssertionKey]

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -9,7 +9,7 @@ import zipfile
 import jsonschema
 
 from pydantic import BaseModel
-from typing import Literal, Optional, List, Union
+from typing import Literal
 
 logger = logging.getLogger("xtest")
 logging.basicConfig()
@@ -56,7 +56,7 @@ class KeyAccessObject(BaseModel):
     url: str
     protocol: str
     wrappedKey: str
-    policyBinding: Union[str, PolicyBinding]
+    policyBinding: PolicyBinding | str
     encryptedMetadata: str | None = None
     kid: str | None = None
     sid: str | None = None
@@ -118,7 +118,7 @@ class EncryptionInformation(BaseModel):
 class Manifest(BaseModel):
     encryptionInformation: EncryptionInformation
     payload: PayloadReference
-    assertions: Optional[List[tdfassertions.Assertion]] = []
+    assertions: list[tdfassertions.Assertion] | None = None
 
 
 def manifest(tdf_file: str) -> Manifest:


### PR DESCRIPTION
- Prefer `|` to Union, and `| None` to Optional
- Prefer `list` to `List`