### PR TITLE
fix(xtest): correct X-Wing KAO size assertions for ASN.1 wrappedKey format

### DIFF
--- a/xtest/otdfctl.py
+++ b/xtest/otdfctl.py
@@ -312,7 +312,10 @@ class OpentdfCommandLineTool:
         # Handle race condition: if key already exists, return the existing one
         if process.returncode != 0:
             err_str = (err.decode() if err else "") + (out.decode() if out else "")
-            if "Invalid key parameters: invalid algorithm" in err_str:
+            if (
+                "Invalid key parameters: invalid algorithm" in err_str
+                or "key_algorithm_defined" in err_str
+            ):
                 raise InvalidAlgorithm(
                     f"Algorithm not supported by platform: {err_str}"
                 )

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -136,8 +136,10 @@ class PlatformFeatureSet(BaseModel):
         if self.semver >= (0, 13, 0):
             self.features.add("mechanism-ec-curves-384-521")
 
-        # X-Wing hybrid PQ/T KEM support (ML-KEM-768 + X25519)
-        if self.semver >= (0, 14, 0):
+        # X-Wing / secp+ML-KEM hybrid PQ/T KEM support.
+        # Key management API for hpqt:* algorithms landed after service/v0.15.0;
+        # v0.15.0 rejects them with a key_algorithm validation error.
+        if self.semver >= (0, 16, 0):
             self.features.add("mechanism-xwing")
             self.features.add("mechanism-secpmlkem")
 

--- a/xtest/test_pqc.py
+++ b/xtest/test_pqc.py
@@ -32,17 +32,19 @@ def _pem_decoded_len(pem: str) -> int:
 
 
 def assert_xwing_kao_sizes(kao: KeyAccessObject):
-    """Assert that an X-Wing KAO has correctly sized wrappedKey and ephemeralPublicKey."""
+    """Assert that an X-Wing KAO has correctly sized wrappedKey.
+
+    The wrappedKey is an ASN.1 DER structure containing the X-Wing KEM
+    ciphertext (1120 bytes) plus an AES-GCM encrypted DEK (~60 bytes)
+    and ASN.1 framing overhead, so it must be larger than the raw
+    ciphertext alone.  hybrid-wrapped KAOs do not use ephemeralPublicKey.
+    """
     wrapped_len = _b64_decoded_len(kao.wrappedKey)
-    assert wrapped_len == XWING_CIPHERTEXT_SIZE, (
-        f"X-Wing wrappedKey should be {XWING_CIPHERTEXT_SIZE} bytes, got {wrapped_len}"
+    assert wrapped_len > XWING_CIPHERTEXT_SIZE, (
+        f"X-Wing wrappedKey should be > {XWING_CIPHERTEXT_SIZE} bytes, got {wrapped_len}"
     )
-    assert kao.ephemeralPublicKey is not None, (
-        "X-Wing KAO must include an ephemeralPublicKey"
-    )
-    epk_len = _b64_decoded_len(kao.ephemeralPublicKey)
-    assert epk_len == XWING_ENCAPSULATION_KEY_SIZE, (
-        f"X-Wing ephemeralPublicKey should be {XWING_ENCAPSULATION_KEY_SIZE} bytes, got {epk_len}"
+    assert kao.ephemeralPublicKey is None, (
+        "hybrid-wrapped X-Wing KAO should not have ephemeralPublicKey"
     )
 
 


### PR DESCRIPTION

  - Fix `assert_xwing_kao_sizes` in `test_pqc.py` to match the actual ASN.1 DER wrappedKey format
  - wrappedKey contains KEM ciphertext + encrypted DEK + ASN.1 overhead (~1190 bytes), not raw ciphertext (1120 bytes)
  - ephemeralPublicKey is None for hybrid-wrapped KAOs (ciphertext is embedded in wrappedKey)

  ## Test plan
  - [ ] X-Wing roundtrip tests pass size assertions
  - [ ] X-Wing + EC hybrid roundtrip tests pass size assertions
  - [ ] secpmlkem tests unaffected (they already assert `> XWING_CIPHERTEXT_SIZE`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated validation for post-quantum key structure handling to match current hybrid-wrapped behavior.
* **Bug Fixes**
  * CLI key-creation now recognizes additional invalid-algorithm error variants and reports them consistently.
* **Chores**
  * Platform feature-gate threshold for hybrid PQ mechanisms raised to a later release to align with platform rollout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentdf/tests/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->