### PR TITLE
chore(xtest): Prefer Paths to str for files & dirs

### DIFF
--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -7,11 +7,10 @@ import base64
 import secrets
 import assertions
 import json
-
-from pydantic_core import to_jsonable_python
-
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
+from pathlib import Path
+from pydantic_core import to_jsonable_python
 
 import abac
 import tdfs
@@ -151,20 +150,19 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
 
 
 @pytest.fixture(scope="module")
-def pt_file(tmp_dir: str, size: str):
-    pt_file = f"{tmp_dir}test-plain-{size}.txt"
+def pt_file(tmp_dir: Path, size: str) -> Path:
+    pt_file = tmp_dir / f"test-plain-{size}.txt"
     length = (5 * 2**30) if size == "large" else 128
-    with open(pt_file, "w") as f:
+    with pt_file.open("w") as f:
         for i in range(0, length, 16):
             f.write("{:15,d}\n".format(i))
     return pt_file
 
 
 @pytest.fixture(scope="module")
-def tmp_dir():
-    dname = "tmp/"
-    if not os.path.exists(dname):
-        os.makedirs(dname)
+def tmp_dir() -> Path:
+    dname = Path("tmp/")
+    dname.mkdir(parents=True, exist_ok=True)
     return dname
 
 
@@ -732,17 +730,17 @@ def rs256_keys() -> tuple[str, str]:
 
 
 def write_assertion_to_file(
-    tmp_dir: str, file_name: str, assertion_list: list[assertions.Assertion] = []
-):
-    as_file = f"{tmp_dir}test-assertion-{file_name}.json"
+    tmp_dir: Path, file_name: str, assertion_list: list[assertions.Assertion] = []
+) -> Path:
+    as_file = tmp_dir / f"test-assertion-{file_name}.json"
     assertion_json = json.dumps(to_jsonable_python(assertion_list, exclude_none=True))
-    with open(as_file, "w") as f:
+    with as_file.open("w") as f:
         f.write(assertion_json)
     return as_file
 
 
 @pytest.fixture(scope="module")
