### PR TITLE
chore(xtest): Skips nonconformant ecwrap clients

### DIFF
--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -39,8 +39,14 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     ecwrap)
-      "${cmd[@]}" help encrypt | grep wrapping-key
-      exit $?
+      if "${cmd[@]}" help encrypt | grep wrapping-key; then
+        # while the otdfctl app may support ecwrap, but sdk versions 0.3.28 and earlier uses the old salt
+        "${cmd[@]}" --version --json | jq -re .sdk_version | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 3) || ($1 == 0 && $2 == 3 && $3 >= 29)) exit 0; else exit 1; }'
+        exit $?
+      else
+        echo "ecwrap not supported"
+        exit 1
+      fi
       ;;
     hexless)
       set -o pipefail

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -52,8 +52,14 @@ if [ "$1" == "supports" ]; then
       ;;
 
     ecwrap)
-      java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep encap-key
-      exit $?
+      if java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep encap-key; then
+        # versions 0.7.6 and earlier used an older value for EC HKDF salt; check for 0.7.7 or later
+        java -jar "$SCRIPT_DIR"/cmdline.jar --version | jq -re .version | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 7) || ($1 == 0 && $2 == 7 && $3 >= 7)) exit 0; else exit 1; }'
+        exit $?
+      else
+        echo "ecwrap not supported"
+        exit 1
+      fi
       ;;
 
     hexless)

--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -44,8 +44,14 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     ecwrap)
-      npx $CTL help | grep encapKeyType
-      exit $?
+      if npx $CTL help | grep encapKeyType; then
+        # Claims to support ecwrap, but maybe with old salt? Look up version
+        npx $CTL --version | jq -re '.["@opentdf/sdk"]' | awk -F. '{ if ($1 > 2) exit 0; else exit 1; }'
+        exit $?
+      else
+        echo "ecwrap not supported"
+        exit 1
+      fi
       ;;
     hexless)
       set -o pipefail

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -82,6 +82,7 @@ class PlatformFeatureSet(BaseModel):
 
         if self.semver >= (0, 4, 19):
             self.features.add("ns_grants")
+        print(f"PLATFORM_VERSION '{v}' supports [{', '.join(self.features)}]")
 
 
 class DataAttribute(BaseModel):


### PR DESCRIPTION
We briefly enabled ec-wrap key access objects in most clients with a different salt value for the hkdf during development. This should skip testing the ecwrap feature on those clients now that we've enabled skew testing