### PR TITLE
chore(xtest): Support 'target mode' option

### DIFF
--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -17,6 +17,7 @@
 #  XT_WITH_ASSERTION_VERIFICATION_KEYS [string] - Path to assertion verification private key file
 #  XT_WITH_ATTRIBUTES [string] - Attributes to be used for encryption
 #  XT_WITH_MIME_TYPE [string] - MIME type for the encrypted file
+#  XT_WITH_TARGET_MODE [string] - Target spec mode for the encrypted file
 #
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
@@ -41,7 +42,7 @@ if [ "$1" == "supports" ]; then
     nano_ecdsa)
       if java -jar "$SCRIPT_DIR"/cmdline.jar help encryptnano | grep ecdsa-binding; then
         # Java version 0.7.7 fixwa a bug in the ECDSA parsing for nano
-        java -jar "$SCRIPT_DIR"/cmdline.jar --version | jq -re .version | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 7) || ($1 == 0 && $2 == 7 && $3 >= 7)) exit 0; else exit 1; }' 
+        java -jar "$SCRIPT_DIR"/cmdline.jar --version | jq -re .version | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 7) || ($1 == 0 && $2 == 7 && $3 >= 7)) exit 0; else exit 1; }'
         exit $?
       else
         echo "ecdsa-binding not supported"
@@ -71,6 +72,11 @@ if [ "$1" == "supports" ]; then
     hexless)
       set -o pipefail
       java -jar "$SCRIPT_DIR"/cmdline.jar --version | jq -re .tdfSpecVersion | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 > 2) || ($1 == 4 && $2 == 3 && $3 >= 0)) exit 0; else exit 1; }'
+      exit $?
+      ;;
+
+    hexaflexible)
+      java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep with-target-mode
       exit $?
       ;;
 
@@ -127,6 +133,10 @@ fi
 
 if [ "$XT_WITH_VERIFY_ASSERTIONS" == 'false' ]; then
   args+=(--with-assertion-verification-disabled)
+fi
+
+if [ -n "$XT_WITH_TARGET_MODE" ]; then
+  args+=(--with-target-mode "$XT_WITH_TARGET_MODE")
 fi
 
 echo java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" --file="$2" ">" "$3"

--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -17,6 +17,7 @@
 #  XT_WITH_ASSERTION_VERIFICATION_KEYS [string] - Path to assertion verification private key file
 #  XT_WITH_ATTRIBUTES [string] - Attributes to be used for encryption
 #  XT_WITH_MIME_TYPE [string] - MIME type for the encrypted file
+#  XT_WITH_TARGET_MODE [string] - Target spec mode for the encrypted file
 #
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
@@ -56,6 +57,10 @@ if [ "$1" == "supports" ]; then
     hexless)
       set -o pipefail
       npx $CTL --version | jq -re .tdfSpecVersion | awk -F. '{ if ($1 > 4 || ($1 == 4 && $2 > 2) || ($1 == 4 && $2 == 3 && $3 >= 0)) exit 0; else exit 1; }'
+      exit $?
+      ;;
+    hexaflexible)
+      npx $CTL help | grep tdfSpecVersion
       exit $?
       ;;
     nano_ecdsa)
@@ -153,6 +158,9 @@ if [ "$1" == "encrypt" ]; then
   fi
   if [ "$XT_WITH_ECWRAP" == 'true' ]; then
     args+=(--encapKeyType "ec:secp256r1")