-def assertion_file_no_keys(tmp_dir: str):
+def assertion_file_no_keys(tmp_dir: Path) -> Path:
     assertion_list = [
         assertions.Assertion(
             appliesToState="encrypted",
@@ -763,8 +761,8 @@ def assertion_file_no_keys(tmp_dir: str):
 
 @pytest.fixture(scope="module")
 def assertion_file_rs_and_hs_keys(
-    tmp_dir: str, hs256_key: str, rs256_keys: tuple[str, str]
-):
+    tmp_dir: Path, hs256_key: str, rs256_keys: tuple[str, str]
+) -> Path:
     rs256_private, _ = rs256_keys
     assertion_list = [
         assertions.Assertion(
@@ -804,23 +802,23 @@ def assertion_file_rs_and_hs_keys(
 
 
 def write_assertion_verification_keys_to_file(
-    tmp_dir: str,
+    tmp_dir: Path,
     file_name: str,
     assertion_verification_keys: assertions.AssertionVerificationKeys,
-):
-    as_file = f"{tmp_dir}test-assertion-verification-{file_name}.json"
+) -> Path:
+    as_file = tmp_dir / f"test-assertion-verification-{file_name}.json"
     assertion_verification_json = json.dumps(
         to_jsonable_python(assertion_verification_keys, exclude_none=True)
     )
-    with open(as_file, "w") as f:
+    with as_file.open("w") as f:
         f.write(assertion_verification_json)
     return as_file
 
 
 @pytest.fixture(scope="module")
 def assertion_verification_file_rs_and_hs_keys(
-    tmp_dir: str, hs256_key: str, rs256_keys: tuple[str, str]
-):
+    tmp_dir: Path, hs256_key: str, rs256_keys: tuple[str, str]
+) -> Path:
     _, rs256_public = rs256_keys
     assertion_verification = assertions.AssertionVerificationKeys(
         keys={

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -7,6 +7,7 @@ import pytest
 import re
 import subprocess
 import zipfile
+import shutil
 from collections.abc import Callable
 from pydantic import BaseModel
 from typing import Any, Literal
@@ -226,6 +227,8 @@ def update_manifest(
             for filename in filenames:
                 file_path = folder / filename
                 zipped.write(file_path, file_path.relative_to(unzipped_dir))
+    # Cleanup the unzipped directory; its contents are now stored as outfile
+    shutil.rmtree(unzipped_dir, ignore_errors=True)
     return outfile
 
 
@@ -249,6 +252,8 @@ def update_payload(
             for filename in filenames:
                 file_path = Path(folder_name) / filename
                 zipped.write(file_path, file_path.relative_to(unzipped_dir))
+    # Cleanup the unzipped directory; its contents are now stored as outfile
+    shutil.rmtree(unzipped_dir, ignore_errors=True)
     return outfile
 
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -5,9 +5,9 @@ import logging
 import os
 import pytest
 import re
+import shutil
 import subprocess
 import zipfile
-import shutil
 from collections.abc import Callable
 from pydantic import BaseModel
 from typing import Any, Literal

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -1,19 +1,20 @@
 import filecmp
 import pytest
+from pathlib import Path
 
 import tdfs
 from abac import Attribute
 
 
-cipherTexts: dict[str, str] = {}
+cipherTexts: dict[str, Path] = {}
 
 
 def test_autoconfigure_one_attribute_standard(
     attribute_single_kas_grant: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_value1: str,
     in_focus: set[tdfs.SDK],
 ):
@@ -28,7 +29,7 @@ def test_autoconfigure_one_attribute_standard(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         cipherTexts[sample_name] = ct_file
         encrypt_sdk.encrypt(
             pt_file,
@@ -38,7 +39,6 @@ def test_autoconfigure_one_attribute_standard(
             attr_values=attribute_single_kas_grant.value_fqns,
             target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
         )
-        cipherTexts[sample_name] = ct_file
     manifest = tdfs.manifest(ct_file)
     assert len(manifest.encryptionInformation.keyAccess) == 1
     assert manifest.encryptionInformation.keyAccess[0].url == kas_url_value1
@@ -47,7 +47,7 @@ def test_autoconfigure_one_attribute_standard(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-one-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-one-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -56,8 +56,8 @@ def test_autoconfigure_two_kas_or_standard(
     attribute_two_kas_grant_or: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_value1: str,
     kas_url_value2: str,
     in_focus: set[tdfs.SDK],
@@ -71,7 +71,7 @@ def test_autoconfigure_two_kas_or_standard(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -97,7 +97,7 @@ def test_autoconfigure_two_kas_or_standard(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -106,8 +106,8 @@ def test_autoconfigure_double_kas_and(
     attribute_two_kas_grant_and: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_value1: str,
     kas_url_value2: str,
     in_focus: set[tdfs.SDK],
@@ -121,7 +121,7 @@ def test_autoconfigure_double_kas_and(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -148,7 +148,7 @@ def test_autoconfigure_double_kas_and(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -157,8 +157,8 @@ def test_autoconfigure_one_attribute_attr_grant(
     one_attribute_attr_kas_grant: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_attr: str,
     in_focus: set[tdfs.SDK],
 ):
@@ -171,7 +171,7 @@ def test_autoconfigure_one_attribute_attr_grant(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -191,7 +191,7 @@ def test_autoconfigure_one_attribute_attr_grant(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-one-attr-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-one-attr-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -200,8 +200,8 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
     attr_and_value_kas_grants_or: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_attr: str,
     kas_url_value1: str,
     in_focus: set[tdfs.SDK],
@@ -215,7 +215,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -242,7 +242,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-attr-val-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-attr-val-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -251,8 +251,8 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
     attr_and_value_kas_grants_and: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_attr: str,
     kas_url_value1: str,
     in_focus: set[tdfs.SDK],
@@ -266,7 +266,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -293,7 +293,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-attr-val-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-attr-val-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -302,8 +302,8 @@ def test_autoconfigure_one_attribute_ns_grant(
     one_attribute_ns_kas_grant: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_ns: str,
     in_focus: set[tdfs.SDK],
 ):
@@ -316,7 +316,7 @@ def test_autoconfigure_one_attribute_ns_grant(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -336,7 +336,7 @@ def test_autoconfigure_one_attribute_ns_grant(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-one-ns-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-one-ns-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -345,8 +345,8 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
     ns_and_value_kas_grants_or: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_ns: str,
     kas_url_value1: str,
     in_focus: set[tdfs.SDK],
@@ -360,7 +360,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -387,7 +387,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-ns-val-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-ns-val-or-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)
 
@@ -396,8 +396,8 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
     ns_and_value_kas_grants_and: Attribute,
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
-    pt_file: str,
+    tmp_dir: Path,
+    pt_file: Path,
     kas_url_ns: str,
     kas_url_value1: str,
     in_focus: set[tdfs.SDK],
@@ -411,7 +411,7 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
     if sample_name in cipherTexts:
         ct_file = cipherTexts[sample_name]
     else:
-        ct_file = f"{tmp_dir}/{sample_name}.tdf"
+        ct_file = tmp_dir / f"{sample_name}.tdf"
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
@@ -438,6 +438,6 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
         kao.type == "ec-wrapped" for kao in manifest.encryptionInformation.keyAccess
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
-    rt_file = f"{tmp_dir}test-abac-ns-val-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
+    rt_file = tmp_dir / f"test-abac-ns-val-and-{encrypt_sdk}-{decrypt_sdk}.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
     assert filecmp.cmp(pt_file, rt_file)

--- a/xtest/test_legacy.py
+++ b/xtest/test_legacy.py
@@ -1,20 +1,21 @@
 import pytest
 import os
+from pathlib import Path
 
 import tdfs
 
 
-def get_golden_file(golden_file_name: str) -> str:
-    xtest_dir = os.path.dirname(os.path.realpath(__file__))
-    filename = os.path.join(xtest_dir, "golden", f"{golden_file_name}")
-    if os.path.isfile(filename):
+def get_golden_file(golden_file_name: str) -> Path:
+    xtest_dir = Path(__file__).parent
+    filename = xtest_dir / "golden" / golden_file_name
+    if filename.is_file():
         return filename
     raise FileNotFoundError(f"Golden file '{filename}' not found.")
 
 
 def test_decrypt_small(
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
+    tmp_dir: Path,
     in_focus: set[tdfs.SDK],
 ):
     if not in_focus & {decrypt_sdk}:
@@ -22,19 +23,19 @@ def test_decrypt_small(
     if not decrypt_sdk.supports("hexless"):
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("small-java-4.3.0-e0f8caf.tdf")
-    rt_file = os.path.join(tmp_dir, "small-java.untdf")
+    rt_file = tmp_dir / "small-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
-    with open(rt_file, "rb") as f:
+    with rt_file.open("rb") as f:
         while b := f.read(1024):
             assert b == expected_bytes
 
 
 def test_decrypt_big(
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
+    tmp_dir: Path,
     in_focus: set[tdfs.SDK],
 ):
     if not in_focus & {decrypt_sdk}:
@@ -42,19 +43,19 @@ def test_decrypt_big(
     if not decrypt_sdk.supports("hexless"):
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("big-java-4.3.0-e0f8caf.tdf")
-    rt_file = os.path.join(tmp_dir, "big-java.untdf")
+    rt_file = tmp_dir / "big-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 10 * 2**20
     expected_bytes = bytes([0] * 1024)
-    with open(rt_file, "rb") as f:
+    with rt_file.open("rb") as f:
         while b := f.read(1024):
             assert b == expected_bytes
 
 
 def test_decrypt_no_splitid(
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
+    tmp_dir: Path,
     in_focus: set[tdfs.SDK],
 ):
     if not in_focus & {decrypt_sdk}:
@@ -62,19 +63,19 @@ def test_decrypt_no_splitid(
     if not decrypt_sdk.supports("hexless"):
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("no-splitids-java.tdf")
-    rt_file = os.path.join(tmp_dir, "no-splitids-java.untdf")
+    rt_file = tmp_dir / "no-splitids-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
-    with open(rt_file, "rb") as f:
+    with rt_file.open("rb") as f:
         while b := f.read(1024):
             assert b == expected_bytes
 
 
 def test_decrypt_object_statement_value_json(
     decrypt_sdk: tdfs.SDK,
-    tmp_dir: str,
+    tmp_dir: Path,
     in_focus: set[tdfs.SDK],
 ):
     if not in_focus & {decrypt_sdk}:
@@ -82,7 +83,7 @@ def test_decrypt_object_statement_value_json(
     if not decrypt_sdk.supports("assertion_verification"):
         pytest.skip("assertion_verification is not supported")
     ct_file = get_golden_file("with-json-object-assertions-java.tdf")
-    rt_file = os.path.join(tmp_dir, "with-json-object-assertions-java.untdf")
+    rt_file = tmp_dir / "with-json-object-assertions-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf", verify_assertions=False)
-    with open(rt_file, "rb") as f:
+    with rt_file.open("rb") as f:
         assert f.read().decode("utf-8") == "text"

--- a/xtest/test_nano.py
+++ b/xtest/test_nano.py
@@ -1,7 +1,6 @@
 import base64
 
 import nano
-
 from nano import dec_hex, enc_hex
 
 


### PR DESCRIPTION
Some advantages to the `pathlib` object:

- Lets us use `/` to join paths instead of more verbose `os.path.join`
- Less likely to accidentally have invalid chars in path
- Better suggestions when combined with strict types (via pyright or similar)

While here, also stops unzipping the whole package when just validating manifest schemas.
This also cleans up some of the file names in the tmp folder, making local debugging easier as the file names more clearly match the sdk version and scenario