### PR TITLE
chore(xtest): Adds pyright to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
           STATUS=$?
           if [ $STATUS -ne 0 ]; then
             echo -e "## type check error\n\`\`\`\n$OUTPUT\n\`\`\`" >> $GITHUB_STEP_SUMMARY
-          elif [ -z "$OUTPUT" ]; then
+          elif [[ -z "$OUTPUT" || "$OUTPUT" == '0 errors, 0 warnings, 0 informations'* ]]; then
             echo "No type errors found."
           else
             echo "Type check passed with warnings.\n\n$OUTPUT"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,4 +37,8 @@ jobs:
           STATUS=$?
           if [ $STATUS -ne 0 ]; then
             echo -e "## type check error\n\`\`\`\n$OUTPUT\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+          elif [ -z "$OUTPUT" ]; then
+            echo "No type errors found."
+          else
+            echo "Type check passed with warnings.\n\n$OUTPUT"
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,8 +18,9 @@ jobs:
       - name: 🧽 🐍 
         run: |-
           pip install -r requirements.txt
-          pip install ruff
-          pip install black
+          pip install black pyright ruff
+          pip install 
           ruff check
           black --check .
+          pyright .
         working-directory: xtest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: 🦪 ✔ 🧼🧼🧼
         run: >-
           docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "koalaman/shellcheck:v0.8.0" --color=always \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,6 @@ jobs:
         run: |-
           pip install -r requirements.txt
           pip install black pyright ruff
-          pip install 
           ruff check
           black --check .
           pyright .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,5 +29,12 @@ jobs:
           pip install black pyright ruff
           ruff check
           black --check .
-          pyright .
         working-directory: xtest
+      - name: Run Pyright and summarize errors if any
+        run: |
+          set +e
+          OUTPUT=$(pyright 2>&1)
+          STATUS=$?
+          if [ $STATUS -ne 0 ]; then
+            echo -e "## type check error\n\`\`\`\n$OUTPUT\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,8 @@ on:
       - main
 jobs:
   scriptcheck:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -15,6 +17,10 @@ jobs:
         run: >-
           docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "koalaman/shellcheck:v0.8.0" --color=always \
               $(find . -type f -exec grep -m1 -l -E '^#!.*sh.*' {} \; | grep -v '/.git/')
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          cache: pip
+          python-version: '3.13' 
       - name: 🧽 🐍 
         run: |-
           pip install -r requirements.txt

--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -24,7 +24,9 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
           node-version: "16.x"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -101,9 +101,10 @@ jobs:
           CRON_NIGHTLY: ${{ github.event.schedule == '30 6 * * *' }}
           CRON_MONDAY_WEDNESDAY: ${{ github.event.schedule == '0 5 * * 1,3' }}
           CRON_WEEKLY: ${{ github.event.schedule == '0 18 * * 0' }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: otdf-sdk
+          persist-credentials: false
           repository: opentdf/tests
           sparse-checkout: xtest/sdk
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
@@ -214,7 +215,7 @@ jobs:
       matrix:
         platform-tag: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-list) }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: opentdf/tests
           path: otdftests # use different name bc other repos might have tests directories

--- a/xtest/assertions.py
+++ b/xtest/assertions.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Literal
 
 
@@ -9,8 +9,10 @@ BindingMethod = Literal["jws", "JWS"]
 
 
 class Statement(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     format: str
-    schema: str
+    schema_: str = Field(..., alias="schema")
     value: str | dict[str, str]
 
 

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -68,6 +68,14 @@ def pytest_addoption(parser: pytest.Parser):
     )
 
 
+def sample_pyright_warning[T](message: str) -> T:
+    """
+    A sample function to demonstrate a Pyright warning.
+    This function is intentionally incorrect to trigger a warning.
+    """
+    # This will cause a type error because we are returning an int where T is expected
+    return 42  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
+
 def pytest_generate_tests(metafunc: pytest.Metafunc):
     if "size" in metafunc.fixturenames:
         metafunc.parametrize(

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -68,15 +68,6 @@ def pytest_addoption(parser: pytest.Parser):
     )
 
 
