### PR TITLE
chore(xtest): Lets go work otdf ctl 🤝 plat

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -62,6 +62,7 @@ jobs:
     outputs:
       platform-tag-to-sha: ${{ steps.platform-version-info.outputs.platform-tag-to-sha }}
       tag-list: ${{ steps.platform-version-info.outputs.tag-list }}
+      heads: ${{ steps.platform-version-info.outputs.heads }}
     steps:
       - name: Validate focus-sdk input
         if : ${{ inputs.focus-sdk != '' }}
@@ -97,6 +98,9 @@ jobs:
           version_info=$(./scripts/resolve-version.py platform $PLATFORM_REF)
           echo "tag-list=$(echo $version_info | jq -rc '[.[].tag]')" >> $GITHUB_OUTPUT
           echo "platform-tag-to-sha=$(echo $version_info | jq -rc 'map({(.tag): .sha}) | add')" >> $GITHUB_OUTPUT
+          head_tags=$(echo "$version_info" | jq -c '[.[] | select(.head == true) | .tag]')
+          echo "head_tags=$head_tags"
+          echo "heads=$head_tags" >> $GITHUB_OUTPUT
 
           echo "### Platform Versions under Test" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -111,8 +115,7 @@ jobs:
             exit 1
           fi
         working-directory: otdf-sdk/xtest/sdk
-    
-      
+
   cross-client-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -208,7 +211,7 @@ jobs:
           version: "${{ inputs.otdfctl-ref || steps.default-tags.outputs.values }}"
 
       - name: Replace otdfctl go.mod packages, but only at heaad version of platform
-        if: env.FOCUS_SDK == 'go' && matrix.platform-tag == 'main'
+        if: env.FOCUS_SDK == 'go' && contains(fromJSON(needs.resolve-versions.outputs.heads), matrix.platform-tag)
         run: |-
           echo "Replacing go.mod packages..."
           PLATFORM_DIR_ABS="$(pwd)/${{ steps.run-platform.outputs.platform-working-dir }}"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -275,11 +275,6 @@ jobs:
         run: |-
           pip install -r requirements.txt
         working-directory: otdftests/xtest
-      # When the schema gets merged into the spec repo, we can just rely on that as a source of truth
-      - name: Get manifest schema from platform repo
-        run: |-
-          curl -L -o manifest.schema.json https://raw.githubusercontent.com/opentdf/platform/main/sdk/schema/manifest.schema.json
-        working-directory: otdftests/xtest
       - name: Validate xtest helper library (tests of the test harness and its utilities)
         if: ${{ !inputs }}
         run: |-

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -200,6 +200,7 @@ jobs:
 
       ######## CHECKOUT GO CLI #############
       - name: Configure otdfctl
+        id: configure-go
         uses: ./otdftests/xtest/setup-cli-tool
         with:
           path: otdftests/xtest/sdk
@@ -211,14 +212,19 @@ jobs:
         run: |-
           echo "Replacing go.mod packages..."
           PLATFORM_DIR_ABS="$(pwd)/${{ steps.run-platform.outputs.platform-working-dir }}"
-          OTDFCTL_DIR_ABS="$(pwd)/otdftests/xtest/sdk/go/src/main"
+          OTDFCTL_DIR_ABS="$(pwd)/otdftests/xtest/sdk/go/src/"
           echo "PLATFORM_DIR_ABS: $PLATFORM_DIR_ABS"
           echo "OTDFCTL_DIR_ABS: $OTDFCTL_DIR_ABS"
-          cd "${OTDFCTL_DIR_ABS}"
-          for m in lib/fixtures lib/ocrypto protocol/go sdk; do
-            go mod edit -replace "github.com/opentdf/platform/$m=${PLATFORM_DIR_ABS}/$m"
+          for head in $(echo "${OTDFCTL_HEADS}" | jq -r '.[]'); do
+            echo "Processing head: $head"
+            cd "${OTDFCTL_DIR_ABS}/$head"
+            for m in lib/fixtures lib/ocrypto protocol/go sdk; do
+              go mod edit -replace "github.com/opentdf/platform/$m=${PLATFORM_DIR_ABS}/$m"
+            done
+            go mod tidy
           done
-          go mod tidy
+        env:
+          OTDFCTL_HEADS: ${{ steps.configure-go.outputs.heads }}
 
       ######## SETUP THE GO CLI #############
       - name: Prepare go cli

--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -30,11 +30,7 @@ if [ "$1" == "supports" ]; then
     autoconfigure | nano_ecdsa | ns_grants)
       exit 0
       ;;
-    assertions)
-      "${cmd[@]}" help encrypt | grep with-assertions
-      exit $?
-      ;;
-    assertion_verification)
+    assertions | assertion_verification)
       "${cmd[@]}" help decrypt | grep with-assertion-verification-keys
       exit $?
       ;;
