### PR TITLE
chore(xtest): Let main java-sdk target plat main

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -296,6 +296,26 @@ jobs:
           path: otdftests/xtest/sdk
           sdk: java
           version-info: "${{ needs.resolve-versions.outputs.java }}"
+      
+      - name: Replace java/main.env file if needed
+        if: |
+          contains('["go", "java"]', env.FOCUS_SDK) && contains(fromJSON(needs.resolve-versions.outputs.heads), matrix.platform-tag)
+        run: |-
+            echo "Replacing .env files for java-sdk..."
+            echo "Platform tag: $platform_tag"
+            echo "Java version info: $java-version-info"
+            for row in $(echo "$java-version-info" | jq -c '.[]'); do
+              TAG=$(echo "$row" | jq -r '.tag')
+              HEAD=$(echo "$row" | jq -r '.head')
+              if [[ "$HEAD" == "true" ]]; then
+                echo "Creating .env file for tag: $TAG"
+                echo "PLATFORM_BRANCH=$PLATFORM_TAG" > "otdftests/xtest/sdk/java/${TAG}.env"
+              fi
+            done
+        env:
+          java-version-info: ${{ needs.resolve-versions.outputs.java }}
+          platform-ref: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-to-sha)[matrix.platform-tag] }}
+          platform-tag: ${{ matrix.platform-tag }}
 
       ####### SETUP JAVA CLI ##############
       - name: Prepare java cli

--- a/xtest/sdk/.gitignore
+++ b/xtest/sdk/.gitignore
@@ -4,6 +4,9 @@
 */src
 */dist
 
