### PR TITLE
feat(xtest): Enable kao tamper tests for js sdk

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -130,7 +130,7 @@ jobs:
             const refs = {
               platform: process.env.PLATFORM_REF || defaultTags,
               go: process.env.OTDFCTL_REF || defaultTags,
-              js: process.env.WEB_REF || defaultTags,
+              js: process.env.JS_REF || defaultTags,
               java: process.env.JAVA_REF || defaultTags
             };
 
@@ -252,6 +252,14 @@ jobs:
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
           node-version: "22.x"
+
+      ######### CHECKOUT JS CLI #############
+      - name: Configure js-sdk
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: js
+          version-info: "${{ needs.resolve-versions.outputs.js }}"
 
       ######## SETUP THE JS CLI #############
       - name: build and setup the web-sdk cli

--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -101,7 +101,7 @@ args=(
 )
 
 # only ignore allowlist if the kas allowlist fetching from kas registry has not been implemented
-if ! npx $CTL help | grep 'the list from "/key-access-servers" endpoint'; then
+if ! npx $CTL help | grep 'from "/key-access-servers" endpoint'; then
   args+=(--ignoreAllowList)
 fi
 

--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -45,7 +45,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     kasallowlist)
-      npx $CTL help | grep kas-allowlist
+      npx $CTL help | grep 'the list from "/key-access-servers" endpoint'
       exit $?
       ;;
     ecwrap)

--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -45,7 +45,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     kasallowlist)
-      npx $CTL help | grep 'the list from "/key-access-servers" endpoint'
+      npx $CTL help | grep 'from "/key-access-servers" endpoint'
       exit $?
       ;;
     ecwrap)
@@ -99,11 +99,6 @@ args=(
   --oidcEndpoint "$KCFULLURL"
   --auth opentdf:secret
 )
-
-# only ignore allowlist if the kas allowlist fetching from kas registry has not been implemented
-if ! npx $CTL help | grep 'from "/key-access-servers" endpoint'; then
-  args+=(--ignoreAllowList)
-fi
 
 # default for js cli is nano
 if [ "$4" == "ztdf" ]; then
@@ -181,6 +176,13 @@ elif [ "$1" == "decrypt" ]; then
   if [ "$XT_WITH_ECWRAP" == 'true' ]; then
     args+=(--rewrapKeyType "ec:secp256r1")
   fi
+  # only ignore allowlist if the kas allowlist fetching from kas registry has not been implemented
+  if npx $CTL help | grep 'from "/key-access-servers" endpoint'; then
+    args+=(--policyEndpoint "$PLATFORMURL")
+  else
+    args+=(--ignoreAllowList)
+  fi
+
   echo npx $CTL decrypt "$src_file" "${args[@]}"
   npx $CTL decrypt "$src_file" "${args[@]}"
 else

--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -96,10 +96,15 @@ dst_file=$(realpath "$(dirname "$3")")/$(basename "$3")
 args=(
   --output "$dst_file"
   --kasEndpoint "$KASURL"
-  --ignoreAllowList # should be removed when fetching from registry is implemented
   --oidcEndpoint "$KCFULLURL"
   --auth opentdf:secret
 )
+
+# only ignore allowlist if the kas allowlist fetching from kas registry has not been implemented
+if ! npx $CTL help | grep 'the list from "/key-access-servers" endpoint'; then
+  args+=(--ignoreAllowList)
+fi
+
 # default for js cli is nano
 if [ "$4" == "ztdf" ]; then
   args+=(--containerType tdf3)

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -798,5 +798,11 @@ def test_tdf_with_malicious_kao(
     except subprocess.CalledProcessError as exc:
         assert any(
             err in exc.output
-            for err in [b"allowlist", b"kasallowlist", b"KasAllowlist", b"not allowed", b"disallowed KASes"]
+            for err in [
+                b"allowlist",
+                b"kasallowlist",
+                b"KasAllowlist",
+                b"not allowed",
+                b"disallowed KASes",
+            ]
         ), f"Unexpected error output: [{exc.output}]"

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -798,5 +798,5 @@ def test_tdf_with_malicious_kao(
     except subprocess.CalledProcessError as exc:
         assert any(
             err in exc.output
-            for err in [b"allowlist", b"kasallowlist", b"KasAllowlist", b"not allowed"]
+            for err in [b"allowlist", b"kasallowlist", b"KasAllowlist", b"not allowed", b"disallowed KASes"]
         ), f"Unexpected error output: [{exc.output}]"


### PR DESCRIPTION
fix js sdk checkout
enable kao tamper tests, adjust errors to include js thrown error