### PR TITLE
feat(xtest): Test for malicious kao

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -68,7 +68,7 @@ jobs:
       java: ${{ steps.version-info.outputs.java-version-info }}
       js: ${{ steps.version-info.outputs.js-version-info }}
     env:
-      PLATFORM_REF: "${{ inputs.platform-ref || 'dspx-966-kas-allowlist' }}"
+      PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
       JS_REF: "${{ inputs.js-ref || 'main' }}"
       OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'dspx-966-kas-allowlist-options' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -70,7 +70,7 @@ jobs:
     env:
       PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
       JS_REF: "${{ inputs.js-ref || 'main' }}"
-      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'dspx-966-kas-allowlist-options' }}"
+      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
       FOCUS_SDK: "${{ inputs.focus-sdk || 'all' }}"
     steps:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -68,9 +68,9 @@ jobs:
       java: ${{ steps.version-info.outputs.java-version-info }}
       js: ${{ steps.version-info.outputs.js-version-info }}
     env:
-      PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
+      PLATFORM_REF: "${{ inputs.platform-ref || 'dspx-966-kas-allowlist' }}"
       JS_REF: "${{ inputs.js-ref || 'main' }}"
-      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
+      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'dspx-966-kas-allowlist-options' }}"
       JAVA_REF: "${{ inputs.java-ref || 'main' }}"
       FOCUS_SDK: "${{ inputs.focus-sdk || 'all' }}"
     steps:

--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -34,6 +34,10 @@ if [ "$1" == "supports" ]; then
       "${cmd[@]}" help decrypt | grep with-assertion-verification-keys
       exit $?
       ;;
+    kasallowlist)
+      "${cmd[@]}" help decrypt | grep kas-allowlist
+      exit $?
+      ;;
     ecwrap)
       if "${cmd[@]}" help encrypt | grep wrapping-key; then
         # while the otdfctl app may support ecwrap, but sdk versions 0.3.28 and earlier uses the old salt

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -58,7 +58,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     kasallowlist)
-      java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep kas-allowlist
+      java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep kas-allowlist
       exit $?
       ;;
     ecwrap)

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -93,9 +93,16 @@ fi
 args=(
   "--client-id=$CLIENTID"
   "--client-secret=$CLIENTSECRET"
-  "--platform-endpoint=$PLATFORMENDPOINT"
   "--plaintext"
 )
+
+# when we added support for KAS allowlist, we changed the platform endpoint format to require scheme
+if java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep kas-allowlist; then
+  args+=("--platform-endpoint=$PLATFORMURL")
+else
+  args+=("--platform-endpoint=$PLATFORMENDPOINT")
+fi
+
 COMMAND="$1"
 if [[ $4 == nano* ]]; then
   COMMAND="$1"nano

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -57,7 +57,10 @@ if [ "$1" == "supports" ]; then
       java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep with-assertion-verification-keys
       exit $?
       ;;
-
+    kasallowlist)
+      java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep kas-allowlist
+      exit $?
+      ;;
     ecwrap)
       if java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep encap-key; then
         # versions 0.7.6 and earlier used an older value for EC HKDF salt; check for 0.7.7 or later

--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -44,6 +44,10 @@ if [ "$1" == "supports" ]; then
       npx $CTL help | grep autoconfigure
       exit $?
       ;;
+    kasallowlist)
+      npx $CTL help | grep kas-allowlist
+      exit $?
+      ;;
     ecwrap)
       if npx $CTL help | grep encapKeyType; then
         # Claims to support ecwrap, but maybe with old salt? Look up version
@@ -92,7 +96,7 @@ dst_file=$(realpath "$(dirname "$3")")/$(basename "$3")
 args=(
   --output "$dst_file"
   --kasEndpoint "$KASURL"
-  --ignoreAllowList
+  --ignoreAllowList # should be removed when fetching from registry is implemented
   --oidcEndpoint "$KCFULLURL"
   --auth opentdf:secret
 )

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -475,9 +475,9 @@ def change_payload_end(payload_bytes: bytes) -> bytes:
 
 def malicious_kao(manifest: tdfs.Manifest) -> tdfs.Manifest:
     assert manifest.encryptionInformation.keyAccess
