### PR TITLE
chore(xtest): Refactoring: SDK class

### DIFF
--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -108,7 +108,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
         )
         # convert list of sdk_type to list of SDK objects
         e_sdks = [tdfs.SDK(sdk) for sdk in encrypt_sdks]
-        metafunc.parametrize("encrypt_sdk", e_sdks)
+        metafunc.parametrize("encrypt_sdk", e_sdks, ids=[str(x) for x in e_sdks])
         subject_sdks |= set(e_sdks)
     if "decrypt_sdk" in metafunc.fixturenames:
         decrypt_sdks: list[tdfs.sdk_type] = []
@@ -118,7 +118,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
             list(typing.get_args(tdfs.sdk_type)),
         )
         d_sdks = [tdfs.SDK(sdk) for sdk in decrypt_sdks]
-        metafunc.parametrize("decrypt_sdk", d_sdks)
+        metafunc.parametrize("decrypt_sdk", d_sdks, ids=[str(x) for x in d_sdks])
         subject_sdks |= set(d_sdks)
 
     if "in_focus" in metafunc.fixturenames:
@@ -130,7 +130,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
             focus = set(typing.get_args(tdfs.sdk_type))
         else:
             focus = set(list_opt("--focus", tdfs.focus_type))
-        metafunc.parametrize("in_focus", [focus & subject_sdks])
+        focused_sdks = set(s for s in subject_sdks if s.sdk in focus)
+        metafunc.parametrize("in_focus", [focused_sdks])
 
     if "container" in metafunc.fixturenames:
         containers: list[tdfs.container_type] = []

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -224,23 +224,24 @@ def fmt_env(env: dict[str, str]) -> str:
 
 
 class SDK:
-    def __init__(self, sdk: sdk_type):
     sdk: sdk_type
+
+    def __init__(self, sdk: sdk_type):
         self.sdk = sdk
         self.path = sdk_paths[sdk]
         if not os.path.isfile(self.path):
             raise FileNotFoundError(f"SDK executable not found at path: {self.path}")
 
     def __str__(self) -> str:
-        return f"{self.sdk}@{self.version}"
-    
+        return f"{self.sdk}"
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SDK):
             return NotImplemented
-        return self.sdk == other.sdk and self.version == other.version
+        return self.sdk == other.sdk
 
     def __hash__(self) -> int:
