### PR TITLE
feat(xtest): Allow selecting sdk versions for xtest

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -190,7 +190,7 @@ jobs:
             for (const [sdkType, refInfo] of Object.entries(versionData)) {
               if (sdkType === 'platform') continue;
               for (const { tag, err } of refInfo) {
-                if (!err) sdkVersionList.push(`${sdkType}:${tag}`);
+                if (!err) sdkVersionList.push(`${sdkType}@${tag}`);
               }
             }
             core.setOutput('sdk-version-list', JSON.stringify(sdkVersionList));
@@ -418,7 +418,7 @@ jobs:
         if: >-
           steps.detect-otdfctl.outputs.otdfctl-source != 'platform'
           && fromJson(steps.configure-go.outputs.heads)[0] != null
-          && startsWith(matrix.sdk-version, 'go:')
+          && startsWith(matrix.sdk-version, 'go@')
           && contains(fromJSON(needs.resolve-versions.outputs.heads), matrix.platform-tag)
         env:
           PLATFORM_WORKING_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
@@ -466,7 +466,7 @@ jobs:
       - name: pre-release protocol buffers for java-sdk
         if: >-
           fromJson(steps.configure-java.outputs.heads)[0] != null
-          && (startsWith(matrix.sdk-version, 'go:') || startsWith(matrix.sdk-version, 'java:'))
+          && (startsWith(matrix.sdk-version, 'go@') || startsWith(matrix.sdk-version, 'java@'))
           && contains(fromJSON(needs.resolve-versions.outputs.heads), matrix.platform-tag)
         run: |-
           echo "Replacing .env files for java-sdk..."

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -709,19 +709,24 @@ jobs:
           KAS_KM1_LOG_FILE: "../../${{ steps.kas-km1.outputs.log-file }}"
           KAS_KM2_LOG_FILE: "../../${{ steps.kas-km2.outputs.log-file }}"
 
+      - name: Sanitize sdk-version for artifact name
+        id: artifact-name
+        if: success() || failure()
+        run: echo "sdk_version=${ENCRYPT_SDK//\//-}" >> "$GITHUB_OUTPUT"
+
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         id: upload-artifact
         if: success() || failure()
         with:
-          name: ${{ job.status == 'success' && '✅' || job.status == 'failure' && '❌' }} ${{ matrix.sdk-version }}-${{matrix.platform-tag}}
+          name: ${{ job.status == 'success' && '✅' || job.status == 'failure' && '❌' }} ${{ steps.artifact-name.outputs.sdk_version }}-${{ matrix.platform-tag }}
           path: otdftests/xtest/test-results/*.html
 
       - name: Upload audit logs on failure
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
-          name: audit-logs-${{ matrix.sdk-version }}-${{ matrix.platform-tag }}
+          name: audit-logs-${{ steps.artifact-name.outputs.sdk_version }}-${{ matrix.platform-tag }}
           path: otdftests/xtest/test-results/audit-logs/*.log
           if-no-files-found: ignore
 

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -274,6 +274,7 @@ jobs:
     env:
       FOCUS_SDK: ${{ inputs.focus-sdk || 'all' }}
       ENCRYPT_SDK: ${{ matrix.sdk-version }}
+      SKIP_RELEASED_PAIRS: ${{ github.event_name != 'workflow_dispatch' }}
     strategy:
       fail-fast: false
       matrix:
@@ -569,7 +570,8 @@ jobs:
       ######## RUN THE TESTS #############
       - name: Run legacy decryption tests
         run: |-
-          uv run pytest -n auto --dist worksteal --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-decrypt "${ENCRYPT_SDK}" -ra -v --focus "$FOCUS_SDK" test_legacy.py
+          skip_flag=$([[ "$SKIP_RELEASED_PAIRS" == "true" ]] && echo "--skip-released-pairs" || echo "")
+          uv run pytest -n auto --dist worksteal --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-decrypt "${ENCRYPT_SDK}" -ra -v --focus "$FOCUS_SDK" $skip_flag test_legacy.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
@@ -578,7 +580,8 @@ jobs:
       - name: Run all standard xtests
         if: ${{ env.FOCUS_SDK == 'all' }}
         run: |-
-          uv run pytest -n auto --dist loadscope --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-encrypt "${ENCRYPT_SDK}" -ra -v test_tdfs.py test_policytypes.py test_pqc.py
+          skip_flag=$([[ "$SKIP_RELEASED_PAIRS" == "true" ]] && echo "--skip-released-pairs" || echo "")
+          uv run pytest -n auto --dist loadscope --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-encrypt "${ENCRYPT_SDK}" -ra -v $skip_flag test_tdfs.py test_policytypes.py test_pqc.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
@@ -588,7 +591,8 @@ jobs:
       - name: Run xtests focusing on a specific SDK
         if: ${{ env.FOCUS_SDK != 'all' }}
         run: |-
-          uv run pytest -n auto --dist loadscope --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-encrypt "${ENCRYPT_SDK}" -ra -v --focus "$FOCUS_SDK" test_tdfs.py test_policytypes.py test_pqc.py
+          skip_flag=$([[ "$SKIP_RELEASED_PAIRS" == "true" ]] && echo "--skip-released-pairs" || echo "")
+          uv run pytest -n auto --dist loadscope --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-encrypt "${ENCRYPT_SDK}" -ra -v --focus "$FOCUS_SDK" $skip_flag test_tdfs.py test_policytypes.py test_pqc.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
@@ -683,18 +687,16 @@ jobs:
 
       - name: Run attribute based configuration tests
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        run: >-
-          uv run pytest
-          -ra
-          -v
-          --numprocesses auto
-          --dist loadscope
-          --html test-results/attributes-${FOCUS_SDK}-${PLATFORM_TAG}.html
-          --self-contained-html
-          --audit-log-dir test-results/audit-logs
-          --sdks-encrypt "${ENCRYPT_SDK}"
-          --focus "$FOCUS_SDK"
-          test_abac.py
+        run: |-
+          skip_flag=$([[ "$SKIP_RELEASED_PAIRS" == "true" ]] && echo "--skip-released-pairs" || echo "")
+          uv run pytest -ra -v --numprocesses auto --dist loadscope \
+            --html test-results/attributes-${FOCUS_SDK}-${PLATFORM_TAG}.html \
+            --self-contained-html \
+            --audit-log-dir test-results/audit-logs \
+            --sdks-encrypt "${ENCRYPT_SDK}" \
+            --focus "$FOCUS_SDK" \
+            $skip_flag \
+            test_abac.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -775,9 +775,9 @@ jobs:
       contents: read
     steps:
       - name: Assert all matrix jobs passed
-        if: ${{ needs.xct.result == 'failure' || needs.xct.result == 'cancelled' }}
+        if: ${{ needs.xct.result == 'failure' || needs.xct.result == 'cancelled' || needs.xct.result == 'skipped' }}
         run: |-
-          echo "xct matrix had failures (overall result: ${XCT_RESULT}). Marking xtest failed." >> "$GITHUB_STEP_SUMMARY"
+          echo "xct matrix failed or was skipped (overall result: ${XCT_RESULT}). Marking xtest failed." >> "$GITHUB_STEP_SUMMARY"
           exit 1
         env:
           XCT_RESULT: ${{ needs.xct.result }}

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -274,7 +274,7 @@ jobs:
     env:
       FOCUS_SDK: ${{ inputs.focus-sdk || 'all' }}
       ENCRYPT_SDK: ${{ matrix.sdk-version }}
-      SKIP_RELEASED_PAIRS: ${{ github.event_name != 'workflow_dispatch' }}
+      SKIP_RELEASED_PAIRS: ${{ github.event_name != 'workflow_dispatch' && !contains(fromJSON(needs.resolve-versions.outputs.heads), matrix.platform-tag) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -569,7 +569,7 @@ jobs:
       ######## RUN THE TESTS #############
       - name: Run legacy decryption tests
         run: |-
-          uv run pytest -n auto --dist worksteal --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-encrypt "${ENCRYPT_SDK}" -ra -v --focus "$FOCUS_SDK" test_legacy.py
+          uv run pytest -n auto --dist worksteal --html=test-results/sdk-${FOCUS_SDK}-${PLATFORM_TAG}.html --self-contained-html --sdks-decrypt "${ENCRYPT_SDK}" -ra -v --focus "$FOCUS_SDK" test_legacy.py
         working-directory: otdftests/xtest
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -82,6 +82,7 @@ jobs:
       go: ${{ steps.version-info.outputs.go-version-info }}
       java: ${{ steps.version-info.outputs.java-version-info }}
       js: ${{ steps.version-info.outputs.js-version-info }}
+      sdk-version-list: ${{ steps.version-info.outputs.sdk-version-list }}
     env:
       PLATFORM_REF: "${{ inputs.platform-ref }}"
       JS_REF: "${{ inputs.js-ref }}"
@@ -185,6 +186,15 @@ jobs:
 
             core.setOutput('all', JSON.stringify(versionData));
 
+            const sdkVersionList = [];
+            for (const [sdkType, refInfo] of Object.entries(versionData)) {
+              if (sdkType === 'platform') continue;
+              for (const { tag, err } of refInfo) {
+                if (!err) sdkVersionList.push(`${sdkType}:${tag}`);
+              }
+            }
+            core.setOutput('sdk-version-list', JSON.stringify(sdkVersionList));
+
             core.summary.addHeading('Versions under Test', 3);
 
             function artifactLink(sdkType, tag, release, head, source) {
@@ -263,12 +273,12 @@ jobs:
       pull-requests: write # Add comments to PRs
     env:
       FOCUS_SDK: ${{ inputs.focus-sdk || 'all' }}
-      ENCRYPT_SDK: ${{ matrix.sdk }}
+      ENCRYPT_SDK: ${{ matrix.sdk-version }}
     strategy:
       fail-fast: false
       matrix:
         platform-tag: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-list) }}
-        sdk: ["go", "java", "js"]
+        sdk-version: ${{ fromJSON(needs.resolve-versions.outputs.sdk-version-list) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -408,7 +418,7 @@ jobs:
         if: >-
           steps.detect-otdfctl.outputs.otdfctl-source != 'platform'
           && fromJson(steps.configure-go.outputs.heads)[0] != null
-          && env.FOCUS_SDK == 'go'
+          && startsWith(matrix.sdk-version, 'go:')
           && contains(fromJSON(needs.resolve-versions.outputs.heads), matrix.platform-tag)
         env:
           PLATFORM_WORKING_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
@@ -456,7 +466,7 @@ jobs:
       - name: pre-release protocol buffers for java-sdk
         if: >-
           fromJson(steps.configure-java.outputs.heads)[0] != null
-          && (env.FOCUS_SDK == 'go' || env.FOCUS_SDK == 'java')
+          && (startsWith(matrix.sdk-version, 'go:') || startsWith(matrix.sdk-version, 'java:'))
           && contains(fromJSON(needs.resolve-versions.outputs.heads), matrix.platform-tag)
         run: |-
           echo "Replacing .env files for java-sdk..."
@@ -702,14 +712,14 @@ jobs:
         id: upload-artifact
         if: success() || failure()
         with:
-          name: ${{ job.status == 'success' && '✅' || job.status == 'failure' && '❌' }} ${{ matrix.sdk }}-${{matrix.platform-tag}}
+          name: ${{ job.status == 'success' && '✅' || job.status == 'failure' && '❌' }} ${{ matrix.sdk-version }}-${{matrix.platform-tag}}
           path: otdftests/xtest/test-results/*.html
 
       - name: Upload audit logs on failure
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: failure()
         with:
-          name: audit-logs-${{ matrix.sdk }}-${{ matrix.platform-tag }}
+          name: audit-logs-${{ matrix.sdk-version }}-${{ matrix.platform-tag }}
           path: otdftests/xtest/test-results/audit-logs/*.log
           if-no-files-found: ignore
 

--- a/xtest/audit_logs.py
+++ b/xtest/audit_logs.py
@@ -1711,10 +1711,10 @@ class AuditLogAsserter:
 
         if matching:
             context.append("Matching logs:")
-            for log in matching[:10]:
-                context.append(
-                    f"  [{log.timestamp}] {log.service_name}: {log.raw_line}"
-                )
+            context.extend(
+                f"  [{log.timestamp}] {log.service_name}: {log.raw_line}"
+                for log in matching[:10]
+            )
             if len(matching) > 10:
                 context.append(f"  ... and {len(matching) - 10} more")
             context.append("")
@@ -1734,10 +1734,10 @@ class AuditLogAsserter:
             context.append(
                 f"Logs before timeout (last {len(recent_logs)} of {len(all_logs)}):"
             )
-            for log in recent_logs:
-                context.append(
-                    f"  [{log.timestamp}] {log.service_name}: {log.raw_line}"
-                )
+            context.extend(
+                f"  [{log.timestamp}] {log.service_name}: {log.raw_line}"
+                for log in recent_logs
+            )
 
         # Show timeout marker
         if timeout_time:
@@ -1751,10 +1751,10 @@ class AuditLogAsserter:
             context.append(
                 f"Logs AFTER timeout ({len(late_to_show)} of {len(late_logs)} late arrivals):"
             )
-            for log in late_to_show:
-                context.append(
-                    f"  [{log.timestamp}] {log.service_name}: {log.raw_line}"
-                )
+            context.extend(
+                f"  [{log.timestamp}] {log.service_name}: {log.raw_line}"
+                for log in late_to_show
+            )
             if len(late_logs) > 10:
                 context.append(f"  ... and {len(late_logs) - 10} more late arrivals")
             context.append("")

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -61,9 +61,9 @@ def is_type_or_list_of_types(t: typing.Any) -> typing.Callable[[str], typing.Any
 
 
 def sdk_spec_type(v: str) -> str:
-    """Validate SDK specifiers: 'go', 'go:*', 'go:main', 'go:v0.18.0', etc."""
+    """Validate SDK specifiers: 'go', 'go@*', 'go@main', 'go@v0.18.0', etc."""
     for spec in v.split():
-        sdk_type_val = spec.split(":", 1)[0]
+        sdk_type_val = spec.split("@", 1)[0]
         if not tdfs.is_sdk_type(sdk_type_val):
             raise ValueError(f"Invalid SDK type: {sdk_type_val!r}")
     return v

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -61,11 +61,16 @@ def is_type_or_list_of_types(t: typing.Any) -> typing.Callable[[str], typing.Any
 
 
 def sdk_spec_type(v: str) -> str:
-    """Validate SDK specifiers: 'go', 'go@*', 'go@main', 'go@v0.18.0', etc."""
-    for spec in v.split():
-        sdk_type_val = spec.split("@", 1)[0]
-        if not tdfs.is_sdk_type(sdk_type_val):
-            raise ValueError(f"Invalid SDK type: {sdk_type_val!r}")
+    """Validate a whitespace-separated list of SDK specifiers: 'go', 'go@*', 'go@main java@v1.2.0', etc."""
+    specs = v.split()
+    if not specs:
+        raise ValueError("At least one SDK specifier is required")
+    for spec in specs:
+        parts = spec.split("@", 1)
+        if not tdfs.is_sdk_type(parts[0]):
+            raise ValueError(f"Invalid SDK type: {parts[0]!r}")
+        if len(parts) == 2 and not parts[1]:
+            raise ValueError(f"Empty version in SDK specifier {spec!r}; use e.g. go@main, go@v0.18.0, go@*")
     return v
 
 
@@ -103,7 +108,7 @@ def pytest_addoption(parser: pytest.Parser):
     )
     parser.addoption(
         "--sdks",
-        help=f"select which sdks to run by default, unless overridden; one or more of {englist(typing.get_args(tdfs.sdk_type))}, optionally version-qualified (e.g. go:main, go:v0.18.0, go:*)",
+        help=f"select which sdks to run by default, unless overridden; one or more of {englist(typing.get_args(tdfs.sdk_type))}, optionally version-qualified (e.g. go@main, go@v0.18.0, go@*)",
         type=sdk_spec_type,
     )
     parser.addoption(
@@ -159,19 +164,25 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
     subject_sdks: set[tdfs.SDK] = set()
 
     if "encrypt_sdk" in metafunc.fixturenames:
-        e_sdks = [
-            sdk
-            for spec in sdk_specs_opt(["--sdks-encrypt", "--sdks"])
-            for sdk in tdfs.parse_sdk_spec(spec)
-        ]
+        try:
+            e_sdks = [
+                sdk
+                for spec in sdk_specs_opt(["--sdks-encrypt", "--sdks"])
+                for sdk in tdfs.parse_sdk_spec(spec)
+            ]
+        except (FileNotFoundError, ValueError) as e:
+            raise pytest.UsageError(str(e)) from e
         metafunc.parametrize("encrypt_sdk", e_sdks, ids=[str(x) for x in e_sdks])
         subject_sdks |= set(e_sdks)
     if "decrypt_sdk" in metafunc.fixturenames:
-        d_sdks = [
-            sdk
-            for spec in sdk_specs_opt(["--sdks-decrypt", "--sdks"])
-            for sdk in tdfs.parse_sdk_spec(spec)
-        ]
+        try:
+            d_sdks = [
+                sdk
+                for spec in sdk_specs_opt(["--sdks-decrypt", "--sdks"])
+                for sdk in tdfs.parse_sdk_spec(spec)
+            ]
+        except (FileNotFoundError, ValueError) as e:
+            raise pytest.UsageError(str(e)) from e
         metafunc.parametrize("decrypt_sdk", d_sdks, ids=[str(x) for x in d_sdks])
         subject_sdks |= set(d_sdks)
 

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -109,6 +109,11 @@ def pytest_addoption(parser: pytest.Parser):
         help="disable automatic KAS audit log collection",
     )
     parser.addoption(
+        "--skip-released-pairs",
+        action="store_true",
+        help="skip round-trip tests where all SDKs are released artifacts",
+    )
+    parser.addoption(
         "--sdks",
         help=f"select which sdks to run by default, unless overridden; one or more of {englist(typing.get_args(tdfs.sdk_type))}, optionally version-qualified (e.g. go@main, go@v0.18.0, go@*)",
         type=sdk_spec_type,
@@ -209,6 +214,18 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
         else:
             containers = list(typing.get_args(tdfs.container_type))
         metafunc.parametrize("container", containers)
+
+
+def pytest_runtest_setup(item: pytest.Item):
+    if not item.config.getoption("--skip-released-pairs", default=False):
+        return
+    params = getattr(item, "callspec", None)
+    if params is None:
+        return
+    e = params.params.get("encrypt_sdk")
+    d = params.params.get("decrypt_sdk")
+    if e is not None and d is not None and e.is_released() and d.is_released():
+        pytest.skip(f"released-only pair ({e} × {d})")
 
 
 # Core fixtures

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -64,7 +64,7 @@ def sdk_spec_type(v: str) -> str:
     """Validate SDK specifiers: 'go', 'go:*', 'go:main', 'go:v0.18.0', etc."""
     for spec in v.split():
         sdk_type_val = spec.split(":", 1)[0]
-        if sdk_type_val not in typing.get_args(tdfs.sdk_type):
+        if not tdfs.is_sdk_type(sdk_type_val):
             raise ValueError(f"Invalid SDK type: {sdk_type_val!r}")
     return v
 

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -60,6 +60,15 @@ def is_type_or_list_of_types(t: typing.Any) -> typing.Callable[[str], typing.Any
     return is_a
 
 
+def sdk_spec_type(v: str) -> str:
+    """Validate SDK specifiers: 'go', 'go:*', 'go:main', 'go:v0.18.0', etc."""
+    for spec in v.split():
+        sdk_type_val = spec.split(":", 1)[0]
+        if sdk_type_val not in typing.get_args(tdfs.sdk_type):
+            raise ValueError(f"Invalid SDK type: {sdk_type_val!r}")
+    return v
+
+
 def pytest_addoption(parser: pytest.Parser):
     """Add custom CLI options for pytest."""
     parser.addoption(
@@ -94,18 +103,18 @@ def pytest_addoption(parser: pytest.Parser):
     )
     parser.addoption(
         "--sdks",
-        help=f"select which sdks to run by default, unless overridden, one or more of {englist(typing.get_args(tdfs.sdk_type))}",
-        type=is_type_or_list_of_types(tdfs.sdk_type),
+        help=f"select which sdks to run by default, unless overridden; one or more of {englist(typing.get_args(tdfs.sdk_type))}, optionally version-qualified (e.g. go:main, go:v0.18.0, go:*)",
+        type=sdk_spec_type,
     )
     parser.addoption(
         "--sdks-decrypt",
-        help="select which sdks to run for decrypt only",
-        type=is_type_or_list_of_types(tdfs.sdk_type),
+        help="select which sdks to run for decrypt only; accepts same format as --sdks",
+        type=sdk_spec_type,
     )
     parser.addoption(
         "--sdks-encrypt",
-        help="select which sdks to run for encrypt only",
-        type=is_type_or_list_of_types(tdfs.sdk_type),
+        help="select which sdks to run for encrypt only; accepts same format as --sdks",
+        type=sdk_spec_type,
     )
 
 
@@ -139,43 +148,29 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
                 raise ValueError(f"Invalid value for {name}: {i}, must be one of {ttt}")
         return a
 
-    def defaulted_list_opt[T](
-        names: list[str], t: typing.Any, default: list[T]
-    ) -> list[T]:
+    def sdk_specs_opt(names: list[str]) -> list[str]:
+        """Return SDK specifier tokens from the first matching option, or all sdk types."""
         for name in names:
             v = metafunc.config.getoption(name)
             if v:
-                return cast(list[T], list_opt(name, t))
-        return default
+                return v.split()
+        return list(typing.get_args(tdfs.sdk_type))
 
     subject_sdks: set[tdfs.SDK] = set()
 
     if "encrypt_sdk" in metafunc.fixturenames:
-        encrypt_sdks: list[tdfs.sdk_type] = []
-        encrypt_sdks = defaulted_list_opt(
-            ["--sdks-encrypt", "--sdks"],
-            tdfs.sdk_type,
-            list(typing.get_args(tdfs.sdk_type)),
-        )
-        # convert list of sdk_type to list of SDK objects
         e_sdks = [
-            v
-            for sdks in [tdfs.all_versions_of(sdk) for sdk in encrypt_sdks]
-            for v in sdks
+            sdk
+            for spec in sdk_specs_opt(["--sdks-encrypt", "--sdks"])
+            for sdk in tdfs.parse_sdk_spec(spec)
         ]
         metafunc.parametrize("encrypt_sdk", e_sdks, ids=[str(x) for x in e_sdks])
         subject_sdks |= set(e_sdks)
     if "decrypt_sdk" in metafunc.fixturenames:
-        decrypt_sdks: list[tdfs.sdk_type] = []
-        decrypt_sdks = defaulted_list_opt(
-            ["--sdks-decrypt", "--sdks"],
-            tdfs.sdk_type,
-            list(typing.get_args(tdfs.sdk_type)),
-        )
         d_sdks = [
-            v
-            for sdks in [tdfs.all_versions_of(sdk) for sdk in decrypt_sdks]
-            for v in sdks
+            sdk
+            for spec in sdk_specs_opt(["--sdks-decrypt", "--sdks"])
+            for sdk in tdfs.parse_sdk_spec(spec)
         ]
         metafunc.parametrize("decrypt_sdk", d_sdks, ids=[str(x) for x in d_sdks])
         subject_sdks |= set(d_sdks)

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -70,7 +70,9 @@ def sdk_spec_type(v: str) -> str:
         if not tdfs.is_sdk_type(parts[0]):
             raise ValueError(f"Invalid SDK type: {parts[0]!r}")
         if len(parts) == 2 and not parts[1]:
-            raise ValueError(f"Empty version in SDK specifier {spec!r}; use e.g. go@main, go@v0.18.0, go@*")
+            raise ValueError(
+                f"Empty version in SDK specifier {spec!r}; use e.g. go@main, go@v0.18.0, go@*"
+            )
     return v
 
 

--- a/xtest/pyproject.toml
+++ b/xtest/pyproject.toml
@@ -70,6 +70,7 @@ select = [
     "B",      # flake8-bugbear
     "C4",     # flake8-comprehensions
     "UP",     # pyupgrade
+    "PERF",   # Perflint
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)

--- a/xtest/pyproject.toml
+++ b/xtest/pyproject.toml
@@ -87,6 +87,8 @@ indent-style = "space"
 [tool.pyright]
 pythonVersion = "3.14"
 typeCheckingMode = "standard"
+venvPath = "."
+venv = ".venv"
 include = ["."]
 exclude = ["**/__pycache__", ".venv", ".ruff_cache", ".pytest_cache", "sdk", "tmp", "golden"]
 reportMissingImports = true

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -529,7 +529,8 @@ def parse_sdk_spec(spec: str) -> list[SDK]:
     """
     if ":" in spec:
         sdk_type_val, version = spec.split(":", 1)
-        assert is_sdk_type(sdk_type_val), f"Unknown SDK type: {sdk_type_val!r}"
+        if not is_sdk_type(sdk_type_val):
+            raise ValueError(f"Unknown SDK type: {sdk_type_val!r}")
         if version == "*":
             return all_versions_of(sdk_type_val)
         return [SDK(sdk_type_val, version)]

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -8,7 +8,7 @@ import subprocess
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeIs, get_args
 
 import jsonschema
 import pytest
@@ -22,6 +22,11 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 
 sdk_type = Literal["go", "java", "js"]
+
+
+def is_sdk_type(val: str) -> TypeIs[sdk_type]:
+    return val in get_args(sdk_type)
+
 
 focus_type = Literal[sdk_type, "all"]
 
@@ -524,9 +529,11 @@ def parse_sdk_spec(spec: str) -> list[SDK]:
     """
     if ":" in spec:
         sdk_type_val, version = spec.split(":", 1)
