### PR TITLE
fix: we were serializing `assertion.statement.schema` as `schema_`

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -374,12 +374,12 @@ jobs:
         working-directory: otdftests/xtest
 
       ######## RUN THE TESTS #############
-      # - name: Run legacy decryption tests
-      #   run: |-
-      #     pytest -ra -v --focus "$FOCUS_SDK" test_legacy.py
-      #   working-directory: otdftests/xtest
-      #   env:
-      #     PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+      - name: Run legacy decryption tests
+        run: |-
+          pytest -ra -v --focus "$FOCUS_SDK" test_legacy.py
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
       - name: Run all standard xtests
         if: ${{ env.FOCUS_SDK == 'all' }}
         run: |-

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -383,7 +383,7 @@ jobs:
       - name: Run all standard xtests
         if: ${{ env.FOCUS_SDK == 'all' }}
         run: |-
-           pytest -vvvv test_tdfs.py::test_tdf_with_altered_seg_sig_wrong --sdks-encrypt=java --sdks-decrypt=js
+           pytest -ra -v test_tdfs.py test_policytypes.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -383,7 +383,7 @@ jobs:
       - name: Run all standard xtests
         if: ${{ env.FOCUS_SDK == 'all' }}
         run: |-
-           pytest -ra -v test_tdfs.py test_policytypes.py
+          pytest -ra -v test_tdfs.py test_policytypes.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -383,7 +383,7 @@ jobs:
       - name: Run all standard xtests
         if: ${{ env.FOCUS_SDK == 'all' }}
         run: |-
-          pytest --encrypt-sdks=java --decrypt-sdks=js -ra -v test_tdfs.py test_policytypes.py
+           pytest -vvvv test_tdfs.py::test_tdf_with_altered_seg_sig_wrong --sdks-encrypt=java --sdks-decrypt=js
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -374,16 +374,16 @@ jobs:
         working-directory: otdftests/xtest
 
       ######## RUN THE TESTS #############
-      - name: Run legacy decryption tests
-        run: |-
-          pytest -ra -v --focus "$FOCUS_SDK" test_legacy.py
-        working-directory: otdftests/xtest
-        env:
-          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+      # - name: Run legacy decryption tests
+      #   run: |-
+      #     pytest -ra -v --focus "$FOCUS_SDK" test_legacy.py
+      #   working-directory: otdftests/xtest
+      #   env:
+      #     PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
       - name: Run all standard xtests
         if: ${{ env.FOCUS_SDK == 'all' }}
         run: |-
-          pytest -ra -v test_tdfs.py test_policytypes.py
+          pytest --encrypt-sdks=java --decrypt-sdks=js -ra -v test_tdfs.py test_policytypes.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -234,7 +234,7 @@ def update_manifest(
         manifest_data = Manifest.model_validate_json(manifest_file.read())
     new_manifest_data = manifest_change(manifest_data)
     with (unzipped_dir / "0.manifest.json").open("w") as manifest_file:
-        manifest_file.write(new_manifest_data.model_dump_json())
+        manifest_file.write(new_manifest_data.model_dump_json(by_alias=True))
     outfile = tmp_dir / f"{fname}-{scenario_name}.tdf"
     with zipfile.ZipFile(outfile, "w") as zipped:
         for folder_name, _, filenames in os.walk(unzipped_dir):


### PR DESCRIPTION
when modifying tdfs to test error conditions we'd read a field named `.schema` and writing one named `.schema_`.

[we had the alias in place](https://github.com/opentdf/tests/blob/324ac800166adc98641640556bd2d9776df61972/xtest/assertions.py#L15) but it was ignored during serialization without `by_alias=True`

[it looks like running the java sdk (at least)](https://github.com/opentdf/tests/actions/runs/16472645962/job/46565640776) from a branch is broken so I want to merge this under the theory
that it doesn't make anything worse.
```
Error:  The goal you specified requires a project to execute but there is no POM in this directory (/home/runner/work/tests/tests/otdftests/xtest/sdk/java/src/dspx-817). Please verify you invoked Maven from the correct directory. -> [Help 1]
```