### PR TITLE
fix(xtest): Skip tests for public_client_id mismatch for otdfctl

### DIFF
--- a/xtest/sdk/go/cli.sh
+++ b/xtest/sdk/go/cli.sh
@@ -72,6 +72,12 @@ if [ "$1" == "supports" ]; then
       "${cmd[@]}" --version --json | jq -re .sdk_version | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 3) || ($1 == 0 && $2 == 3 && $3 >= 18)) exit 0; else exit 1; }'
       exit $?
       ;;
+    public-client-id)
+      # this was removed in 0.21.0
+      set -o pipefail
+      "${cmd[@]}" --version --json | jq -re .version | awk -F. '{ if (($1 == 0 && $2 < 21)) exit 0; else exit 1; }'
+      exit $?
+      ;;
     *)
       echo "Unknown feature: $2"
       exit 2

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -100,6 +100,10 @@ class PlatformFeatureSet(BaseModel):
         if self.semver >= (0, 4, 28):
             self.features.add("connectrpc")
 
+        # removed after service 0.5.5
+        if self.semver <= (0, 5, 5):
+            self.features.add("public-client-id")
+
         print(f"PLATFORM_VERSION '{v}' supports [{', '.join(self.features)}]")
 
 
@@ -469,6 +473,14 @@ def skip_hexless_skew(encrypt_sdk: SDK, decrypt_sdk: SDK):
 
 def skip_connectrpc_skew(encrypt_sdk: SDK, decrypt_sdk: SDK, pfs: PlatformFeatureSet):
     return False
