### PR TITLE
fix(xtest): skip pqc-enabled on platform versions before v0.17

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -275,6 +275,25 @@ jobs:
         run: |-
           echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
 
+      - name: Check PQC support based on platform tag
+        id: pqc-check
+        run: |-
+          if [[ "$PLATFORM_TAG" == "main" ]]; then
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$PLATFORM_TAG" =~ ^v([0-9]+)\.([0-9]+) ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            if [[ "$MAJOR" -gt 0 ]] || [[ "$MINOR" -ge 17 ]]; then
+              echo "supported=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "supported=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_TAG: ${{ matrix.platform-tag }}
+
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers
         id: run-platform
@@ -284,7 +303,7 @@ jobs:
           ec-tdf-enabled: true
           extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
           log-type: json
-          pqc-enabled: true
+          pqc-enabled: ${{ steps.pqc-check.outputs.supported == 'true' }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
@@ -574,7 +593,7 @@ jobs:
           kas-name: alpha
           kas-port: 8181
           log-type: json
-          pqc-enabled: true
+          pqc-enabled: ${{ steps.pqc-check.outputs.supported == 'true' }}
           root-key: ${{ steps.km-check.outputs.root_key }}
 
       - name: Start additional kas
@@ -586,7 +605,7 @@ jobs:
           kas-name: beta
           kas-port: 8282
           log-type: json
-          pqc-enabled: true
+          pqc-enabled: ${{ steps.pqc-check.outputs.supported == 'true' }}
           root-key: ${{ steps.km-check.outputs.root_key }}
 
       - name: Start additional kas
@@ -598,7 +617,7 @@ jobs:
           kas-name: gamma
           kas-port: 8383
           log-type: json
-          pqc-enabled: true
+          pqc-enabled: ${{ steps.pqc-check.outputs.supported == 'true' }}
           root-key: ${{ steps.km-check.outputs.root_key }}
 
       - name: Start additional kas
@@ -610,7 +629,7 @@ jobs:
           kas-port: 8484
           kas-name: delta
           log-type: json
-          pqc-enabled: true
+          pqc-enabled: ${{ steps.pqc-check.outputs.supported == 'true' }}
           root-key: ${{ steps.km-check.outputs.root_key }}
 
       - name: Start additional KM kas (km1)
@@ -623,7 +642,7 @@ jobs:
           kas-name: km1
           kas-port: 8585
           log-type: json
-          pqc-enabled: true
+          pqc-enabled: ${{ steps.pqc-check.outputs.supported == 'true' }}
           root-key: ${{ steps.km-check.outputs.root_key }}
 
       - name: Start additional KM kas (km2)
@@ -636,7 +655,7 @@ jobs:
           key-management: ${{ steps.km-check.outputs.supported }}
           kas-port: 8686
           log-type: json
-          pqc-enabled: true
+          pqc-enabled: ${{ steps.pqc-check.outputs.supported == 'true' }}
           root-key: ${{ steps.km-check.outputs.root_key }}
 
       - name: Run attribute based configuration tests


### PR DESCRIPTION
## Summary

- Adds a `pqc-check` step in the `xct` job that determines whether the platform tag being tested is likely to support PQC (i.e., `main` or a released version `>= v0.17`)
- Replaces all 7 hardcoded `pqc-enabled: true` parameters with `${{ steps.pqc-check.outputs.supported == 'true' }}` so older platform versions don't receive an unsupported input

## Test plan

- [ ] Trigger workflow via `workflow_dispatch` against `main` platform ref — `pqc-enabled` should evaluate to `true`
- [ ] Trigger workflow via `workflow_dispatch` against an older platform ref (e.g., `service/v0.16.x`) — `pqc-enabled` should evaluate to `false`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)