### PR TITLE
fix(xtest): Use embedded platform otdfctl in auto

### DIFF
--- a/xtest/setup-cli-tool/action.yaml
+++ b/xtest/setup-cli-tool/action.yaml
@@ -175,14 +175,12 @@ runs:
               checkout_path="${INPUT_PATH}/${INPUT_SDK}/platform-src/${tag}"
             fi
           elif [[ "$INPUT_SDK" == "go" && -n "$PLATFORM_OTDFCTL_DIR" && "$needs_source" == "true" ]]; then
-            # Auto-detect fallback: resolver used standalone repo but the
-            # test job detected otdfctl in the platform checkout.
-            # NOTE: SHA comparison across repos is not meaningful (the standalone
-            # repo and platform repo have different commit histories), so we
-            # cannot safely reuse the platform checkout here. Fall through to
-            # a standalone checkout. To use the platform source, set
-            # otdfctl-source=platform explicitly.
-            echo "::notice::Go version ${tag} resolved from standalone repo; platform checkout available but cannot auto-reuse (different repo). Set otdfctl-source=platform to use the platform source."
+            # Auto-detect: resolver used standalone repo but detect-otdfctl found
+            # an embedded otdfctl/ in the platform checkout. PLATFORM_OTDFCTL_DIR
+            # is only set after confirming the directory exists, so reuse it directly.
+            echo "::notice::Go version ${tag} resolved from standalone repo; reusing platform-embedded otdfctl at $PLATFORM_OTDFCTL_DIR."
+            use_existing=true
+            needs_source=false
           fi
 
           echo "needs-checkout-${slot}=${needs_source}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
When detect-otdfctl finds otdfctl/ in the platform checkout, PLATFORM_OTDFCTL_DIR
is set and guaranteed to exist. The auto-detect fallback was previously warning
and falling through to a standalone opentdf/otdfctl checkout, so platform PRs
that embed otdfctl (e.g. for PQC support) were not actually tested against their
own source. Now we set use_existing=true so the symlink step wires sdk/go/src/{tag}
to the platform checkout instead.

Older platform tags (e.g. v0.9.0) are unaffected: detect-otdfctl finds no otdfctl/
directory there, so PLATFORM_OTDFCTL_DIR stays empty and the elif condition is false.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go auto-detect logic in the setup tool to properly reuse existing platform-embedded tools when available, reducing unnecessary reinstallations and improving setup efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->