### PR TITLE
chore(xtest): Fix scheduled run versions

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -51,8 +51,9 @@ on:
         type: string
         default: all
   schedule:
-    - cron: "30 6 * * *"
-    - cron: "0 18 * * 0"
+    - cron: "30 6 * * *" # 0630 UTC
+    - cron: "0 5 * * 1,3" # 500 UTC (Monday, Wednesday)
+    - cron: "0 18 * * 0" # 1800 UTC (Sunday)
 jobs:
   resolve-versions:
     timeout-minutes: 10
@@ -68,11 +69,10 @@ jobs:
       java: ${{ steps.version-info.outputs.java-version-info }}
       js: ${{ steps.version-info.outputs.js-version-info }}
     env:
-      PLATFORM_REF: "${{ inputs.platform-ref || 'main' }}"
-      JS_REF: "${{ inputs.js-ref || 'main' }}"
-      OTDFCTL_REF: "${{ inputs.otdfctl-ref || 'main' }}"
-      JAVA_REF: "${{ inputs.java-ref || 'main' }}"
-      FOCUS_SDK: "${{ inputs.focus-sdk || 'all' }}"
+      PLATFORM_REF: "${{ inputs.platform-ref }}"
+      JS_REF: "${{ inputs.js-ref }}"
+      OTDFCTL_REF: "${{ inputs.otdfctl-ref }}"
+      JAVA_REF: "${{ inputs.java-ref }}"
     steps:
       - name: Validate focus-sdk input
         if: ${{ inputs.focus-sdk != '' }}
@@ -87,6 +87,9 @@ jobs:
           if [[ $CRON_NIGHTLY == 'true' ]]; then
             echo "Running nightly tests"
             echo "DEFAULT_TAGS=main latest" >> "$GITHUB_ENV"
+          elif [[ $CRON_MONDAY_WEDNESDAY == 'true' ]]; then
+            echo "Running Monday/Wednesday tests"
+            echo "DEFAULT_TAGS=main lts" >> "$GITHUB_ENV"
           elif [[ $CRON_WEEKLY == 'true' ]]; then
             echo "Running weekly tests"
             echo "DEFAULT_TAGS=main latest lts" >> "$GITHUB_ENV"
@@ -96,6 +99,7 @@ jobs:
           fi
         env:
           CRON_NIGHTLY: ${{ github.event.schedule == '30 6 * * *' }}
+          CRON_MONDAY_WEDNESDAY: ${{ github.event.schedule == '0 5 * * 1,3' }}
           CRON_WEEKLY: ${{ github.event.schedule == '0 18 * * 0' }}
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The idea is:
- weekly: test all current supported releases
- semi-weekly: tests main against LTS
- daily: test all releases against current release