+  fi
+  if [ -n "$XT_WITH_TARGET_MODE" ]; then
+    args+=(--tdfSpecVersion "$XT_WITH_TARGET_MODE")
   fi
 
   echo npx $CTL encrypt "$src_file" "${args[@]}"

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -76,6 +76,7 @@ def test_autoconfigure_two_kas_or_standard(
                 attribute_two_kas_grant_or.value_fqns[0],
                 attribute_two_kas_grant_or.value_fqns[1],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
     manifest = tdfs.manifest(ct_file)
@@ -122,6 +123,7 @@ def test_autoconfigure_double_kas_and(
                 attribute_two_kas_grant_and.value_fqns[0],
                 attribute_two_kas_grant_and.value_fqns[1],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
 
@@ -166,6 +168,7 @@ def test_autoconfigure_one_attribute_attr_grant(
             attr_values=[
                 one_attribute_attr_kas_grant.value_fqns[0],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
 
@@ -206,6 +209,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
                 attr_and_value_kas_grants_or.value_fqns[0],
                 attr_and_value_kas_grants_or.value_fqns[1],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
 
@@ -252,6 +256,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
                 attr_and_value_kas_grants_and.value_fqns[0],
                 attr_and_value_kas_grants_and.value_fqns[1],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
 
@@ -296,6 +301,7 @@ def test_autoconfigure_one_attribute_ns_grant(
             attr_values=[
                 one_attribute_ns_kas_grant.value_fqns[0],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
 
@@ -336,6 +342,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
                 ns_and_value_kas_grants_or.value_fqns[0],
                 ns_and_value_kas_grants_or.value_fqns[1],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
 
@@ -382,6 +389,7 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
                 ns_and_value_kas_grants_and.value_fqns[0],
                 ns_and_value_kas_grants_and.value_fqns[1],
             ],
+            target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
         cipherTexts[sample_name] = ct_file
 

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -124,6 +124,37 @@ def test_tdf_roundtrip(
             assert filecmp.cmp(pt_file, ert_file)
 
 
+def test_tdf_spec_target_422(
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
+    pt_file: str,
+    tmp_dir: str,
+    in_focus: set[tdfs.SDK],
+):
+    pfs = tdfs.PlatformFeatureSet()
+    if "hexaflexible" not in pfs.features:
+        pytest.skip(f"Hexaflexible is not supported in platform {pfs.version}")
+    if not in_focus & {encrypt_sdk, decrypt_sdk}:
+        pytest.skip("Not in focus")
+    if not encrypt_sdk.supports("hexaflexible"):
+        pytest.skip(
+            f"Encrypt SDK {encrypt_sdk} doesn't support targeting container format 4.2.2"
+        )
+
+    ct_file = do_encrypt_with(
+        pt_file,
+        encrypt_sdk,
+        "ztdf",
+        tmp_dir,
+        target_mode="4.2.2",
+    )
+    assert os.path.isfile(ct_file)
+    fname = os.path.basename(ct_file).split(".")[0]
+    rt_file = f"{tmp_dir}test-{fname}.untdf"
+    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    assert filecmp.cmp(pt_file, rt_file)
+
+
 #### MANIFEST VALIDITY TESTS
 
 

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -24,6 +24,7 @@ def do_encrypt_with(
     tmp_dir: str,
     az: str = "",
     scenario: str = "",
+    target_mode: tdfs.container_version | None = None,
 ) -> str:
     global counter
     counter = (counter or 0) + 1
@@ -43,6 +44,7 @@ def do_encrypt_with(
         mime_type="text/plain",
         container=container,
         assert_value=az,
+        target_mode=target_mode,
     )
     if tdfs.simple_container(container) == "ztdf":
         manifest = tdfs.manifest(ct_file)
@@ -104,6 +106,7 @@ def test_tdf_roundtrip(
         encrypt_sdk,
         container,
         tmp_dir,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
     )
     assert os.path.isfile(ct_file)
     fname = os.path.basename(ct_file).split(".")[0]
@@ -185,6 +188,7 @@ def test_tdf_assertions_unkeyed(
         tmp_dir,
         scenario="assertions",
         az=assertion_file_no_keys,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
     )
     assert os.path.isfile(ct_file)
     fname = os.path.basename(ct_file).split(".")[0]
@@ -216,6 +220,7 @@ def test_tdf_assertions_with_keys(
         tmp_dir,
         scenario="assertions-keys-roundtrip",
         az=assertion_file_rs_and_hs_keys,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
     )
     assert os.path.isfile(ct_file)
     fname = os.path.basename(ct_file).split(".")[0]
@@ -353,7 +358,13 @@ def test_tdf_with_unbound_policy(
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
-    ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
+    ct_file = do_encrypt_with(
+        pt_file,
+        encrypt_sdk,
+        "ztdf",
+        tmp_dir,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
+    )
     assert os.path.isfile(ct_file)
     b_file = tdfs.update_manifest("unbound_policy", ct_file, change_policy)
     fname = os.path.basename(b_file).split(".")[0]
@@ -402,7 +413,13 @@ def test_tdf_with_altered_root_sig(
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
-    ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
+    ct_file = do_encrypt_with(
+        pt_file,
+        encrypt_sdk,
+        "ztdf",
+        tmp_dir,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
+    )
     assert os.path.isfile(ct_file)
     b_file = tdfs.update_manifest("broken_root_sig", ct_file, change_root_signature)
     fname = os.path.basename(b_file).split(".")[0]
@@ -424,7 +441,13 @@ def test_tdf_with_altered_seg_sig_wrong(
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
-    ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
+    ct_file = do_encrypt_with(
+        pt_file,
+        encrypt_sdk,
+        "ztdf",
+        tmp_dir,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
+    )
     assert os.path.isfile(ct_file)
     b_file = tdfs.update_manifest("broken_seg_sig", ct_file, change_segment_hash)
     fname = os.path.basename(b_file).split(".")[0]
@@ -449,7 +472,13 @@ def test_tdf_with_altered_enc_seg_size(
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
-    ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
+    ct_file = do_encrypt_with(
+        pt_file,
+        encrypt_sdk,
+        "ztdf",
+        tmp_dir,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
+    )
     assert os.path.isfile(ct_file)
     b_file = tdfs.update_manifest(
         "broken_enc_seg_sig", ct_file, change_encrypted_segment_size
@@ -488,6 +517,7 @@ def test_tdf_with_altered_assertion_statement(
         tmp_dir,
         scenario="assertions",
         az=assertion_file_no_keys,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
     )
     assert os.path.isfile(ct_file)
     b_file = tdfs.update_manifest(
@@ -525,6 +555,7 @@ def test_tdf_with_altered_assertion_with_keys(
         tmp_dir,
         scenario="assertions-keys-roundtrip",
         az=assertion_file_rs_and_hs_keys,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
     )
     assert os.path.isfile(ct_file)
     b_file = tdfs.update_manifest(
@@ -558,7 +589,13 @@ def test_tdf_altered_payload_end(
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
-    ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
+    ct_file = do_encrypt_with(
+        pt_file,
+        encrypt_sdk,
+        "ztdf",
+        tmp_dir,
+        target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
+    )
     assert os.path.isfile(ct_file)
     b_file = tdfs.update_payload("altered_payload_end", ct_file, change_payload_end)
     fname = os.path.basename(b_file).split(".")[0]


### PR DESCRIPTION
- If the sdk tool supports 'target mode', downtarget older SDKs during skew testing
- Adds a 4.2.2 test that runs iff the encrypt SDK under test supports downtargeting