### PR TITLE
chore(xtest): Allow 'hexless' upgrade

### DIFF
--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -27,6 +27,13 @@ if [ "$1" == "supports" ]; then
       java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep with-assertion-verification-keys
       exit $?
       ;;
+
+    hexless)
+      set -o pipefail
+      java -jar "$SCRIPT_DIR"/cmdline.jar --version | jq -re .tdfSpecVersion | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 > 2) || ($1 == 4 && $2 == 3 && $3 >= 0)) exit 0; else exit 1; }'
+      exit $?
+      ;;
+
     *)
       echo "Unknown feature: $2"
       exit 2

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -31,7 +31,8 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     hexless)
-      npx $CTL --version | jq -r .tdfSpecVersion | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 > 2) || ($1 == 4 && $2 == 3 && $3 >= 0)) exit 0; else exit 1; }'
+      set -o pipefail
+      npx $CTL --version | jq -re .tdfSpecVersion | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 > 2) || ($1 == 4 && $2 == 3 && $3 >= 0)) exit 0; else exit 1; }'
       exit $?
       ;;
     nano_ecdsa)

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -30,6 +30,10 @@ if [ "$1" == "supports" ]; then
       npx $CTL help | grep autoconfigure
       exit $?
       ;;
+    hexless)
+      npx $CTL --version | jq -r .tdfSpecVersion | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 > 2) || ($1 == 4 && $2 == 3 && $3 >= 0)) exit 0; else exit 1; }'
+      exit $?
+      ;;
     nano_ecdsa)
       npx $CTL help | grep policyBinding
       exit $?

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -18,7 +18,9 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 sdk_type = Literal["go", "java", "js"]
 
-feature_type = Literal["assertions", "autoconfigure", "nano_ecdsa", "ns_grants"]
+feature_type = Literal[
+    "assertions", "autoconfigure", "nano_ecdsa", "ns_grants", "hexless"
+]
 
 sdk_paths: dict[sdk_type, str] = {
     "go": "sdk/go/cli.sh",
@@ -246,6 +248,8 @@ def supports(sdk: sdk_type, feature: feature_type) -> bool:
             return True
         case ("ns_grants", ("go" | "java")):
             return True
+        case _:
+            pass
 
     c = [
         sdk_paths[sdk],

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -19,6 +19,7 @@ def test_autoconfigure_one_attribute(
     # We have a grant for alpha to localhost kas. Now try to use it...
 
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-one-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -54,6 +55,7 @@ def test_autoconfigure_two_kas_or(
     kas_url_value2: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-two-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -93,6 +95,15 @@ def skip_if_unsupported(sdk: tdfs.sdk_type, *features: tdfs.feature_type):
             pytest.skip(f"{sdk} sdk doesn't yet support [{feature}]")
 
 
+def skip_hexless_skew(encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type):
+    if tdfs.supports(encrypt_sdk, "hexless") and not tdfs.supports(
+        decrypt_sdk, "hexless"
+    ):
+        pytest.skip(
+            f"{decrypt_sdk} sdk doesn't yet support [hexless], but {encrypt_sdk} does"
+        )
+
+
 def test_autoconfigure_double_kas_and(
     attribute_two_kas_grant_and,
     encrypt_sdk,
@@ -103,6 +114,7 @@ def test_autoconfigure_double_kas_and(
     kas_url_value2: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-three-and-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -145,6 +157,7 @@ def test_autoconfigure_one_attribute_attr_grant(
     kas_url_attr: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-one-attr-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -181,6 +194,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
     kas_url_value1: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-attr-val-or-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -224,6 +238,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
     kas_url_value1: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-attr-val-and-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -266,6 +281,7 @@ def test_autoconfigure_one_attribute_ns_grant(
     kas_url_ns: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure", "ns_grants")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-one-ns-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -302,6 +318,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
     kas_url_value1: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure", "ns_grants")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-ns-val-or-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -345,6 +362,7 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
     kas_url_value1: str,
 ):
     skip_if_unsupported(encrypt_sdk, "autoconfigure", "ns_grants")
+    skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
     sample_name = f"test-abac-ns-val-and-{encrypt_sdk}"
     if sample_name in cipherTexts:

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -63,7 +63,9 @@ def do_encrypt_with(
 #### BASIC ROUNDTRIP TESTS
 
 
-def test_tdf(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, container):
+def test_tdf(
+    encrypt_sdk: str, decrypt_sdk: str, pt_file: str, tmp_dir: str, container: str
+):
     use_ecdsa = False
     if container == "nano-with-ecdsa":
         if not tdfs.supports(encrypt_sdk, "nano_ecdsa"):
@@ -72,6 +74,10 @@ def test_tdf(encrypt_sdk, decrypt_sdk, pt_file, tmp_dir, container):
             )
         container = "nano"
         use_ecdsa = True
+    if tdfs.supports(encrypt_sdk, "hexless") and not tdfs.supports(
+        decrypt_sdk, "hexless"
+    ):
+        pytest.skip(f"{decrypt_sdk} sdk doesn't yet support hexless")
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, container, tmp_dir, use_ecdsa)
     assert os.path.isfile(ct_file)
     fname = os.path.basename(ct_file).split(".")[0]


### PR DESCRIPTION
- If encrypt produces a 'hexless' TDF, don't bother testing with older SDK on decrypt
- Currenly, only supports JS library