### PR TITLE
chore(xtest): Fix for pull requests

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -134,7 +134,7 @@ jobs:
         with:
           path: otdftests/xtest/sdk
           sdk: js
-          version: "${{ inputs.js-ref || 'main refs/pull/517/merge' }}"
+          version: "${{ inputs.js-ref || 'main' }}"
 
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -134,7 +134,7 @@ jobs:
         with:
           path: otdftests/xtest/sdk
           sdk: js
-          version: "${{ inputs.js-ref || 'main' }}"
+          version: "${{ inputs.js-ref || 'main refs/pull/517/merge' }}"
 
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers

--- a/xtest/sdk/scripts/resolve-version.py
+++ b/xtest/sdk/scripts/resolve-version.py
@@ -72,6 +72,16 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
             ]
             sha, _ = [tag for tag in all_heads if "refs/heads/main" in tag][0]
             return {"sdk": sdk, "alias": "main", "tag": "main", "sha": sha}
+        
+        if version.startswith("refs/pull/"):
+            merge_heads = [
+                r.split("\t") for r in repo.ls_remote(sdk_url).split("\n") if r.endswith(version)
+            ]
+            pr_number = version.split("/")[-2]
+            if not merge_heads:
+                return {"sdk": sdk, "alias": version, "err": f"pull request {pr_number} not found in {sdk_url}"}
+            sha, _ = merge_heads[0]
+            return {"sdk": sdk, "alias": version, "tag": f"pull-{pr_number}", "sha": sha}
 
         remote_tags = [
             r.split("\t") for r in repo.ls_remote(sdk_url, tags=True).split("\n")

--- a/xtest/sdk/scripts/resolve-version.py
+++ b/xtest/sdk/scripts/resolve-version.py
@@ -72,16 +72,27 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
             ]
             sha, _ = [tag for tag in all_heads if "refs/heads/main" in tag][0]
             return {"sdk": sdk, "alias": "main", "tag": "main", "sha": sha}
-        
+
         if version.startswith("refs/pull/"):
             merge_heads = [
-                r.split("\t") for r in repo.ls_remote(sdk_url).split("\n") if r.endswith(version)
+                r.split("\t")
+                for r in repo.ls_remote(sdk_url).split("\n")
+                if r.endswith(version)
             ]
             pr_number = version.split("/")[-2]
             if not merge_heads:
-                return {"sdk": sdk, "alias": version, "err": f"pull request {pr_number} not found in {sdk_url}"}
+                return {
+                    "sdk": sdk,
+                    "alias": version,
+                    "err": f"pull request {pr_number} not found in {sdk_url}",
+                }
             sha, _ = merge_heads[0]
-            return {"sdk": sdk, "alias": version, "tag": f"pull-{pr_number}", "sha": sha}
+            return {
+                "sdk": sdk,
+                "alias": version,
+                "tag": f"pull-{pr_number}",
+                "sha": sha,
+            }
 
         remote_tags = [
             r.split("\t") for r in repo.ls_remote(sdk_url, tags=True).split("\n")

--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -53,12 +53,9 @@ runs:
       env:
         VERSIONS: "${{ inputs.version }}"
       run: |
-        if [[ ! $VERSIONS =~ ^[0-9a-zA-Z\.\ \\]+$ ]]; then
-          echo "Error: Invalid version string: $VERSIONS" >> $GITHUB_STEP_SUMMARY
-          exit 1
-        fi
         if [[ $(echo "$VERSIONS" | wc -w) -gt 4 ]]; then
-          echo "Error: Too many versions specified: $VERSIONS" >> $GITHUB_STEP_SUMMARY
+          echo "Error: Too many versions specified: [$VERSIONS]"
+          echo "Error: Too many versions specified: [$VERSIONS]" >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
 

--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -53,7 +53,7 @@ runs:
       env:
         VERSIONS: "${{ inputs.version }}"
       run: |
-        if [[ ! $VERSIONS =~ ^[0-9a-zA-Z\.\ ]+$ ]]; then
+        if [[ ! $VERSIONS =~ ^[0-9a-zA-Z\.\ \\]+$ ]]; then
           echo "Error: Invalid version string: $VERSIONS" >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
@@ -66,6 +66,7 @@ runs:
       uses: actions/checkout@v4
       with:
         path: otdf-sdk
+        repository: opentdf/tests
         sparse-checkout: xtest/sdk
 
     - name: Set up Python 3.12


### PR DESCRIPTION
Ths lets the `resolve-versions` script handle `refs/pulls/[number]/{merge,head}` style ref names.
It also fixes a remaining `checkout` action that was missing the `repository` parameter