### PR TITLE
fix(xtest): Otdfctl is changing list structure.

### DIFF
--- a/xtest/abac.py
+++ b/xtest/abac.py
@@ -309,7 +309,7 @@ class OpentdfCommandLineTool:
         o = json.loads(out)
         if not o:
             return []
-        elif o["key_access_servers"]:
+        if isinstance(o, dict) and "key_access_servers" in o:
             o = o["key_access_servers"]
         return [KasEntry(**n) for n in o]
 


### PR DESCRIPTION
1.) Modify the kas-registry/kas-keys/namespace list commands to fit the new list responses generated by [otdfctl](https://github.com/opentdf/otdfctl/pull/695)
- Otdfctl is changing it's List commands to return pagination as well