### PR TITLE
chore(xtest): Fixes ecwrap detection on js

### DIFF
--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -39,7 +39,7 @@ def pytest_addoption(parser: pytest.Parser):
     parser.addoption("--sdks-encrypt", help="select which sdks to run for encrypt only")
     parser.addoption(
         "--containers",
-        help=f"which container formats to test, one or more of {englist(typing.get_args(tdfs.format_type))}",
+        help=f"which container formats to test, one or more of {englist(typing.get_args(tdfs.container_type))}",
     )
 
 
@@ -79,7 +79,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
         if metafunc.config.getoption("--containers"):
             containers = list_opt("--containers")
         else:
-            containers = typing.get_args(tdfs.format_type)
+            containers = typing.get_args(tdfs.container_type)
         metafunc.parametrize("container", containers)
 
 

--- a/xtest/sdk/js/cli/cli.sh
+++ b/xtest/sdk/js/cli/cli.sh
@@ -31,7 +31,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     ecwrap)
-      npx $CTL help | grep encapsulation-algorithm
+      npx $CTL help | grep encapKeyType
       exit $?
       ;;
     hexless)

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -58,6 +58,10 @@ def do_encrypt_with(
     if container == "ztdf":
         manifest = tdfs.manifest(ct_file)
         assert manifest.payload.isEncrypted
+        if use_ecwrap:
+            assert manifest.encryptionInformation.keyAccess[0].type == "ec-wrapped"
+        else:
+            assert manifest.encryptionInformation.keyAccess[0].type == "wrapped"
     elif container == "nano":
         with open(ct_file, "rb") as f:
             envelope = nano.parse(f.read())

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -29,7 +29,7 @@ def skip_hexless_skew(encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type):
 def do_encrypt_with(
     pt_file: str,
     encrypt_sdk: tdfs.sdk_type,
-    container: tdfs.format_type,
+    container: tdfs.container_type,
     tmp_dir: str,
     use_ecdsa: bool = False,
     use_ecwrap: bool = False,
@@ -53,6 +53,7 @@ def do_encrypt_with(
         fmt=container,
         use_ecdsa_binding=use_ecdsa,
         assert_value=az,
+        ecwrap=use_ecwrap,
     )
     if container == "ztdf":
         manifest = tdfs.manifest(ct_file)
@@ -73,12 +74,12 @@ def do_encrypt_with(
 #### BASIC ROUNDTRIP TESTS
 
 
-def test_tdf(
+def test_tdf_roundtrip(
     encrypt_sdk: tdfs.sdk_type,
     decrypt_sdk: tdfs.sdk_type,
     pt_file: str,
     tmp_dir: str,
-    container: tdfs.format_type,
+    container: tdfs.container_type,
 ):
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     use_ecdsa = False


### PR DESCRIPTION
- the JS help string is breaking on the detected keyword, so I picked one that is less likely to suffer word wrap issues
- While I'm here, renames 'format_type' to 'container_type' to match the custom arg name
- Improve debug logging of script invoker to include environment variables, as that is the way we are adding more features now instead of using positional parameters
- Fix bug where ecwrap wasn't being done on encrypt (it was being used for the return rewrap though)