### PR TITLE
fix(ci): use platform checkout for start-additional-kas

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -463,7 +463,7 @@ jobs:
       - name: Start additional kas
         id: kas-alpha
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@998929e5c66d41f928b90e6af7dbaa0a14302ca6  # watch-sh-fix
+        uses: ./otdf-test-platform/test/start-additional-kas
         with:
           ec-tdf-enabled: true
           kas-name: alpha
@@ -473,7 +473,7 @@ jobs:
       - name: Start additional kas
         id: kas-beta
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@998929e5c66d41f928b90e6af7dbaa0a14302ca6  # watch-sh-fix
+        uses: ./otdf-test-platform/test/start-additional-kas
         with:
           ec-tdf-enabled: true
           kas-name: beta
@@ -483,7 +483,7 @@ jobs:
       - name: Start additional kas
         id: kas-gamma
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@998929e5c66d41f928b90e6af7dbaa0a14302ca6  # watch-sh-fix
+        uses: ./otdf-test-platform/test/start-additional-kas
         with:
           ec-tdf-enabled: true
           kas-name: gamma
@@ -493,7 +493,7 @@ jobs:
       - name: Start additional kas
         id: kas-delta
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@998929e5c66d41f928b90e6af7dbaa0a14302ca6  # watch-sh-fix
+        uses: ./otdf-test-platform/test/start-additional-kas
         with:
           ec-tdf-enabled: true
           kas-port: 8484
@@ -503,7 +503,7 @@ jobs:
       - name: Start additional KM kas (km1)
         id: kas-km1
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@998929e5c66d41f928b90e6af7dbaa0a14302ca6  # watch-sh-fix
+        uses: ./otdf-test-platform/test/start-additional-kas
         with:
           ec-tdf-enabled: true
           key-management: ${{ steps.km-check.outputs.supported }}
@@ -514,7 +514,7 @@ jobs:
       - name: Start additional KM kas (km2)
         id: kas-km2
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@998929e5c66d41f928b90e6af7dbaa0a14302ca6  # watch-sh-fix
+        uses: ./otdf-test-platform/test/start-additional-kas
         with:
           ec-tdf-enabled: true
           kas-name: km2


### PR DESCRIPTION
### Proposed Changes

* Use the platform repo checked out by start-up-with-containers for the start-additional-kas action (instead of opentdf/platform@main).

### Checklist

- [ ] I have added or updated unit tests
- [ ] I have added or updated integration tests (if appropriate)
- [ ] I have added or updated documentation

### Testing Instructions

CI only.