+# Generated helper build .env files
+*/*.env
+
 # generated binaries
 otdfctl-*
 otdfctl

--- a/xtest/sdk/java/Makefile
+++ b/xtest/sdk/java/Makefile
@@ -2,6 +2,9 @@
 
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
+# Let PLATFORM_VERSIONS default to `main` if not provided
+PLATFORM_BRANCH ?= main
+
 # Dynamically set VERSIONS to the names of all directories in the src folder if not provided
 VERSIONS ?= $(shell find $(MAKEFILE_DIR)/src -mindepth 1 -maxdepth 1 -type d -not -name "*.git" -exec basename {} \;)
 
@@ -19,12 +22,23 @@ all: build
 build:
 	@echo "Building java sdk and commandline for versions: $(VERSIONS)"
 	@for version in $(VERSIONS); do \
+		if [ -f "$(MAKEFILE_DIR)/$$version.env" ]; then \
+			echo "Loading environment variables from $(MAKEFILE_DIR)/$$version.env"; \
+			set -a; \
+			. "$(MAKEFILE_DIR)/$$version.env"; \
+			set +a; \
+		fi; \
 		echo "Building binary for $$version"; \
 		cd $(MAKEFILE_DIR)/src/$$version && \
-		mvn --batch-mode clean install -DskipTests -Dmaven.javadoc.skip=true || { \
+		if [ -n "$(PLATFORM_BRANCH)" ]; then \
+			mvn --batch-mode clean install "-Dplatform.branch=$(PLATFORM_BRANCH)" -DskipTests -Dmaven.javadoc.skip=true; \
+		else \
+			mvn --batch-mode clean install -DskipTests -Dmaven.javadoc.skip=true; \
+		fi; \
+		if [ $$? -ne 0 ]; then \
 			echo "Error: Maven build failed for $$version"; \
 			exit 1; \
-		}; \
+		fi; \
 		echo "Copying cmdline.jar and cli.sh to dist/$$version"; \
 		mkdir -p $(MAKEFILE_DIR)/dist/$$version; \
 		cp $(MAKEFILE_DIR)/src/$$version/cmdline/target/cmdline.jar \

--- a/xtest/sdk/scripts/post-checkout-java.sh
+++ b/xtest/sdk/scripts/post-checkout-java.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Post checkout cleanups for java
+# Currently, this inserts the missing `platform.branch` property into the pom.xml files
+# on older branches that do not have it defined.
+
+# Base directory for the script
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BASE_DIR="$SCRIPT_DIR/../java/src"
+
+# Loop through all subdirectories in the base directory
+find "$BASE_DIR" -mindepth 1 -maxdepth 1 -type d -not -name "*.git" | while read -r SRC_DIR; do
+  POM_FILE="$SRC_DIR/sdk/pom.xml"
+
+  # Skip if path or file does not exist
+  if [[ ! -f $POM_FILE ]]; then
+    echo "No pom.xml file found in $SRC_DIR, skipping."
+    continue
+  fi
+
+  # Check if the platform.branch property is already defined
+  if grep -q "<platform.branch>" "$POM_FILE"; then
+    echo "platform.branch already defined in $POM_FILE, skipping."
+    continue
+  fi
+
+  echo "Updating $POM_FILE..."
+
+  # Add the platform.branch property to the <properties> section
+  sed -i '' '/<properties>/a \
+        <platform.branch>main</platform.branch>' "$POM_FILE"
+
+  # Replace hardcoded branch=main with branch=${platform.branch} in the maven-antrun-plugin configuration
+  # shellcheck disable=SC2016 # Literal $; it is for a variable expansion in the maven file
+  sed -i '' 's/branch=main/branch=${platform.branch}/g' "$POM_FILE"
+done
+
+echo "Update complete."

--- a/xtest/sdk/scripts/resolve-version.py
+++ b/xtest/sdk/scripts/resolve-version.py
@@ -32,6 +32,7 @@
 #   {
 #     "sdk": "go",
 #     "alias": "0.15.0",
+#     "env": "ADDITONAL_OPTION=per build metadata",
 #     "release": "v0.15.0",
 #     "sha": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
 #     "tag": "v0.15.0"
@@ -70,6 +71,7 @@ from urllib.parse import quote
 class ResolveSuccess(TypedDict):
     sdk: str  # The SDK name
     alias: str  # The tag that was requested
+    env: NotRequired[str]  # Additional options for the SDK
     head: NotRequired[bool]  # True if the tag is a head of a live branch
     pr: NotRequired[str]  # The pull request number associated with the tag
     release: NotRequired[str]  # The release name for the tag
@@ -103,6 +105,32 @@ lts_versions = {
 merge_queue_regex = r"^refs/heads/gh-readonly-queue/(?P<branch>[^/]+)/pr-(?P<pr_number>\d+)-(?P<sha>[a-f0-9]{40})$"
 
 sha_regex = r"^[a-f0-9]{7,40}$"
+
+
+def lookup_additional_options(sdk: str, version: str) -> str | None:
+    if sdk != "java":
+        return None
+    if version.startswith("v"):
+        version = version[1:]
+    match version:
+        case "0.7.8" | "0.7.7":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.29"
+        case "0.7.6":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.25"
+        case "0.7.5" | "0.7.4":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.18"
+        case "0.7.3" | "0.7.2":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.17"
+        case "0.6.1" | "0.6.0":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.14"
+        case "0.5.0":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.13"
+        case "0.4.0" | "0.3.0" | "0.2.0":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.10"
+        case "0.1.0":
+            return "PLATFORM_BRANCH=protocol/go/v0.2.3"
+        case _:
+            return None
 
 
 def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
@@ -306,6 +334,10 @@ def main():
     shas: set[str] = set()
     for version in versions:
         v = resolve(sdk, version, infix)
+        if "err" not in v:
+            env = lookup_additional_options(sdk, version)
+            if env:
+                v["env"] = env
         if "sha" in v:
             if v["sha"] in shas:
                 continue

--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -110,3 +110,21 @@ runs:
         path: ${{ inputs.path }}/${{ inputs.sdk }}/src/${{ fromJson(steps.resolve.outputs.version-d).tag }}
         ref: ${{ fromJson(steps.resolve.outputs.version-d).sha }}
         repository: ${{ env.sdk_repo }}
+
+    - name: post checkout cleanups; currently only java does this
+      if: inputs.sdk == 'java'
+      run: |
+        otdf-sdk/xtest/sdk/scripts/post-checkout-java.sh
+      shell: bash
+
+    - name: save env from version-info
+      shell: bash
+      run: |
+        # Iterate over each version and save the env variable to a file
+        for version in $(echo "${{ inputs.version-info }}" | jq -c '.[]'); do
+          tag=$(echo "$version" | jq -r '.tag')
+          env=$(echo "$version" | jq -r '.env // empty')
+          if [[ -n "$env" ]]; then
+            echo "$env" > "${{ inputs.path }}/${{ inputs.sdk }}/src/${tag}.env"
+          fi
+        done


### PR DESCRIPTION
This uses the platform.branch build property in the java-sdk build system to build appropriate protocol buffers as needed.

1. For skew tests with older builds, where the property wasn't defined, retro-actively add it and pin to an appropriate tag. (Right now, this is the tag that was last added when the java tag was released, but I suspect we will need something more nuanced)
2. For tests from java-sdk pull requests, use the main version of plat when testing against platform head; for tests with released platforms, use the baked version
3. For tests from platform pull requests, let the head version of the java sdk use the platform head; for tests with released java-sdk, use the baked in version

This invoves:

- extending resolve-version.py with a lookup table matchching old releases of java-sdk to the appropriate release of protocol/go
- adding an optional 'post-checkout' pass that performs modifications to the source code (in this case, adding the missing maven property)
- updating the build phase to enable taking in [version].env lists of variables to configure custom make options per-checked out source code