+
+
+def skip_public_client_id_skew(encrypt_sdk: SDK, decrypt_sdk: SDK, pfs: PlatformFeatureSet):
+    for sdk in (encrypt_sdk, decrypt_sdk):
+        if sdk is not None and sdk.sdk == "go" and sdk.supports("public-client-id") and "public-client-id" not in pfs.features:
+            pytest.skip(
+                f"{sdk} sdk expects [public_client_id], but platform service {pfs.version} does not support it"
+            )
 
 
 def select_target_version(

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -42,6 +42,7 @@ def test_autoconfigure_one_attribute_standard(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-one-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -87,6 +88,7 @@ def test_autoconfigure_two_kas_or_standard(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-two-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -140,6 +142,7 @@ def test_autoconfigure_double_kas_and(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-three-and-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -193,6 +196,7 @@ def test_autoconfigure_one_attribute_attr_grant(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-one-attr-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -240,6 +244,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-attr-val-or-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -294,6 +299,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-attr-val-and-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -347,6 +353,7 @@ def test_autoconfigure_one_attribute_ns_grant(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-one-ns-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -394,6 +401,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-ns-val-or-{encrypt_sdk}"
     if sample_name in cipherTexts:
@@ -448,6 +456,7 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
 
     sample_name = f"test-abac-ns-val-and-{encrypt_sdk}"
     if sample_name in cipherTexts:

--- a/xtest/test_legacy.py
+++ b/xtest/test_legacy.py
@@ -22,6 +22,8 @@ def test_decrypt_small(
         pytest.skip("Not in focus")
     if not decrypt_sdk.supports("hexless"):
         pytest.skip("Decrypting hexless files is not supported")
+    pfs = tdfs.PlatformFeatureSet()
+    tdfs.skip_public_client_id_skew(None, decrypt_sdk, pfs)
     ct_file = get_golden_file("small-java-4.3.0-e0f8caf.tdf")
     rt_file = tmp_dir / "small-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
@@ -42,6 +44,8 @@ def test_decrypt_big(
         pytest.skip("Not in focus")
     if not decrypt_sdk.supports("hexless"):
         pytest.skip("Decrypting hexless files is not supported")
+    pfs = tdfs.PlatformFeatureSet()
+    tdfs.skip_public_client_id_skew(None, decrypt_sdk, pfs)
     ct_file = get_golden_file("big-java-4.3.0-e0f8caf.tdf")
     rt_file = tmp_dir / "big-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
@@ -62,6 +66,8 @@ def test_decrypt_no_splitid(
         pytest.skip("Not in focus")
     if not decrypt_sdk.supports("hexless"):
         pytest.skip("Decrypting hexless files is not supported")
+    pfs = tdfs.PlatformFeatureSet()
+    tdfs.skip_public_client_id_skew(None, decrypt_sdk, pfs)
     ct_file = get_golden_file("no-splitids-java.tdf")
     rt_file = tmp_dir / "no-splitids-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
@@ -82,6 +88,8 @@ def test_decrypt_object_statement_value_json(
         pytest.skip("Not in focus")
     if not decrypt_sdk.supports("assertion_verification"):
         pytest.skip("assertion_verification is not supported")
+    pfs = tdfs.PlatformFeatureSet()
+    tdfs.skip_public_client_id_skew(None, decrypt_sdk, pfs)
     ct_file = get_golden_file("with-json-object-assertions-java.tdf")
     rt_file = tmp_dir / "with-json-object-assertions-java.untdf"
     decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf", verify_assertions=False)

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -112,6 +112,7 @@ def test_tdf_roundtrip(
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if container == "nano-with-ecdsa":
         if not encrypt_sdk.supports("nano_ecdsa"):
             pytest.skip(
@@ -163,6 +164,7 @@ def test_tdf_spec_target_422(
 ):
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if "hexaflexible" not in pfs.features:
         pytest.skip(f"Hexaflexible is not supported in platform {pfs.version}")
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
@@ -266,6 +268,8 @@ def test_manifest_validity(
 ):
     if not in_focus & {encrypt_sdk}:
         pytest.skip("Not in focus")
+    pfs = tdfs.PlatformFeatureSet()
+    tdfs.skip_public_client_id_skew(encrypt_sdk, None, pfs)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
 
     tdfs.validate_manifest_schema(ct_file)
@@ -282,6 +286,8 @@ def test_manifest_validity_with_assertions(
         pytest.skip("Not in focus")
     if not encrypt_sdk.supports("assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
+    pfs = tdfs.PlatformFeatureSet()
+    tdfs.skip_public_client_id_skew(encrypt_sdk, None, pfs)
     ct_file = do_encrypt_with(
         pt_file,
         encrypt_sdk,
@@ -310,6 +316,7 @@ def test_tdf_assertions_unkeyed(
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if not encrypt_sdk.supports("assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not decrypt_sdk.supports("assertions"):
@@ -343,6 +350,7 @@ def test_tdf_assertions_with_keys(
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if not encrypt_sdk.supports("assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not decrypt_sdk.supports("assertion_verification"):
@@ -381,6 +389,7 @@ def test_tdf_assertions_422_format(
         pytest.skip("Not in focus")
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if not encrypt_sdk.supports("hexaflexible"):
         pytest.skip(
             f"Encrypt SDK {encrypt_sdk} doesn't support targeting container format 4.2.2"
@@ -553,6 +562,7 @@ def test_tdf_with_unbound_policy(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     ct_file = do_encrypt_with(
         pt_file,
         encrypt_sdk,
@@ -582,6 +592,7 @@ def test_tdf_with_altered_policy_binding(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)
     b_file = tdfs.update_manifest(
         "altered_policy_binding", ct_file, change_policy_binding
@@ -610,6 +621,7 @@ def test_tdf_with_altered_root_sig(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     ct_file = do_encrypt_with(
         pt_file,
         encrypt_sdk,
@@ -639,6 +651,7 @@ def test_tdf_with_altered_seg_sig_wrong(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     ct_file = do_encrypt_with(
         pt_file,
         encrypt_sdk,
@@ -671,6 +684,7 @@ def test_tdf_with_altered_enc_seg_size(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     ct_file = do_encrypt_with(
         pt_file,
         encrypt_sdk,
@@ -706,6 +720,7 @@ def test_tdf_with_altered_assertion_statement(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if not encrypt_sdk.supports("assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not decrypt_sdk.supports("assertions"):
@@ -745,6 +760,7 @@ def test_tdf_with_altered_assertion_with_keys(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if not encrypt_sdk.supports("assertions"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support assertions")
     if not decrypt_sdk.supports("assertion_verification"):
@@ -793,6 +809,7 @@ def test_tdf_altered_payload_end(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     ct_file = do_encrypt_with(
         pt_file,
         encrypt_sdk,
@@ -825,6 +842,7 @@ def test_tdf_with_malicious_kao(
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
+    tdfs.skip_public_client_id_skew(encrypt_sdk, decrypt_sdk, pfs)
     if not decrypt_sdk.supports("kasallowlist"):
         pytest.skip(f"{encrypt_sdk} sdk doesn't yet support an allowlist for kases")
     ct_file = do_encrypt_with(pt_file, encrypt_sdk, "ztdf", tmp_dir)


### PR DESCRIPTION
the public_client_id was removed from the platform configuration, skip tests if otdfctl expects but the platform does not have it