-    manifest.encryptionInformation.keyAccess[
-        0
-    ].url = "http://localhost:8585/malicious/kas"  # nothing running at 8585
+    manifest.encryptionInformation.keyAccess[0].url = (
+        "http://localhost:8585/malicious/kas"  # nothing running at 8585
+    )
     return manifest
 
 

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -474,14 +474,11 @@ def change_payload_end(payload_bytes: bytes) -> bytes:
     return change_last_three(payload_bytes)
 
 
-def add_malicious_kao(manifest: tdfs.Manifest) -> tdfs.Manifest:
+def malicious_kao(manifest: tdfs.Manifest) -> tdfs.Manifest:
     assert manifest.encryptionInformation.keyAccess
-    kaos = manifest.encryptionInformation.keyAccess
-    malicious_kao = copy.deepcopy(kaos[0])
-    malicious_kao.url = "http://localhost:8585/malicious/kas"  # nothing running at 8585
-    malicious_kao.sid = malicious_kao.sid + "1"  # append 1 to sid
-    kaos.insert(0, malicious_kao)
-    manifest.encryptionInformation.keyAccess = kaos
+    manifest.encryptionInformation.keyAccess[
+        0
+    ].url = "http://localhost:8585/malicious/kas"  # nothing running at 8585
     return manifest
 
 