@@ -50,7 +46,8 @@ if [ "$1" == "supports" ]; then
       ;;
     hexless)
       set -o pipefail
-      "${cmd[@]}" --version --json | jq -re .schema_version | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 > 2) || ($1 == 4 && $2 == 3 && $3 >= 0)) exit 0; else exit 1; }'
+      # Schema version 4.3.0 introduced hexless
+      "${cmd[@]}" --version --json | jq -re .schema_version | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 >= 2)) exit 0; else exit 1; }'
       exit $?
       ;;
     *)

--- a/xtest/sdk/scripts/resolve-version.py
+++ b/xtest/sdk/scripts/resolve-version.py
@@ -94,7 +94,13 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
                 r.split("\t") for r in repo.ls_remote(sdk_url, heads=True).split("\n")
             ]
             sha, _ = [tag for tag in all_heads if "refs/heads/main" in tag][0]
-            return {"sdk": sdk, "alias": version, "head": True, "tag": "main", "sha": sha}
+            return {
+                "sdk": sdk,
+                "alias": version,
+                "head": True,
+                "tag": "main",
+                "sha": sha,
+            }
 
         if re.match(sha_regex, version):
             ls_remote = [r.split("\t") for r in repo.ls_remote(sdk_url).split("\n")]

--- a/xtest/sdk/scripts/resolve-version.py
+++ b/xtest/sdk/scripts/resolve-version.py
@@ -130,14 +130,37 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
                         }
                 # No pull request, probably a feature branch or release branch
                 for sha, tag in matching_tags:
-                    if tag.startswith("refs/heads/"):
+                    if tag.startswith("refs/heads/gh-readonly-queue/"):
+                        to_branch, from_pr = tag.split("/")[-2:]
+                        if to_branch and from_pr:
+                            return {
+                                "sdk": sdk,
+                                "alias": version,
+                                "head": True,
+                                "tag": f"mq-{to_branch}-{from_pr}",
+                                "sha": sha,
+                            }
+                        suffix = tag.split("refs/heads/gh-readonly-queue/")[-1]
+                        flattag = "mq--" + suffix.replace("/", "--")
                         return {
                             "sdk": sdk,
                             "alias": version,
                             "head": True,
-                            "tag": tag.split("refs/heads/")[-1],
+                            "tag": flattag,
                             "sha": sha,
                         }
+                    head = False
+                    if tag.startswith("refs/heads/"):
+                        head = True
+                        tag = tag.split("refs/heads/")[-1]
+                    flattag = tag.replace("/", "--")
+                    return {
+                        "sdk": sdk,
+                        "alias": version,
+                        "head": head,
+                        "tag": flattag,
+                        "sha": sha,
+                    }
 
                 return {
                     "sdk": sdk,

--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -107,7 +107,8 @@ runs:
         echo "version-c=$version_c" >> $GITHUB_OUTPUT
         echo "version-d=$version_d" >> $GITHUB_OUTPUT
         head_tags=$(echo "$version_info" | jq -c '[.[] | select(.head == true) | .tag]')
-        echo "head=$head_tags" >> $GITHUB_OUTPUT
+        echo "head_tags=$head_tags"
+        echo "heads=$head_tags" >> $GITHUB_OUTPUT
       working-directory: otdf-sdk/xtest/sdk/
 
     - name: checkout version a

--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -25,6 +25,9 @@ outputs:
   version-d:
     description: "Object containing tag, sha, and name of a version checked out, if four were specified"
     value: ${{ steps.resolve.outputs.version-d }}
+  heads:
+    description: "JSON list of tags that represent main or branch heads"
+    value: ${{ steps.resolve.outputs.heads }}
 
 runs:
   using: composite
@@ -103,6 +106,8 @@ runs:
         echo "version-b=$version_b" >> $GITHUB_OUTPUT
         echo "version-c=$version_c" >> $GITHUB_OUTPUT
         echo "version-d=$version_d" >> $GITHUB_OUTPUT
+        head_tags=$(echo "$version_info" | jq -c '[.[] | select(.head == true) | .tag]')
+        echo "head=$head_tags" >> $GITHUB_OUTPUT
       working-directory: otdf-sdk/xtest/sdk/
 
     - name: checkout version a


### PR DESCRIPTION
Required changes to let the otdfctl repo dispatch skew tests

- Adds a 'head' flag for checked out source SDKs
- For otdfctl, use this to indicate we should be using the checked-out version of plat for the libraries in that repo. For example, this now properly sets up a go workspace for pull requests on the otdfctl repo
- While here, also stops doing testing assertions with older versions of otdfctl (before we added verification) because their format is unreliable (unsurprising as we had no CI in place to test it)
- Lets merge request descriptions be prettier in the summary
- Stop dynamically loading the manifest. This was causing test failures due to this job getting 429'd
 
<img width="728" alt="image" src="https://github.com/user-attachments/assets/4f9acf91-25b6-424d-85c7-08ce80aec690" />