-        return hash((self.sdk, self.version))
+        return hash(self.sdk)
 
     def encrypt(
         self,

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -225,8 +225,22 @@ def fmt_env(env: dict[str, str]) -> str:
 
 class SDK:
     def __init__(self, sdk: sdk_type):
+    sdk: sdk_type
         self.sdk = sdk
         self.path = sdk_paths[sdk]
+        if not os.path.isfile(self.path):
+            raise FileNotFoundError(f"SDK executable not found at path: {self.path}")
+
+    def __str__(self) -> str:
+        return f"{self.sdk}@{self.version}"
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SDK):
+            return NotImplemented
+        return self.sdk == other.sdk and self.version == other.version
+
+    def __hash__(self) -> int:
+        return hash((self.sdk, self.version))
 
     def encrypt(
         self,

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -10,8 +10,8 @@ cipherTexts: dict[str, str] = {}
 
 def test_autoconfigure_one_attribute_standard(
     attribute_single_kas_grant: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_value1: str,
@@ -30,8 +30,7 @@ def test_autoconfigure_one_attribute_standard(
     else:
         ct_file = f"{tmp_dir}{sample_name}.tdf"
         cipherTexts[sample_name] = ct_file
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -44,14 +43,14 @@ def test_autoconfigure_one_attribute_standard(
     assert manifest.encryptionInformation.keyAccess[0].url == kas_url_value1
 
     rt_file = f"{tmp_dir}test-abac-one-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
 def test_autoconfigure_two_kas_or_standard(
     attribute_two_kas_grant_or: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_value1: str,
@@ -68,8 +67,7 @@ def test_autoconfigure_two_kas_or_standard(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -91,20 +89,18 @@ def test_autoconfigure_two_kas_or_standard(
     )
 
     rt_file = f"{tmp_dir}test-abac-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
-def skip_if_unsupported(sdk: tdfs.sdk_type, *features: tdfs.feature_type):
+def skip_if_unsupported(sdk: tdfs.SDK, *features: tdfs.feature_type):
     for feature in features:
-        if not tdfs.supports(sdk, feature):
+        if not sdk.supports(feature):
             pytest.skip(f"{sdk} sdk doesn't yet support [{feature}]")
 
 
-def skip_hexless_skew(encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type):
-    if tdfs.supports(encrypt_sdk, "hexless") and not tdfs.supports(
-        decrypt_sdk, "hexless"
-    ):
+def skip_hexless_skew(encrypt_sdk: tdfs.SDK, decrypt_sdk: tdfs.SDK):
+    if encrypt_sdk.supports("hexless") and not decrypt_sdk.supports("hexless"):
         pytest.skip(
             f"{decrypt_sdk} sdk doesn't yet support [hexless], but {encrypt_sdk} does"
         )
@@ -112,8 +108,8 @@ def skip_hexless_skew(encrypt_sdk: tdfs.sdk_type, decrypt_sdk: tdfs.sdk_type):
 
 def test_autoconfigure_double_kas_and(
     attribute_two_kas_grant_and: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_value1: str,
@@ -130,8 +126,7 @@ def test_autoconfigure_double_kas_and(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -153,14 +148,14 @@ def test_autoconfigure_double_kas_and(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
     rt_file = f"{tmp_dir}test-abac-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
 def test_autoconfigure_one_attribute_attr_grant(
     one_attribute_attr_kas_grant: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_attr: str,
@@ -176,8 +171,7 @@ def test_autoconfigure_one_attribute_attr_grant(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -192,14 +186,14 @@ def test_autoconfigure_one_attribute_attr_grant(
     assert len(manifest.encryptionInformation.keyAccess) == 1
     assert manifest.encryptionInformation.keyAccess[0].url == kas_url_attr
     rt_file = f"{tmp_dir}test-abac-one-attr-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
 def test_autoconfigure_two_kas_or_attr_and_value_grant(
     attr_and_value_kas_grants_or: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_attr: str,
@@ -216,8 +210,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -239,14 +232,14 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
     rt_file = f"{tmp_dir}test-abac-attr-val-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
 def test_autoconfigure_two_kas_and_attr_and_value_grant(
     attr_and_value_kas_grants_and: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_attr: str,
@@ -263,8 +256,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -286,14 +278,14 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
     rt_file = f"{tmp_dir}test-abac-attr-val-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
 def test_autoconfigure_one_attribute_ns_grant(
     one_attribute_ns_kas_grant: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_ns: str,
@@ -309,8 +301,7 @@ def test_autoconfigure_one_attribute_ns_grant(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -325,14 +316,14 @@ def test_autoconfigure_one_attribute_ns_grant(
     assert len(manifest.encryptionInformation.keyAccess) == 1
     assert manifest.encryptionInformation.keyAccess[0].url == kas_url_ns
     rt_file = f"{tmp_dir}test-abac-one-ns-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
 def test_autoconfigure_two_kas_or_ns_and_value_grant(
     ns_and_value_kas_grants_or: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_ns: str,
@@ -349,8 +340,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -372,14 +362,14 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
     rt_file = f"{tmp_dir}test-abac-ns-val-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
 def test_autoconfigure_two_kas_and_ns_and_value_grant(
     ns_and_value_kas_grants_and: Attribute,
-    encrypt_sdk: tdfs.sdk_type,
-    decrypt_sdk: tdfs.sdk_type,
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     pt_file: str,
     kas_url_ns: str,
@@ -396,8 +386,7 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
         ct_file = cipherTexts[sample_name]
     else:
         ct_file = f"{tmp_dir}/{sample_name}.tdf"
-        tdfs.encrypt(
-            encrypt_sdk,
+        encrypt_sdk.encrypt(
             pt_file,
             ct_file,
             mime_type="text/plain",
@@ -419,5 +408,5 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
         [kao.url for kao in manifest.encryptionInformation.keyAccess]
     )
     rt_file = f"{tmp_dir}test-abac-ns-val-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)

--- a/xtest/test_legacy.py
+++ b/xtest/test_legacy.py
@@ -13,7 +13,7 @@ def get_golden_file(golden_file_name: str) -> str:
 
 
 def test_decrypt_small(
-    decrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     in_focus: set[tdfs.sdk_type],
 ):
@@ -21,7 +21,7 @@ def test_decrypt_small(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("small-java-4.3.0-e0f8caf.tdf")
     rt_file = os.path.join(tmp_dir, "small-java.untdf")
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
@@ -31,7 +31,7 @@ def test_decrypt_small(
 
 
 def test_decrypt_big(
-    decrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     in_focus: set[tdfs.sdk_type],
 ):
@@ -39,7 +39,7 @@ def test_decrypt_big(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("big-java-4.3.0-e0f8caf.tdf")
     rt_file = os.path.join(tmp_dir, "big-java.untdf")
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 10 * 2**20
     expected_bytes = bytes([0] * 1024)
@@ -49,7 +49,7 @@ def test_decrypt_big(
 
 
 def test_decrypt_no_splitid(
-    decrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     in_focus: set[tdfs.sdk_type],
 ):
@@ -57,7 +57,7 @@ def test_decrypt_no_splitid(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("no-splitids-java.tdf")
     rt_file = os.path.join(tmp_dir, "no-splitids-java.untdf")
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
@@ -67,7 +67,7 @@ def test_decrypt_no_splitid(
 
 
 def test_decrypt_object_statement_value_json(
-    decrypt_sdk: tdfs.sdk_type,
+    decrypt_sdk: tdfs.SDK,
     tmp_dir: str,
     in_focus: set[tdfs.sdk_type],
 ):
@@ -75,6 +75,6 @@ def test_decrypt_object_statement_value_json(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("with-json-object-assertions-java.tdf")
     rt_file = os.path.join(tmp_dir, "with-json-object-assertions-java.untdf")
-    tdfs.decrypt(decrypt_sdk, ct_file, rt_file, fmt="ztdf", verify_assertions=False)
+    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf", verify_assertions=False)
     with open(rt_file, "rb") as f:
         assert f.read().decode("utf-8") == "text"


### PR DESCRIPTION
- Converts SDK selection to use a class, instead of just the name
- This will help when we migrate to version selection, since we will not be able to distinguish by name alone