### PR TITLE
feat(xtest): Adds xtest `focus-sdk` parameter

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -23,6 +23,11 @@ on:
         type: string
         default: main
         description: "The branch or commit to use for the java-sdk"
+      focus-sdk:
+        required: false
+        type: string
+        default: all
+        description: "The SDK to focus on (go, js, java, all)"
   workflow_call:
     inputs:
       platform-ref:
@@ -41,6 +46,10 @@ on:
         required: false
         type: string
         default: main
+      focus-sdk:
+        required: false
+        type: string
+        default: all
   schedule:
     - cron: "30 6 * * *"
 jobs:
@@ -55,6 +64,7 @@ jobs:
       JS_REF: "${{ inputs.js-ref || 'main' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
+      FOCUS_SDK: "${{ inputs.focus-sdk || 'all' }}"
     steps:
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers
@@ -165,13 +175,22 @@ jobs:
         working-directory: otdftests/xtest
       - name: Run legacy decryption tests
         run: |-
-          pytest -v test_legacy.py
+          pytest -v  --focus "$FOCUS_SDK" test_legacy.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: '../../${{ steps.run-platform.outputs.platform-working-dir }}'
-      - name: Run xtests
+      - name: Run all standard xtests
+        if: ${{ env.FOCUS_SDK == 'all' }}
         run: |-
           pytest -v test_tdfs.py
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: '../../${{ steps.run-platform.outputs.platform-working-dir }}'
+          SCHEMA_FILE: 'manifest.schema.json'
+      - name: Run xtests focusing on a specific SDK
+        if: ${{ env.FOCUS_SDK != 'all' }}
+        run: |-
+          pytest -v --focus "$FOCUS_SDK" test_tdfs.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: '../../${{ steps.run-platform.outputs.platform-working-dir }}'

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -85,10 +85,10 @@ jobs:
         with:
           repository: opentdf/tests
           path: otdftests # use different name bc other repos might have tests directories
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/xtest/README.md
+++ b/xtest/README.md
@@ -6,7 +6,7 @@
 
 - `go 1.22.3`
 - `node 20`
-- `python 3.10`
+- `python 3.12`
 - `jdk 11`
 - `maven`
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -17,6 +17,9 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 
 sdk_type = Literal["go", "java", "js"]
