### PR TITLE
chore(xtest): Fix error in dedupe-encrypt logic

### DIFF
--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -48,7 +48,7 @@ args=(
   "--plaintext"
 )
 COMMAND="$1"
-if [[ "$4" == nano* ]]; then
+if [[ $4 == nano* ]]; then
   COMMAND="$1"nano
 fi
 args+=("$COMMAND")

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -45,6 +45,7 @@ args=(
   "--client-id=$CLIENTID"
   "--client-secret=$CLIENTSECRET"
   "--platform-endpoint=$PLATFORMENDPOINT"
+  "--plaintext"
 )
 COMMAND="$1"
 if [[ "$4" == nano* ]]; then

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -47,7 +47,7 @@ args=(
   "--platform-endpoint=$PLATFORMENDPOINT"
 )
 COMMAND="$1"
-if [ "$4" == "nano" ]; then
+if [[ "$4" == nano* ]]; then
   COMMAND="$1"nano
 fi
 args+=("$COMMAND")

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -45,7 +45,6 @@ args=(
   "--client-id=$CLIENTID"
   "--client-secret=$CLIENTSECRET"
   "--platform-endpoint=$PLATFORMENDPOINT"
-  -h
 )
 COMMAND="$1"
 if [ "$4" == "nano" ]; then
@@ -57,7 +56,7 @@ if [ "$1" == "encrypt" ]; then
   args+=(--kas-url=$KASURL)
 
   if [ "$USE_ECDSA_BINDING" == "true" ]; then
-    args+=(--ecdsa-binding "true")
+    args+=(--ecdsa-binding)
   fi
 fi
 
@@ -81,5 +80,5 @@ if [ "$VERIFY_ASSERTIONS" == 'false' ]; then
   args+=(--with-assertion-verification-disabled)
 fi
 
-echo java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" -f "$2" ">" "$3"
-java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" -f "$2" >"$3"
+echo java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" --file="$2" ">" "$3"
+java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" --file="$2" >"$3"

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -79,8 +79,8 @@ def do_encrypt_with(
             assert envelope.header.binding_mode.use_ecdsa_binding == use_ecdsa
             if envelope.header.kas.kid is not None:
                 # from xtest/platform/opentdf.yaml
-                # expected_kid = b"ec1" + b"\0" * 5
-                assert envelope.header.kas.kid == b"e1"
+                expected_kid = b"ec1" + b"\0" * 5
+                assert envelope.header.kas.kid == expected_kid
     else:
         assert False, f"Unknown container type: {container}"
     cipherTexts[container_id] = ct_file

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -119,7 +119,7 @@ def test_tdf_roundtrip(
     tdfs.decrypt(decrypt_sdk, ct_file, rt_file, container)
     assert filecmp.cmp(pt_file, rt_file)
 
-    if container == "ztdf" and tdfs.supports(decrypt_sdk, "ecwrap"):
+    if container.startswith("ztdf") and tdfs.supports(decrypt_sdk, "ecwrap"):
         ert_file = f"{tmp_dir}test-{fname}-ecrewrap.untdf"
         tdfs.decrypt(decrypt_sdk, ct_file, ert_file, container, ecwrap=True)
         assert filecmp.cmp(pt_file, ert_file)


### PR DESCRIPTION
Previously, encrypt with the same sdk/container types were shared in the 'created files' cache, even in the containers had different configuration options. This update should correctly generate new versions of the files when presented with new options. Currently, this means some tests were passing might have failed for nano (ECDSA v. GMAC policy bindings) and ZTDF (ec-wrapped v. RSA wrapped KAOs)