### PR TITLE
chore(ci): Fix xtest on sdk branches

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -139,7 +139,11 @@ jobs:
             for (const [sdkType, ref] of Object.entries(refs)) {
               try {
                 const output = execSync(`python3 ${resolveVersionScript} ${sdkType} ${ref}`, { cwd: workingDir }).toString();
-                versionData[sdkType] = JSON.parse(output);
+                const ojson = JSON.parse(output);
+                if (!!ojson.err) {
+                  throw new Error(ojson.err);
+                }
+                versionData[sdkType] = ojson;
               } catch (error) {
                 console.error(`Error resolving version for ${sdkType}:`, error);
                 versionData[sdkType] = [{ tag: ref, err: error.message }];

--- a/xtest/sdk/scripts/resolve-version.py
+++ b/xtest/sdk/scripts/resolve-version.py
@@ -254,7 +254,7 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
             }
 
         remote_tags = [
-            r.split("\t") for r in repo.ls_remote(sdk_url, tags=True).split("\n")
+            r.split("\t") for r in repo.ls_remote(sdk_url).split("\n")
         ]
         all_listed_tags = [
             (sha, tag.split("refs/tags/")[-1])
@@ -262,8 +262,23 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
             if "refs/tags/" in tag
         ]
 
-        if version.startswith("refs/tags/"):
-            version = version.split("refs/tags/")[-1]
+        all_listed_branches = {
+            tag.split("refs/heads/")[-1]: sha
+            for (sha, tag) in remote_tags
+            if tag.startswith("refs/heads/")
+        }
+
+        if version in all_listed_branches:
+            sha = all_listed_branches[version]
+            return {
+                "sdk": sdk,
+                "alias": version,
+                "head": True,
+                "sha": sha,
+                "tag": version,
+            }
+
+        
         if infix and version.startswith(f"{infix}/"):
             version = version.split(f"{infix}/")[-1]
 

--- a/xtest/sdk/scripts/resolve-version.py
+++ b/xtest/sdk/scripts/resolve-version.py
@@ -253,9 +253,7 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
                 "tag": f"pull-{pr_number}",
             }
 
-        remote_tags = [
-            r.split("\t") for r in repo.ls_remote(sdk_url).split("\n")
-        ]
+        remote_tags = [r.split("\t") for r in repo.ls_remote(sdk_url).split("\n")]
         all_listed_tags = [
             (sha, tag.split("refs/tags/")[-1])
             for (sha, tag) in remote_tags
@@ -278,7 +276,6 @@ def resolve(sdk: str, version: str, infix: None | str) -> ResolveResult:
                 "tag": version,
             }
 
-        
         if infix and version.startswith(f"{infix}/"):
             version = version.split(f"{infix}/")[-1]
 


### PR DESCRIPTION
- look up branch names (refs/heads)
- don't try to use versions that resolve to `err`