### PR TITLE
chore(xtest): Add assertions about policy contents

### DIFF
--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -57,6 +57,8 @@ feature_type = Literal[
 
 container_version = Literal["4.2.2", "4.3.0"]
 
+policy_type = Literal["plaintext", "encrypted"]
+
 
 class PlatformFeatureSet(BaseModel):
     version: str | None = None

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -120,8 +120,8 @@ class DataAttribute(BaseModel):
     attribute: str
     isDefault: bool | None = None
     displayName: str | None = None
-    pubKey: str
-    kasUrl: str
+    pubKey: str | None = None
+    kasUrl: str | None = None
     schemaVersion: str | None = None
 
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -58,6 +58,7 @@ feature_type = Literal[
 container_version = Literal["4.2.2", "4.3.0"]
 
 policy_type = Literal["plaintext", "encrypted"]
+"""How policy (data attributes) should be bound within the output container on encrypt."""
 
 
 class PlatformFeatureSet(BaseModel):

--- a/xtest/test_policytypes.py
+++ b/xtest/test_policytypes.py
@@ -300,10 +300,8 @@ def assert_expected_attrs(
     c: tdfs.container_type, pt: tdfs.policy_type | None, ct_file: Path, fqns: list[str]
 ):
     if not pt:
-        if "nano" == tdfs.simple_container(c):
-            pt = "encrypted"
-        else:
-            pt = "plaintext"
+        # Nano defaults to encrypted; ztdf only supports plaintext
+        pt = "encrypted" if "nano" == tdfs.simple_container(c) else "plaintext"
     with open(ct_file, "rb") as f:
         if pt == "encrypted":
             match tdfs.simple_container(c):
@@ -316,7 +314,9 @@ def assert_expected_attrs(
                     assert not envelope.header.policy.embedded
                     assert envelope.header.policy.encrypted
                 case _:
-                    assert False, "Unsupported container & policy type pair"
+                    assert (
+                        False
+                    ), f"Unsupported container & policy type pair [{tdfs.simple_container(c)} & {pt}]"
             return
         policy: tdfs.PolicyBody
         match tdfs.simple_container(c):


### PR DESCRIPTION
Adds xtest assertions that policies contain the requested attributes. NOTE this currently only works for plain text policies, not encrypted policies