### PR TITLE
fix(xtest): normalize refs/heads/ prefix in version resolution

### DIFF
--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
@@ -155,7 +155,9 @@ def resolve(
 
     try:
         repo = Git()
-        if version == "main" or version == "refs/heads/main":
+        if version.startswith("refs/heads/"):
+            version = version[len("refs/heads/"):]
+        if version == "main":
             all_heads = [r.split("\t") for r in repo.ls_remote(sdk_url, heads=True).split("\n")]
             try:
                 sha, _ = next(tag for tag in all_heads if "refs/heads/main" in tag)

--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
@@ -155,8 +155,7 @@ def resolve(
 
     try:
         repo = Git()
-        if version.startswith("refs/heads/"):
-            version = version[len("refs/heads/"):]
+        version = version.removeprefix("refs/heads/")
         if version == "main":
             all_heads = [r.split("\t") for r in repo.ls_remote(sdk_url, heads=True).split("\n")]
             try:

--- a/otdf-sdk-mgr/tests/test_resolve.py
+++ b/otdf-sdk-mgr/tests/test_resolve.py
@@ -67,6 +67,18 @@ class TestResolveMain:
         assert is_resolve_success(result)
         assert result["tag"] == "main"
 
+    def test_refs_heads_non_main_branch(self):
+        ls = make_ls_remote(
+            (SHA40, "refs/heads/release/sdk-v0.17"),
+            (SHA40, "refs/heads/main"),
+        )
+        with patch_git(ls):
+            result = resolve("js", "refs/heads/release/sdk-v0.17", None)
+        assert is_resolve_success(result)
+        assert result["head"] is True
+        assert result["tag"] == "release/sdk-v0.17"
+        assert result["sha"] == SHA40
+
 
 # ---------------------------------------------------------------------------
 # resolve() — SHA inputs

--- a/otdf-sdk-mgr/tests/test_resolve.py
+++ b/otdf-sdk-mgr/tests/test_resolve.py
@@ -75,7 +75,7 @@ class TestResolveMain:
         with patch_git(ls):
             result = resolve("js", "refs/heads/release/sdk-v0.17", None)
         assert is_resolve_success(result)
-        assert result["head"] is True
+        assert "head" in result and result["head"] is True
         assert result["tag"] == "release/sdk-v0.17"
         assert result["sha"] == SHA40
 


### PR DESCRIPTION
Resolves refs/heads/<branch> inputs (other than main) by stripping the
prefix before lookup, so callers passing full git refs like
refs/heads/release/sdk-v0.17 no longer fail version resolution.

Example failure this should fix: https://github.com/opentdf/web-sdk/actions/runs/25129340002

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
