### PR TITLE
chore(xtest): Skip ecdsa tests on older java-sdks

### DIFF
--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -39,8 +39,14 @@ if [ "$1" == "supports" ]; then
       exit 0
       ;;
     nano_ecdsa)
-      java -jar "$SCRIPT_DIR"/cmdline.jar help encryptnano | grep ecdsa-binding
-      exit $?
+      if java -jar "$SCRIPT_DIR"/cmdline.jar help encryptnano | grep ecdsa-binding; then
+        # Java version 0.7.7 fixwa a bug in the ECDSA parsing for nano
+        java -jar "$SCRIPT_DIR"/cmdline.jar --version | jq -re .version | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 7) || ($1 == 0 && $2 == 7 && $3 >= 7)) exit 0; else exit 1; }' 
+        exit $?
+      else
+        echo "ecdsa-binding not supported"
+        exit 1
+      fi
       ;;
     assertions)
       java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep with-assertions

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -309,13 +309,13 @@ class SDK:
         pt_file: str,
         ct_file: str,
         mime_type: str = "application/octet-stream",
-        fmt: container_type = "nano",
+        container: container_type = "nano",
         attr_values: list[str] | None = None,
         assert_value: str = "",
     ):
-        use_ecdsa = fmt == "nano-with-ecdsa"
-        use_ecwrap = fmt == "ztdf-ecwrap"
-        fmt = simple_container(fmt)
+        use_ecdsa = container == "nano-with-ecdsa"
+        use_ecwrap = container == "ztdf-ecwrap"
+        fmt = simple_container(container)
         c = [
             self.path,
             "encrypt",
@@ -350,12 +350,14 @@ class SDK:
         self,
         ct_file: str,
         rt_file: str,
-        fmt: container_type = "nano",
+        container: container_type = "nano",
         assert_keys: str = "",
         verify_assertions: bool = True,
         ecwrap: bool = False,
         expect_error: bool = False,
     ):
+        fmt = simple_container(container)
+
         c = [
             self.path,
             "decrypt",

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -34,7 +34,7 @@ def test_autoconfigure_one_attribute_standard(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=attribute_single_kas_grant.value_fqns,
         )
         cipherTexts[sample_name] = ct_file
@@ -71,7 +71,7 @@ def test_autoconfigure_two_kas_or_standard(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 attribute_two_kas_grant_or.value_fqns[0],
                 attribute_two_kas_grant_or.value_fqns[1],
@@ -117,7 +117,7 @@ def test_autoconfigure_double_kas_and(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 attribute_two_kas_grant_and.value_fqns[0],
                 attribute_two_kas_grant_and.value_fqns[1],
@@ -162,7 +162,7 @@ def test_autoconfigure_one_attribute_attr_grant(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 one_attribute_attr_kas_grant.value_fqns[0],
             ],
@@ -201,7 +201,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 attr_and_value_kas_grants_or.value_fqns[0],
                 attr_and_value_kas_grants_or.value_fqns[1],
@@ -247,7 +247,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 attr_and_value_kas_grants_and.value_fqns[0],
                 attr_and_value_kas_grants_and.value_fqns[1],
@@ -292,7 +292,7 @@ def test_autoconfigure_one_attribute_ns_grant(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 one_attribute_ns_kas_grant.value_fqns[0],
             ],
@@ -331,7 +331,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 ns_and_value_kas_grants_or.value_fqns[0],
                 ns_and_value_kas_grants_or.value_fqns[1],
@@ -377,7 +377,7 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
             pt_file,
             ct_file,
             mime_type="text/plain",
-            fmt="ztdf",
+            container="ztdf",
             attr_values=[
                 ns_and_value_kas_grants_and.value_fqns[0],
                 ns_and_value_kas_grants_and.value_fqns[1],

--- a/xtest/test_legacy.py
+++ b/xtest/test_legacy.py
@@ -21,7 +21,7 @@ def test_decrypt_small(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("small-java-4.3.0-e0f8caf.tdf")
     rt_file = os.path.join(tmp_dir, "small-java.untdf")
-    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
@@ -39,7 +39,7 @@ def test_decrypt_big(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("big-java-4.3.0-e0f8caf.tdf")
     rt_file = os.path.join(tmp_dir, "big-java.untdf")
-    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 10 * 2**20
     expected_bytes = bytes([0] * 1024)
@@ -57,7 +57,7 @@ def test_decrypt_no_splitid(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("no-splitids-java.tdf")
     rt_file = os.path.join(tmp_dir, "no-splitids-java.untdf")
-    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
@@ -75,6 +75,6 @@ def test_decrypt_object_statement_value_json(
         pytest.skip("Not in focus")
     ct_file = get_golden_file("with-json-object-assertions-java.tdf")
     rt_file = os.path.join(tmp_dir, "with-json-object-assertions-java.untdf")
-    decrypt_sdk.decrypt(ct_file, rt_file, fmt="ztdf", verify_assertions=False)
+    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf", verify_assertions=False)
     with open(rt_file, "rb") as f:
         assert f.read().decode("utf-8") == "text"

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -93,6 +93,11 @@ def test_tdf_roundtrip(
             pytest.skip(
                 f"{pfs.version} opentdf platform doesn't yet support ecwrap bindings"
             )
+        # Unlike javascript, Java uses an open box KAO so it doesn't support ecwrap if on older versions
+        if decrypt_sdk.sdk == "java" and not encrypt_sdk.supports("ecwrap"):
+            pytest.skip(
+                f"{decrypt_sdk} sdk doesn't support ecwrap bindings for decrypt"
+            )
 
     ct_file = do_encrypt_with(
         pt_file,

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -41,7 +41,7 @@ def do_encrypt_with(
         pt_file,
         ct_file,
         mime_type="text/plain",
-        fmt=container,
+        container=container,
         assert_value=az,
     )
     if tdfs.simple_container(container) == "ztdf":

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -94,7 +94,7 @@ def test_tdf_roundtrip(
                 f"{pfs.version} opentdf platform doesn't yet support ecwrap bindings"
             )
         # Unlike javascript, Java uses an open box KAO so it doesn't support ecwrap if on older versions
-        if decrypt_sdk.sdk == "java" and not encrypt_sdk.supports("ecwrap"):
+        if decrypt_sdk.sdk == "java" and not decrypt_sdk.supports("ecwrap"):
             pytest.skip(
                 f"{decrypt_sdk} sdk doesn't support ecwrap bindings for decrypt"
             )


### PR DESCRIPTION
This feature is broken in 0.7.6, and unlike web-sdk, since the KAOs are parsed before being passed to rewrap, new fields are dropped