### PR TITLE
fix(xtest): correct PQC version threshold and algorithm error detection

### DIFF
--- a/xtest/otdfctl.py
+++ b/xtest/otdfctl.py
@@ -312,7 +312,10 @@ class OpentdfCommandLineTool:
         # Handle race condition: if key already exists, return the existing one
         if process.returncode != 0:
             err_str = (err.decode() if err else "") + (out.decode() if out else "")
-            if "Invalid key parameters: invalid algorithm" in err_str:
+            if (
+                "Invalid key parameters: invalid algorithm" in err_str
+                or "key_algorithm_defined" in err_str
+            ):
                 raise InvalidAlgorithm(
                     f"Algorithm not supported by platform: {err_str}"
                 )

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -136,8 +136,10 @@ class PlatformFeatureSet(BaseModel):
         if self.semver >= (0, 13, 0):
             self.features.add("mechanism-ec-curves-384-521")
 
-        # X-Wing hybrid PQ/T KEM support (ML-KEM-768 + X25519)
-        if self.semver >= (0, 14, 0):
+        # X-Wing / secp+ML-KEM hybrid PQ/T KEM support.
+        # Key management API for hpqt:* algorithms landed after service/v0.15.0;
+        # v0.15.0 rejects them with a key_algorithm validation error.
+        if self.semver >= (0, 16, 0):
             self.features.add("mechanism-xwing")
             self.features.add("mechanism-secpmlkem")
 


### PR DESCRIPTION
## Context

This is a prerequisite fix for PR #461 (`fix/DSPX-3356-xwing-kao-size-assertions`), which is failing on two CI jobs:

- `xct (main, go@main)` — all PQC tests fail at decrypt (platform bug, unrelated to this PR)
- `xct (v0.15.0, go@v0.32.0)` — PQC tests ERROR instead of SKIP ← fixed here

## What this fixes

### 1. `tdfs.py` — wrong version threshold for `mechanism-xwing` / `mechanism-secpmlkem`

`mechanism-xwing` was gated at `>= (0, 14, 0)`, but platform v0.15.0 rejects `hpqt:xwing` key creation with:

```json
{"message": "Failed to create kas key: invalid_argument: validation error:\n - key_algorithm: The key_algorithm must be one of the defined values. [key_algorithm_defined]"}
```

This means v0.15.0 passes the version check, reaches key creation, fails, and — because the error string doesn't match the existing guard — crashes the fixture with `AssertionError` instead of calling `pytest.skip`.

Raised threshold to `(0, 16, 0)`, the expected next minor release after the commit that added hpqt:* key management support (one commit past `service/v0.15.0`).

### 2. `otdfctl.py` — missing error string in `InvalidAlgorithm` detection

`kas_registry_create_key` only recognised `"Invalid key parameters: invalid algorithm"` as an unsupported-algorithm signal. Platform v0.15.0 returns a protobuf field-validation error containing `"key_algorithm_defined"` instead. Without the match, the error fell through to `assert process.returncode == 0`, turning what should be a `pytest.skip` into a test `ERROR`.

Added `"key_algorithm_defined"` as a second trigger for `InvalidAlgorithm`.

## What this does NOT fix

The `xct (main, go@main)` failures: all PQC tests encrypt successfully but fail at decrypt — every SDK (go, java) returns exit 1. That is the underlying platform bug (DSPX-3356): the KAS at `main` encodes the `wrappedKey` using `ec:secp384r1` wrapping rather than raw X-Wing KEM encapsulation, producing a ciphertext no SDK can unwrap. That fix belongs in `opentdf/platform`, not the test suite.

> **Note for PR #461**: the assertion changes in that PR (accepting `> 1120` bytes and `ephemeralPublicKey is None`) would mask the broken ciphertext and allow the encrypt assertions to pass while decrypt still fails. Recommend reverting those assertion changes and instead landing this PR first so CI goes green on v0.15.0, then tracking the platform decrypt fix separately.

## Test plan

- [ ] `xct (v0.15.0, go@v0.32.0)`: all `test_pqc.py` cases SKIP cleanly (no ERROR)
- [ ] `xct (main, go@main)`: no change expected (decrypt failures are a platform bug)
- [ ] All other xtest jobs: unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)