@@ -780,7 +777,7 @@ def test_tdf_altered_payload_end(
 ## KAO TAMPER TESTS
 
 
-def test_tdf_with_added_malicious_kao(
+def test_tdf_with_malicious_kao(
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
     pt_file: Path,
@@ -794,7 +791,7 @@ def test_tdf_with_added_malicious_kao(
     if not decrypt_sdk.supports("kasallowlist"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support an allowlist for kases")
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, container, tmp_dir)
-    b_file = tdfs.update_manifest("malicious_kao", ct_file, add_malicious_kao)
+    b_file = tdfs.update_manifest("malicious_kao", ct_file, malicious_kao)
     fname = b_file.stem
     rt_file = tmp_dir / f"{fname}.untdf"
     try:

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -5,7 +5,6 @@ import pytest
 import string
 import random
 from pathlib import Path
-import copy
 
 import nano
 import tdfs

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -478,8 +478,8 @@ def add_malicious_kao(manifest: tdfs.Manifest) -> tdfs.Manifest:
     assert manifest.encryptionInformation.keyAccess
     kaos = manifest.encryptionInformation.keyAccess
     malicious_kao = copy.deepcopy(kaos[0])
-    malicious_kao.url = "http://localhost:8585/malicious/kas" #nothing running at 8585
-    malicious_kao.sid = malicious_kao.sid + "1" #append 1 to sid
+    malicious_kao.url = "http://localhost:8585/malicious/kas"  # nothing running at 8585
+    malicious_kao.sid = malicious_kao.sid + "1"  # append 1 to sid
     kaos.insert(0, malicious_kao)
     manifest.encryptionInformation.keyAccess = kaos
     return manifest
@@ -779,6 +779,7 @@ def test_tdf_altered_payload_end(
 
 ## KAO TAMPER TESTS
 
+
 def test_tdf_with_added_malicious_kao(
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
@@ -791,13 +792,9 @@ def test_tdf_with_added_malicious_kao(
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if not decrypt_sdk.supports("kasallowlist"):
-            pytest.skip(
-                f"{encrypt_sdk} sdk doesn't yet support an allowlist for kases"
-            )
+        pytest.skip(f"{encrypt_sdk} sdk doesn't yet support an allowlist for kases")
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, container, tmp_dir)
-    b_file = tdfs.update_manifest(
-        "malicious_kao", ct_file, add_malicious_kao
-    )
+    b_file = tdfs.update_manifest("malicious_kao", ct_file, add_malicious_kao)
     fname = b_file.stem
     rt_file = tmp_dir / f"{fname}.untdf"
     try:
@@ -805,5 +802,6 @@ def test_tdf_with_added_malicious_kao(
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert any(
-            err in exc.output for err in [b"allowlist", b"kasallowlist", b"KasAllowlist", b"not allowed"]
+            err in exc.output
+            for err in [b"allowlist", b"kasallowlist", b"KasAllowlist", b"not allowed"]
         ), f"Unexpected error output: [{exc.output}]"

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -5,6 +5,7 @@ import pytest
 import string
 import random
 from pathlib import Path
+import copy
 
 import nano
 import tdfs
@@ -473,6 +474,17 @@ def change_payload_end(payload_bytes: bytes) -> bytes:
     return change_last_three(payload_bytes)
 
 
+def add_malicious_kao(manifest: tdfs.Manifest) -> tdfs.Manifest:
+    assert manifest.encryptionInformation.keyAccess
+    kaos = manifest.encryptionInformation.keyAccess
+    malicious_kao = copy.deepcopy(kaos[0])
+    malicious_kao.url = "http://localhost:8585/malicious/kas" #nothing running at 8585
+    malicious_kao.sid = malicious_kao.sid + "1" #append 1 to sid
+    kaos.insert(0, malicious_kao)
+    manifest.encryptionInformation.keyAccess = kaos
+    return manifest
+
+
 ### TAMPER TESTS
 
 
@@ -763,3 +775,35 @@ def test_tdf_altered_payload_end(
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_tamper_error(exc, "segment", decrypt_sdk)
+
+
+## KAO TAMPER TESTS
+
+def test_tdf_with_added_malicious_kao(
+    encrypt_sdk: tdfs.SDK,
+    decrypt_sdk: tdfs.SDK,
+    pt_file: Path,
+    tmp_dir: Path,
+    container: tdfs.container_type,
+    in_focus: set[tdfs.SDK],
+) -> None:
+    if not in_focus & {encrypt_sdk, decrypt_sdk}:
+        pytest.skip("Not in focus")
+    tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    if not decrypt_sdk.supports("kasallowlist"):
+            pytest.skip(
+                f"{encrypt_sdk} sdk doesn't yet support an allowlist for kases"
+            )
+    ct_file = do_encrypt_with(pt_file, encrypt_sdk, container, tmp_dir)
+    b_file = tdfs.update_manifest(
+        "malicious_kao", ct_file, add_malicious_kao
+    )
+    fname = b_file.stem
+    rt_file = tmp_dir / f"{fname}.untdf"
+    try:
+        decrypt_sdk.decrypt(b_file, rt_file, container, expect_error=True)
+        assert False, "decrypt succeeded unexpectedly"
+    except subprocess.CalledProcessError as exc:
+        assert any(
+            err in exc.output for err in [b"allowlist", b"kasallowlist", b"KasAllowlist", b"not allowed"]
+        ), f"Unexpected error output: [{exc.output}]"

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -781,7 +781,6 @@ def test_tdf_with_malicious_kao(
     decrypt_sdk: tdfs.SDK,
     pt_file: Path,
     tmp_dir: Path,
-    container: tdfs.container_type,
     in_focus: set[tdfs.SDK],
 ) -> None:
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
@@ -789,12 +788,12 @@ def test_tdf_with_malicious_kao(
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if not decrypt_sdk.supports("kasallowlist"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support an allowlist for kases")
-    ct_file = do_encrypt_with(pt_file, encrypt_sdk, container, tmp_dir)
+    ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     b_file = tdfs.update_manifest("malicious_kao", ct_file, malicious_kao)
     fname = b_file.stem
     rt_file = tmp_dir / f"{fname}.untdf"
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, container, expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert any(


### PR DESCRIPTION
add a test for the case where someone edits a kao in the manifest with a malicious url. with the kas-allowlist feature, the sdk should throw an error for this url as it is not in the kas registry