### PR TITLE
chore(xtest): improve subprocess + server-log diagnostics on failure

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -703,6 +703,21 @@ jobs:
           path: otdftests/xtest/test-results/audit-logs/*.log
           if-no-files-found: ignore
 
+      - name: Upload server logs on failure
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: failure()
+        with:
+          name: server-logs-${{ steps.artifact-name.outputs.sdk_version }}-${{ matrix.platform-tag }}
+          path: |
+            ${{ steps.run-platform.outputs.platform-log-file }}
+            ${{ steps.kas-alpha.outputs.log-file }}
+            ${{ steps.kas-beta.outputs.log-file }}
+            ${{ steps.kas-gamma.outputs.log-file }}
+            ${{ steps.kas-delta.outputs.log-file }}
+            ${{ steps.kas-km1.outputs.log-file }}
+            ${{ steps.kas-km2.outputs.log-file }}
+          if-no-files-found: ignore
+
   publish-results:
     runs-on: ubuntu-latest
     needs: xct

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -192,9 +192,5 @@ if [ -n "$XT_WITH_TARGET_MODE" ]; then
   args+=(--with-target-mode "$XT_WITH_TARGET_MODE")
 fi
 
-if java -jar "$SCRIPT_DIR"/cmdline.jar help | grep -q -- '--verbose'; then
-  args+=(--verbose)
-fi
-
 echo java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" --file="$2" ">" "$3"
 java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" --file="$2" >"$3"

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -192,7 +192,7 @@ if [ -n "$XT_WITH_TARGET_MODE" ]; then
   args+=(--with-target-mode "$XT_WITH_TARGET_MODE")
 fi
 
-if java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep -q -- '--verbose'; then
+if java -jar "$SCRIPT_DIR"/cmdline.jar help | grep -q -- '--verbose'; then
   args+=(--verbose)
 fi
 

--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -192,5 +192,9 @@ if [ -n "$XT_WITH_TARGET_MODE" ]; then
   args+=(--with-target-mode "$XT_WITH_TARGET_MODE")
 fi
 
+if java -jar "$SCRIPT_DIR"/cmdline.jar help decrypt | grep -q -- '--verbose'; then
+  args+=(--verbose)
+fi
+
 echo java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" --file="$2" ">" "$3"
 java -jar "$SCRIPT_DIR"/cmdline.jar "${args[@]}" --file="$2" >"$3"

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -542,7 +542,11 @@ class SDK:
         logger.debug(f"enc [{' '.join([fmt_env(local_env)] + c)}]")
         env = dict(os.environ)
         env |= local_env
-        subprocess.check_call(c, env=env)
+        result = subprocess.run(c, env=env, capture_output=True)
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode, c, output=result.stdout, stderr=result.stderr
+            )
 
     def decrypt(
         self,
@@ -583,7 +587,11 @@ class SDK:
         if expect_error:
             subprocess.check_output(c, stderr=subprocess.STDOUT, env=env)
         else:
-            subprocess.check_call(c, env=env)
+            result = subprocess.run(c, env=env, capture_output=True)
+            if result.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    result.returncode, c, output=result.stdout, stderr=result.stderr
+                )
 
     def supports(self, feature: feature_type) -> bool:
         if feature in self._supports:

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -544,6 +544,10 @@ class SDK:
         env |= local_env
         result = subprocess.run(c, env=env, capture_output=True)
         if result.returncode != 0:
+            if result.stdout:
+                logger.error("enc stdout: %s", result.stdout.decode(errors="replace"))
+            if result.stderr:
+                logger.error("enc stderr: %s", result.stderr.decode(errors="replace"))
             raise subprocess.CalledProcessError(
                 result.returncode, c, output=result.stdout, stderr=result.stderr
             )
@@ -589,6 +593,14 @@ class SDK:
         else:
             result = subprocess.run(c, env=env, capture_output=True)
             if result.returncode != 0:
+                if result.stdout:
+                    logger.error(
+                        "dec stdout: %s", result.stdout.decode(errors="replace")
+                    )
+                if result.stderr:
+                    logger.error(
+                        "dec stderr: %s", result.stderr.decode(errors="replace")
+                    )
                 raise subprocess.CalledProcessError(
                     result.returncode, c, output=result.stdout, stderr=result.stderr
                 )


### PR DESCRIPTION
## Increase ability to debug problems in logs

- **`xtest/tdfs.py`** — `encrypt`/`decrypt` now use `subprocess.run(capture_output=True)` and raise `CalledProcessError` carrying stdout/stderr (so output is visible in pytest-xdist worker failures), and log captured stdout/stderr on failure.
- **`.github/workflows/xtest.yml`** — on test-step failure, upload `PLATFORM_LOG_FILE` and each `KAS_*_LOG_FILE` as `server-logs-*` artifacts, so server-side errors that occur before an audit event fires (e.g. a rewrap returning `code=Internal`) can be inspected from CI.

## Why

The audit-log artifact only captures events from tests that reached the KAS; failures before the audit event left no server-side log in CI. Combined with the subprocess output capture, this makes CI failures debuggable without re-running locally.

## Testing

`ruff check`, `ruff format --check`, and `pyright` all pass on `xtest`.