### PR TITLE
fix(xtest): bump pqc test service module to next version

### DIFF
--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -137,9 +137,9 @@ class PlatformFeatureSet(BaseModel):
             self.features.add("mechanism-ec-curves-384-521")
 
         # X-Wing / secp+ML-KEM hybrid PQ/T KEM support.
-        # Key management API for hpqt:* algorithms landed after service/v0.15.0;
-        # v0.15.0 rejects them with a key_algorithm validation error.
-        if self.semver >= (0, 16, 0):
+        # Key management API for hpqt:* algorithms landed after service/v0.16.0;
+        # v0.16.0 rejects them with a key_algorithm validation error.
+        if self.semver >= (0, 17, 0):
             self.features.add("mechanism-xwing")
             self.features.add("mechanism-secpmlkem")
 


### PR DESCRIPTION
Release of `service v0.16.0` is failing due to a 400 on one of the PQC tests, which is a code path not yet ready for testing/release since it's still in active development. https://github.com/opentdf/platform/actions/runs/26779244647/job/78955290431?pr=3450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform version requirements for feature compatibility, adjusting the minimum supported platform version from 0.16.0 to 0.17.0 for enhanced key management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->