+
+focus_type = Literal[sdk_type, "all"]
+
 container_type = Literal[
     "nano",
     "nano-with-ecdsa",

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -15,10 +15,12 @@ def test_autoconfigure_one_attribute_standard(
     tmp_dir: str,
     pt_file: str,
     kas_url_value1: str,
+    in_focus: set[tdfs.sdk_type],
 ):
     global counter
-    # We have a grant for alpha to localhost kas. Now try to use it...
 
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -54,7 +56,10 @@ def test_autoconfigure_two_kas_or_standard(
     pt_file: str,
     kas_url_value1: str,
     kas_url_value2: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -113,7 +118,10 @@ def test_autoconfigure_double_kas_and(
     pt_file: str,
     kas_url_value1: str,
     kas_url_value2: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -156,7 +164,10 @@ def test_autoconfigure_one_attribute_attr_grant(
     tmp_dir: str,
     pt_file: str,
     kas_url_attr: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -193,7 +204,10 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
     pt_file: str,
     kas_url_attr: str,
     kas_url_value1: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -237,7 +251,10 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
     pt_file: str,
     kas_url_attr: str,
     kas_url_value1: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -280,7 +297,10 @@ def test_autoconfigure_one_attribute_ns_grant(
     tmp_dir: str,
     pt_file: str,
     kas_url_ns: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure", "ns_grants")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -317,7 +337,10 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
     pt_file: str,
     kas_url_ns: str,
     kas_url_value1: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure", "ns_grants")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 
@@ -361,7 +384,10 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
     pt_file: str,
     kas_url_ns: str,
     kas_url_value1: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_if_unsupported(encrypt_sdk, "autoconfigure", "ns_grants")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
 

--- a/xtest/test_legacy.py
+++ b/xtest/test_legacy.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 
 import tdfs
@@ -12,9 +13,10 @@ def get_golden_file(golden_file_name: str) -> str:
 
 
 def test_decrypt_small(
-    decrypt_sdk: tdfs.sdk_type,
-    tmp_dir: str,
+    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     ct_file = get_golden_file("small-java-4.3.0-e0f8caf.tdf")
     rt_file = os.path.join(tmp_dir, "small-java.untdf")
     tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf")
@@ -27,9 +29,10 @@ def test_decrypt_small(
 
 
 def test_decrypt_big(
-    decrypt_sdk: tdfs.sdk_type,
-    tmp_dir,
+    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     ct_file = get_golden_file("big-java-4.3.0-e0f8caf.tdf")
     rt_file = os.path.join(tmp_dir, "big-java.untdf")
     tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf")
@@ -42,9 +45,10 @@ def test_decrypt_big(
 
 
 def test_decrypt_no_splitid(
-    decrypt_sdk: tdfs.sdk_type,
-    tmp_dir: str,
+    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     ct_file = get_golden_file("no-splitids-java.tdf")
     rt_file = os.path.join(tmp_dir, "no-splitids-java.untdf")
     tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf")
@@ -57,9 +61,10 @@ def test_decrypt_no_splitid(
 
 
 def test_decrypt_object_statement_value_json(
-    decrypt_sdk: tdfs.sdk_type,
-    tmp_dir: str,
+    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     ct_file = get_golden_file("with-json-object-assertions-java.tdf")
     rt_file = os.path.join(tmp_dir, "with-json-object-assertions-java.untdf")
     tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf", verify_assertions=False)

--- a/xtest/test_legacy.py
+++ b/xtest/test_legacy.py
@@ -13,7 +13,9 @@ def get_golden_file(golden_file_name: str) -> str:
 
 
 def test_decrypt_small(
-    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
+    decrypt_sdk: tdfs.sdk_type,
+    tmp_dir: str,
+    in_focus: set[tdfs.sdk_type],
 ):
     if not in_focus:
         pytest.skip("Not in focus")
@@ -29,7 +31,9 @@ def test_decrypt_small(
 
 
 def test_decrypt_big(
-    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
+    decrypt_sdk: tdfs.sdk_type,
+    tmp_dir: str,
+    in_focus: set[tdfs.sdk_type],
 ):
     if not in_focus:
         pytest.skip("Not in focus")
@@ -45,7 +49,9 @@ def test_decrypt_big(
 
 
 def test_decrypt_no_splitid(
-    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
+    decrypt_sdk: tdfs.sdk_type,
+    tmp_dir: str,
+    in_focus: set[tdfs.sdk_type],
 ):
     if not in_focus:
         pytest.skip("Not in focus")
@@ -61,7 +67,9 @@ def test_decrypt_no_splitid(
 
 
 def test_decrypt_object_statement_value_json(
-    decrypt_sdk: tdfs.sdk_type, tmp_dir: str, in_focus: set[tdfs.sdk_type]
+    decrypt_sdk: tdfs.sdk_type,
+    tmp_dir: str,
+    in_focus: set[tdfs.sdk_type],
 ):
     if not in_focus:
         pytest.skip("Not in focus")

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -96,7 +96,10 @@ def test_tdf_roundtrip(
     pt_file: str,
     tmp_dir: str,
     container: tdfs.container_type,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if container == "nano-with-ecdsa":
         if not tdfs.supports(encrypt_sdk, "nano_ecdsa"):
@@ -128,15 +131,25 @@ def test_tdf_roundtrip(
 #### MANIFEST VALIDITY TESTS
 
 
-def test_manifest_validity(encrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str):
+def test_manifest_validity(
+    encrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str, in_focus: bool
+):
+    if not in_focus:
+        pytest.skip("Not in focus")
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     assert os.path.isfile(ct_file)
     tdfs.validate_manifest_schema(ct_file)
 
 
 def test_manifest_validity_with_assertions(
-    encrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str, assertion_file_no_keys: str
+    encrypt_sdk: tdfs.sdk_type,
+    pt_file: str,
+    tmp_dir: str,
+    assertion_file_no_keys: str,
+    in_focus: bool,
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     ct_file = do_encrypt_with(
@@ -160,7 +173,10 @@ def test_tdf_assertions_unkeyed(
     pt_file: str,
     tmp_dir: str,
     assertion_file_no_keys: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
@@ -188,7 +204,10 @@ def test_tdf_assertions_with_keys(
     tmp_dir: str,
     assertion_file_rs_and_hs_keys: str,
     assertion_verification_file_rs_and_hs_keys: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
@@ -303,8 +322,14 @@ def change_payload_end(payload_bytes: bytes) -> bytes:
 
 
 def test_tdf_with_unbound_policy(
-    encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str
+    encrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.sdk_type,
+    pt_file: str,
+    tmp_dir: str,
+    in_focus: bool,
 ) -> None:
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     assert os.path.isfile(ct_file)
@@ -320,8 +345,14 @@ def test_tdf_with_unbound_policy(
 
 
 def test_tdf_with_altered_policy_binding(
-    encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str
+    encrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.sdk_type,
+    pt_file: str,
+    tmp_dir: str,
+    in_focus: bool,
 ) -> None:
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     assert os.path.isfile(ct_file)
@@ -342,8 +373,14 @@ def test_tdf_with_altered_policy_binding(
 
 
 def test_tdf_with_altered_root_sig(
-    encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str
+    encrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.sdk_type,
+    pt_file: str,
+    tmp_dir: str,
+    in_focus: bool,
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     assert os.path.isfile(ct_file)
@@ -359,8 +396,14 @@ def test_tdf_with_altered_root_sig(
 
 
 def test_tdf_with_altered_seg_sig_wrong(
-    encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str
+    encrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.sdk_type,
+    pt_file: str,
+    tmp_dir: str,
+    in_focus: bool,
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     assert os.path.isfile(ct_file)
@@ -379,8 +422,14 @@ def test_tdf_with_altered_seg_sig_wrong(
 
 
 def test_tdf_with_altered_enc_seg_size(
-    encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str
+    encrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.sdk_type,
+    pt_file: str,
+    tmp_dir: str,
+    in_focus: bool,
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     assert os.path.isfile(ct_file)
@@ -409,7 +458,10 @@ def test_tdf_with_altered_assertion_statement(
     pt_file: str,
     tmp_dir: str,
     assertion_file_no_keys: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
@@ -444,7 +496,10 @@ def test_tdf_with_altered_assertion_with_keys(
     tmp_dir: str,
     assertion_file_rs_and_hs_keys: str,
     assertion_verification_file_rs_and_hs_keys: str,
+    in_focus: set[tdfs.sdk_type],
 ):
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if not tdfs.supports(encrypt_sdk, "assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
@@ -487,8 +542,14 @@ def test_tdf_with_altered_assertion_with_keys(
 
 
 def test_tdf_altered_payload_end(
-    encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type, pt_file: str, tmp_dir: str
+    encrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.sdk_type,
+    pt_file: str,
+    tmp_dir: str,
+    in_focus: bool,
 ) -> None:
+    if not in_focus:
+        pytest.skip("Not in focus")
     skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     assert os.path.isfile(ct_file)


### PR DESCRIPTION
Focusing on a specific SDK, `go`, `java`, or `js`, will only execute tests that involve that SDK, skipping all tests that are from or between other SDKs, e.g. if `focus == 'go'`, tests won't run that compare outputs between `js` and `java`, that don't involve the go sdk.