### PR TITLE
chore(xtest): Revert Prefer pathless kas uris (#320)

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -367,9 +367,8 @@ jobs:
         run: |-
           pip install -r requirements.txt
         working-directory: otdftests/xtest
-
       - name: Validate xtest helper library (tests of the test harness and its utilities)
-        if: ${{ github.event_name == 'pull_request' && github.repository == 'opentdf/tests' && contains(join(github.event.pull_request.changed_files.*.filename, ','), 'xtest/') }}
+        if: ${{ !inputs }}
         run: |-
           pytest test_nano.py test_self.py
         working-directory: otdftests/xtest

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -278,7 +278,7 @@ def kas_public_key_e1() -> abac.KasPublicKey:
 
 @pytest.fixture(scope="session")
 def kas_url_default():
-    return os.getenv("KASURL", "http://localhost:8080")
+    return os.getenv("KASURL", "http://localhost:8080/kas")
 
 
 @pytest.fixture(scope="module")
@@ -292,7 +292,7 @@ def kas_entry_default(
 
 @pytest.fixture(scope="session")
 def kas_url_value1():
-    return os.getenv("KASURL1", "http://localhost:8181")
+    return os.getenv("KASURL1", "http://localhost:8181/kas")
 
 
 @pytest.fixture(scope="module")
@@ -306,7 +306,7 @@ def kas_entry_value1(
 
 @pytest.fixture(scope="session")
 def kas_url_value2():
-    return os.getenv("KASURL2", "http://localhost:8282")
+    return os.getenv("KASURL2", "http://localhost:8282/kas")
 
 
 @pytest.fixture(scope="module")
@@ -320,7 +320,7 @@ def kas_entry_value2(
 
 @pytest.fixture(scope="session")
 def kas_url_attr():
-    return os.getenv("KASURL3", "http://localhost:8383")
+    return os.getenv("KASURL3", "http://localhost:8383/kas")
 
 
 @pytest.fixture(scope="module")
@@ -334,7 +334,7 @@ def kas_entry_attr(
 
 @pytest.fixture(scope="session")
 def kas_url_ns():
-    return os.getenv("KASURL4", "http://localhost:8484")
+    return os.getenv("KASURL4", "http://localhost:8484/kas")
 
 
 @pytest.fixture(scope="module")

--- a/xtest/test_nano.py
+++ b/xtest/test_nano.py
@@ -18,9 +18,9 @@ def test_magic_version():
 
 
 def test_resource_locator():
-    rl0 = nano.locator("https://localhost:8080")
+    rl0 = nano.locator("https://localhost:8080/kas")
     print(rl0)
-    expected_bits = "01 0e 6c 6f 63 61 6c 68 6f 73 74 3a 38 30 38 30"
+    expected_bits = "01 12 6c 6f 63 61 6c 68 6f 73 74 3a 38 30 38 30 2f 6b 61 73"
     assert expected_bits == enc_hex(bytes(rl0))
 
     rl1 = nano.locator("https://localhost:8080/kas", b"ab")

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -495,7 +495,7 @@ def change_payload_end(payload_bytes: bytes) -> bytes:
 def malicious_kao(manifest: tdfs.Manifest) -> tdfs.Manifest:
     assert manifest.encryptionInformation.keyAccess
     manifest.encryptionInformation.keyAccess[0].url = (
-        "http://localhost:8585/malicious"  # nothing running at 8585
+        "http://localhost:8585/malicious/kas"  # nothing running at 8585
     )
     return manifest
 


### PR DESCRIPTION
This reverts commit cb3576ea8bfc5bdb9d431f104793384a3f5d8e0a.