+        assert is_sdk_type(sdk_type_val), f"Unknown SDK type: {sdk_type_val!r}"
         if version == "*":
             return all_versions_of(sdk_type_val)
         return [SDK(sdk_type_val, version)]
+    assert is_sdk_type(spec), f"Unknown SDK type: {spec!r}"
     return all_versions_of(spec)
 
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -384,6 +384,9 @@ class SDK:
     def __hash__(self) -> int:
         return hash((self.sdk, self.version))
 
+    def is_released(self) -> bool:
+        return bool(re.match(r"^v\d+\.\d+\.\d+", self.version))
+
     def encrypt(
         self,
         pt_file: Path,

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -533,7 +533,8 @@ def parse_sdk_spec(spec: str) -> list[SDK]:
         if version == "*":
             return all_versions_of(sdk_type_val)
         return [SDK(sdk_type_val, version)]
-    assert is_sdk_type(spec), f"Unknown SDK type: {spec!r}"
+    if not is_sdk_type(spec):
+        raise ValueError(f"Unknown SDK type: {spec!r}")
     return all_versions_of(spec)
 
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -524,11 +524,11 @@ def parse_sdk_spec(spec: str) -> list[SDK]:
     """Parse an SDK specifier into SDK objects.
 
     Supports:
-    - "go" or "go:*" → all versions in sdk/go/dist/
-    - "go:main" or "go:v0.18.0" → only that specific version
+    - "go" or "go@*" → all versions in sdk/go/dist/
+    - "go@main" or "go@v0.18.0" → only that specific version
     """
-    if ":" in spec:
-        sdk_type_val, version = spec.split(":", 1)
+    if "@" in spec:
+        sdk_type_val, version = spec.split("@", 1)
         if not is_sdk_type(sdk_type_val):
             raise ValueError(f"Unknown SDK type: {sdk_type_val!r}")
         if version == "*":

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -518,14 +518,14 @@ class SDK:
 
 
 def all_versions_of(sdk: sdk_type) -> list[SDK]:
-    versions: list[SDK] = []
     sdk_path = os.path.join("sdk", sdk, "dist")
     if not os.path.isdir(sdk_path):
         return []
-    for version in os.listdir(sdk_path):
-        if os.path.isdir(os.path.join(sdk_path, version)):
-            versions.append(SDK(sdk, version))
-    return versions
+    return [
+        SDK(sdk, version)
+        for version in os.listdir(sdk_path)
+        if os.path.isdir(os.path.join(sdk_path, version))
+    ]
 
 
 def parse_sdk_spec(spec: str) -> list[SDK]:

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -515,6 +515,21 @@ def all_versions_of(sdk: sdk_type) -> list[SDK]:
     return versions
 
 
+def parse_sdk_spec(spec: str) -> list[SDK]:
+    """Parse an SDK specifier into SDK objects.
+
+    Supports:
+    - "go" or "go:*" → all versions in sdk/go/dist/
+    - "go:main" or "go:v0.18.0" → only that specific version
+    """
+    if ":" in spec:
+        sdk_type_val, version = spec.split(":", 1)
+        if version == "*":
+            return all_versions_of(sdk_type_val)
+        return [SDK(sdk_type_val, version)]
+    return all_versions_of(spec)
+
+
 def skip_if_unsupported(sdk: SDK, *features: feature_type):
     pfs = get_platform_features()
     pfs.skip_if_unsupported(*features)

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -359,6 +359,7 @@ def simple_container(container: container_type) -> container_type:
 
 class SDK:
     sdk: sdk_type
+    version: str
     _supports: dict[feature_type, bool]
 
     def __init__(self, sdk: sdk_type, version: str = "main"):

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -385,7 +385,11 @@ class SDK:
         return hash((self.sdk, self.version))
 
     def is_released(self) -> bool:
-        return bool(re.match(r"^v\d+\.\d+\.\d+", self.version))
+        return bool(
+            re.fullmatch(
+                r"(?:sdk/)?v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", self.version
+            )
+        )
 
     def encrypt(
         self,


### PR DESCRIPTION
## Summary

- Adds version-qualified SDK specifiers (`go@main`, `go@v0.18.0`, `go@*`) to `--sdks`, `--sdks-encrypt`, and `--sdks-decrypt` pytest options
- Replaces the static `sdk: [go, java, js]` CI matrix with a dynamic per-`sdk@version` matrix, so each released or head version of each SDK gets its own test job
- Skips round-trip test pairs where **all** SDKs involved are released artifacts when running non-dispatch CI, to avoid redundant old-vs-old coverage

## Motivation

### Version-qualified SDK selection

Previously the matrix ran one job per SDK type, always using whatever versions happened to be installed. This PR resolves each SDK to explicit versions (via `otdf-sdk-mgr versions resolve`) and parametrizes the matrix over `sdk@version` entries, making it possible to test multiple released versions of the same SDK in a single run and to pin exact versions in CI artifacts.

### Skip released-only pairs

With multiple SDK versions in the matrix, the cross-product of `(encrypt_sdk, decrypt_sdk)` pairs grows quickly. Most of those new pairs are combinations of two already-shipped artifacts — they test code that hasn't changed and add no signal on a PR.

This is analogous to the existing `--focus <sdk>` mechanism, which skips pairs that don't include the focused SDK. The new `--skip-released-pairs` flag (set automatically in CI) skips any round-trip test where both `encrypt_sdk` and `decrypt_sdk` are semver-tagged releases (`v\d+\.\d+\.\d+`).

The flag is **not** set when:
- The event is `workflow_dispatch` — the user explicitly requested a full run
- The platform under test is itself a head build (e.g. `main`) — in that case, testing released SDKs against a new platform IS meaningful for backward-compatibility coverage (covers PRs and cron jobs from `opentdf/platform`)

## Implementation

- `SDK.is_released()` in `tdfs.py` — semver regex on the version string
- `--skip-released-pairs` option + `pytest_runtest_setup` hook in `conftest.py` — auto-skips without touching individual test files
- `SKIP_RELEASED_PAIRS` env var in the CI matrix job, gated on event type and platform head status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --skip-released-pairs to optionally skip tests for released SDK pairs.
  * Tests can target resolved SDK@version entries (SDK plus tag) at runtime.

* **Chores**
  * CI test matrix now uses resolved SDK@version entries and produces clearer artifact names.
  * Test validators and parsing tightened; lint/type-tool configs updated.
  * Aggregate workflow now treats skipped test runs as workflow failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->