### PR TITLE
fix(xtest): Ignore allowlist in js if server does not support connect rpc

### DIFF
--- a/xtest/sdk/js/cli.sh
+++ b/xtest/sdk/js/cli.sh
@@ -18,6 +18,7 @@
 #  XT_WITH_ATTRIBUTES [string] - Attributes to be used for encryption
 #  XT_WITH_MIME_TYPE [string] - MIME type for the encrypted file
 #  XT_WITH_TARGET_MODE [string] - Target spec mode for the encrypted file
+#  XT_WITH_IGNORE_ALLOWLIST [boolean] - Add --ignoreAllowList flag on decrypt to ignore the kas allowlist
 #
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
@@ -176,8 +177,8 @@ elif [ "$1" == "decrypt" ]; then
   if [ "$XT_WITH_ECWRAP" == 'true' ]; then
     args+=(--rewrapKeyType "ec:secp256r1")
   fi
-  # only ignore allowlist if the kas allowlist fetching from kas registry has not been implemented
-  if npx $CTL help | grep 'from "/key-access-servers" endpoint'; then
+  # only ignore allowlist if the kas allowlist fetching from kas registry has not been implemented and XT_WITH_IGNORE_ALLOWLIST is not set to true
+  if npx $CTL help | grep 'from "/key-access-servers" endpoint' && [[ "$XT_WITH_IGNORE_ALLOWLIST" != "true" ]]; then
     args+=(--policyEndpoint "$PLATFORMURL")
   else
     args+=(--ignoreAllowList)

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -96,7 +96,7 @@ class PlatformFeatureSet(BaseModel):
 
         if self.semver >= (0, 4, 28):
             self.features.add("connectrpc")
-        
+
         print(f"PLATFORM_VERSION '{v}' supports [{', '.join(self.features)}]")
 
 
@@ -396,7 +396,11 @@ class SDK:
         if not verify_assertions:
             local_env |= {"XT_WITH_VERIFY_ASSERTIONS": "false"}
         ## if platform does not have connect rpc && sdk is js && sdk supports kasallowlist, add ignore allowlist
-        if "connectrpc" not in pfs.features and self.sdk == "js" and self.supports("kasallowlist"):
+        if (
+            "connectrpc" not in pfs.features
+            and self.sdk == "js"
+            and self.supports("kasallowlist")
+        ):
             local_env |= {"XT_WITH_IGNORE_ALLOWLIST": "true"}
         logger.info(f"dec [{' '.join([fmt_env(local_env)] + c)}]")
         env = dict(os.environ)

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -93,6 +93,10 @@ class PlatformFeatureSet(BaseModel):
 
         if self.semver >= (0, 4, 19):
             self.features.add("ns_grants")
+
+        if self.semver >= (0, 4, 28):
+            self.features.add("connectrpc")
+        
         print(f"PLATFORM_VERSION '{v}' supports [{', '.join(self.features)}]")
 
 
@@ -375,7 +379,7 @@ class SDK:
         expect_error: bool = False,
     ):
         fmt = simple_container(container)
-
+        pfs = PlatformFeatureSet()
         c = [
             self.path,
             "decrypt",
@@ -391,6 +395,9 @@ class SDK:
             local_env |= {"XT_WITH_ECWRAP": "true"}
         if not verify_assertions:
             local_env |= {"XT_WITH_VERIFY_ASSERTIONS": "false"}
+        ## if platform does not have connect rpc && sdk is js && sdk supports kasallowlist, add ignore allowlist
+        if "connectrpc" not in pfs.features and self.sdk == "js" and self.supports("kasallowlist"):
+            local_env |= {"XT_WITH_IGNORE_ALLOWLIST": "true"}
         logger.info(f"dec [{' '.join([fmt_env(local_env)] + c)}]")
         env = dict(os.environ)
         env |= local_env

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -783,11 +783,16 @@ def test_tdf_with_malicious_kao(
     tmp_dir: Path,
     in_focus: set[tdfs.SDK],
 ) -> None:
+    pfs = tdfs.PlatformFeatureSet()
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     if not decrypt_sdk.supports("kasallowlist"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support an allowlist for kases")
+    if decrypt_sdk.sdk == "js" and "connectrpc" not in pfs.features:
+        pytest.skip(
+            f"platform version {pfs.version} does not support connect rpc and {decrypt_sdk} sdk requires it for kasallowlist"
+        )
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     b_file = tdfs.update_manifest("malicious_kao", ct_file, malicious_kao)
     fname = b_file.stem


### PR DESCRIPTION
js client with kasallowlist feature relies on the connect rpc endpoint of the kas registry to fetch kas entries. this will not work with servers pre-connect rpc. if a server is pre connect rpc, then ignore the allowlist