-def sample_pyright_warning[T](message: str) -> T:
-    """
-    A sample function to demonstrate a Pyright warning.
-    This function is intentionally incorrect to trigger a warning.
-    """
-    # This will cause a type error because we are returning an int where T is expected
-    return 42  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
-
-
 def pytest_generate_tests(metafunc: pytest.Metafunc):
     if "size" in metafunc.fixturenames:
         metafunc.parametrize(

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -76,6 +76,7 @@ def sample_pyright_warning[T](message: str) -> T:
     # This will cause a type error because we are returning an int where T is expected
     return 42  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
 
+
 def pytest_generate_tests(metafunc: pytest.Metafunc):
     if "size" in metafunc.fixturenames:
         metafunc.parametrize(

--- a/xtest/requirements.txt
+++ b/xtest/requirements.txt
@@ -5,6 +5,7 @@ charset-normalizer==3.3.2
 construct==2.10.68
 construct-typing==0.6.2
 cryptography==44.0.1
+gitpython==3.1.44
 idna==3.8
 iniconfig==2.0.0
 jsonschema==4.23.0

--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -77,34 +77,38 @@ runs:
         version_info: ${{ inputs.version-info }}
 
     - name: checkout version a
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       if: steps.resolve.outputs.version-a != ''
       with:
         path: ${{ inputs.path }}/${{ inputs.sdk }}/src/${{ fromJson(steps.resolve.outputs.version-a).tag }}
+        persist-credentials: false
         ref: ${{ fromJson(steps.resolve.outputs.version-a).sha }}
         repository: ${{ env.sdk_repo }}
 
     - name: checkout version b
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       if: steps.resolve.outputs.version-b != ''
       with:
         path: ${{ inputs.path }}/${{ inputs.sdk }}/src/${{ fromJson(steps.resolve.outputs.version-b).tag }}
+        persist-credentials: false
         ref: ${{ fromJson(steps.resolve.outputs.version-b).sha }}
         repository: ${{ env.sdk_repo }}
 
     - name: checkout version c
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       if: steps.resolve.outputs.version-c != ''
       with:
         path: ${{ inputs.path }}/${{ inputs.sdk }}/src/${{ fromJson(steps.resolve.outputs.version-c).tag }}
+        persist-credentials: false
         ref: ${{ fromJson(steps.resolve.outputs.version-c).sha }}
         repository: ${{ env.sdk_repo }}
 
     - name: checkout version d
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       if: steps.resolve.outputs.version-d != ''
       with:
         path: ${{ inputs.path }}/${{ inputs.sdk }}/src/${{ fromJson(steps.resolve.outputs.version-d).tag }}
+        persist-credentials: false
         ref: ${{ fromJson(steps.resolve.outputs.version-d).sha }}
         repository: ${{ env.sdk_repo }}
 

--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -3,14 +3,11 @@ description: Check out and build one or more SDK and its CLI tool for use by xte
 inputs:
   path:
     description: The path to checkout the the SDK source code to; concatenated with branch or tag name.
-    type: string
   sdk:
     description: The SDK to configure; one of go, java, js
-    type: string
   version-info:
     description: JSON-encoded output of resolve-version.py
     required: true
-    type: string
 outputs:
   version-a:
     description: "Object containing tag, sha, and name of a version checked out"

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -37,9 +37,12 @@ feature_type = Literal[
     "assertion_verification",
     "autoconfigure",
     "better-messages-2024",
+    "bulk_rewrap",
+    "connectrpc",
     "ecwrap",
     "hexless",
     "hexaflexible",
+    "kasallowlist",
     "nano_ecdsa",
     "ns_grants",
 ]

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -90,7 +90,6 @@ class PlatformFeatureSet(BaseModel):
         if self.semver >= (0, 4, 39):
             self.features.add("hexless")
             self.features.add("hexaflexible")
-            self.features.add("superhexaflexible")
 
         if self.semver >= (0, 4, 23):
             self.features.add("nano_ecdsa")

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -90,6 +90,7 @@ class PlatformFeatureSet(BaseModel):
         if self.semver >= (0, 4, 39):
             self.features.add("hexless")
             self.features.add("hexaflexible")
+            self.features.add("superhexaflexible")
 
         if self.semver >= (0, 4, 23):
             self.features.add("nano_ecdsa")


### PR DESCRIPTION
- Adds `pyright` to the linter list (along with `black` and `ruff`)
  - pyright it used by pylance under the hood, so this should ensure fewer squigglies in vscode with that python language server enabled
- `schema` is reserved in the pydantic BaseModel; this makes the output cleaner by removing a warning about this
- Fixes a couple of issues that pyright had a problem with not inferring type guards as in the spec AFAICT
- Also removes the 'type' parameter from composite actions, which is not present

This doesn't currently block on pyright errors. They are instead pasted into the summary page for lints.

Warnings and informations continue to be hidden in the logs

Error sample [run](https://github.com/opentdf/tests/actions/runs/15326517394):

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/28761d43-156c-4c3a-a6c7-7558eb246e7d" />

Warning sample [run](https://github.com/opentdf/tests/actions/runs/15326733224/job/43123054669#step:6:21):

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/dab86a47-d2a2-4515-8215-b75d938427f7" />

