### PR TITLE
chore(xtest): Adds capstone `xtest` job

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -514,8 +514,10 @@ jobs:
       - name: Assert all matrix jobs passed
         if: ${{ needs.xct.result == 'failure' || needs.xct.result == 'cancelled' }}
         run: |-
-          echo "xct matrix had failures (overall result: ${{ needs.xct.result }}). Marking xtest failed." >> "$GITHUB_STEP_SUMMARY"
+          echo "xct matrix had failures (overall result: ${XCT_RESULT}). Marking xtest failed." >> "$GITHUB_STEP_SUMMARY"
           exit 1
+        env:
+          XCT_RESULT: ${{ needs.xct.result }}
       - name: Success summary
         if: ${{ needs.xct.result == 'success' }}
         run: |-


### PR DESCRIPTION
Having a single named job allows setting up branch protection rulesets to use this name