### PR TITLE
chore(xtest): Update any assert to re

### DIFF
--- a/xtest/test_policytypes.py
+++ b/xtest/test_policytypes.py
@@ -120,7 +120,7 @@ def decrypt_or_dont(
             assert re.search(
                 r"forbidden|unable to reconstruct split key",
                 combined_output,
-                re.IGNORECASE | re.MULTILINE,
+                re.IGNORECASE,
             ), f"decrypt failed with unexpected error: {exc}\nstdout: {output_content}\nstderr: {stderr_content}"
 
 

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -511,7 +511,7 @@ def assert_tamper_error(
 
     if not decrypt_sdk.supports("better-messages-2024"):
         assert re.search(
-            b"integrity|signature|bad request", exc.output, re.IGNORECASE | re.MULTILINE
+            b"integrity|signature|bad request", exc.output, re.IGNORECASE
         ), f"Unexpected error output: [{exc.output}]"
         return
 
@@ -536,7 +536,7 @@ def assert_tamper_error(
     # Convert list of byte strings to regex pattern
     pattern = b"|".join(re.escape(err) for err in expected_error_oneof)
     assert re.search(
-        pattern, exc.output, re.IGNORECASE | re.MULTILINE
+        pattern, exc.output, re.IGNORECASE
     ), f"Unexpected error output: [{exc.output}]"
 
 
@@ -652,7 +652,9 @@ def test_tdf_with_altered_seg_sig_wrong(
     fname = b_file.stem
     rt_file = tmp_dir / f"{fname}.untdf"
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(
+            b_file, rt_file, "ztdf", expect_error=True, verify_assertions=False
+        )
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_tamper_error(exc, "signature", decrypt_sdk)


### PR DESCRIPTION
- Switching to regex may give better output descriptions.
   - Also, updated to ignore case, to improve robustness
- Disable assertion verification on an auth tag check test, since on most clients assertion verification (which will fail if the payload is altered) happens before decrypt.
  - This fixes the false positive test for the last release of web-sdk.
    - Failure at main: https://github.com/opentdf/tests/actions/runs/16716056436/job/47309651858
    - Success on branch: https://github.com/opentdf/tests/actions/runs/16728837194