### PR TITLE
fix: key_management skip decrypt_sdk js v0.2.0 

### DIFF
--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -820,6 +820,7 @@ def test_import_legacy_golden_r1_key_and_decrypt_no_split(
 ):
     if not in_focus & {decrypt_sdk}:
         pytest.skip("Not in focus")
+    tdfs.skip_if_unsupported(decrypt_sdk, "key_management")
     if not decrypt_sdk.supports("hexless"):
         pytest.skip("Decrypting hexless files is not supported")
 
@@ -845,6 +846,7 @@ def test_encrypt_decrypt_all_containers_with_base_key_e1(
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_if_unsupported(encrypt_sdk, "key_management")
+    tdfs.skip_if_unsupported(decrypt_sdk, "key_management")
     pfs = tdfs.PlatformFeatureSet()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)


### PR DESCRIPTION
This pull request makes minor improvements to the ABAC test suite by ensuring that tests are only run when the required key management feature is supported by both the encryption and decryption SDKs. This helps prevent unnecessary test failures when running on unsupported platforms.

Test robustness improvements:

* Added a call to `tdfs.skip_if_unsupported(decrypt_sdk, "key_management")` in `test_import_legacy_golden_r1_key_and_decrypt_no_split` to skip the test if the decrypt SDK does not support key management.
* Added a call to `tdfs.skip_if_unsupported(decrypt_sdk, "key_management")` in `test_encrypt_decrypt_all_containers_with_base_key_e1` for the same reason.