### PR TITLE
chore(xtest): Pins composite action refs

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -497,7 +497,6 @@ jobs:
         with:
           ec-tdf-enabled: true
           kas-port: 8484
-          key-management: ${{ steps.km-check.outputs.supported }}
           kas-name: delta
           root-key: ${{ steps.km-check.outputs.root_key }}
 


### PR DESCRIPTION
Hopefully this reduces the frequency of errors introduced due to untested updates to the action