### PR TITLE
fix(xtest): Fixes unbuildable dist paths on merge_group events

### DIFF
--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
@@ -91,28 +91,19 @@ def _classify_sha_match(
 
     mq_match = re.match(MERGE_QUEUE_REGEX, ref)
     if mq_match:
-        to_branch = mq_match.group("branch")
-        pr_number = mq_match.group("pr_number")
-        if to_branch and pr_number:
-            return {
-                "sdk": sdk,
-                "alias": version,
-                "head": True,
-                "pr": pr_number,
-                "sha": sha,
-                "tag": f"mq-{to_branch}-{pr_number}",
-            }
-        suffix = ref.split("refs/heads/gh-readonly-queue/")[-1]
+        # Both named groups are required by MERGE_QUEUE_REGEX, so a match
+        # guarantees they are non-empty.
         return {
             "sdk": sdk,
             "alias": version,
             "head": True,
+            "pr": mq_match.group("pr_number"),
             "sha": sha,
-            "tag": "mq--" + suffix.replace("/", "--"),
+            "tag": f"mq-{mq_match.group('branch')}-{mq_match.group('pr_number')}",
         }
 
     if ref.startswith("refs/heads/"):
-        branch = ref.split("refs/heads/")[-1]
+        branch = ref.removeprefix("refs/heads/")
         return {
             "sdk": sdk,
             "alias": version,
@@ -121,11 +112,9 @@ def _classify_sha_match(
             "tag": branch.replace("/", "--"),
         }
 
-    tag = ref
-    if tag.startswith("refs/tags/"):
-        tag = tag.split("refs/tags/")[-1]
+    tag = ref.removeprefix("refs/tags/")
     if infix:
-        tag = tag.split(f"{infix}/")[-1]
+        tag = tag.removeprefix(f"{infix}/")
     return {
         "sdk": sdk,
         "alias": version,

--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
@@ -119,7 +119,9 @@ def _classify_sha_match(
         "sdk": sdk,
         "alias": version,
         "sha": sha,
-        "tag": tag,
+        # Flatten any slashes left in a namespaced tag (no-op for plain semver)
+        # so it can't reintroduce a nested dist/<tag>/ path.
+        "tag": tag.replace("/", "--"),
     }
 
 

--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
@@ -53,6 +53,87 @@ MERGE_QUEUE_REGEX = (
 SHA_REGEX = r"^[a-f0-9]{7,64}$"
 
 
+def _ref_specificity(ref: str) -> int:
+    """Sort key for refs that share a SHA: PR head, then merge-queue, then rest."""
+    if ref.startswith("refs/pull/"):
+        return 0
+    if re.match(MERGE_QUEUE_REGEX, ref):
+        return 1
+    return 2
+
+
+def _classify_sha_match(
+    sdk: str,
+    version: str,
+    sha: str,
+    ref: str,
+    infix: str | None,
+) -> ResolveSuccess:
+    """Turn a single (sha, ref) pair matched by a SHA lookup into a result.
+
+    Normalizes the ref into a filesystem-safe ``tag`` (slashes flattened to
+    ``--``) and flags branch-like refs (PR heads, merge-queue refs, branches)
+    as ``head`` so callers know to build from source rather than fetch a
+    released artifact. Shared by both single- and multi-match SHA lookups so a
+    merge-queue commit pointed at by only one ref is handled the same as one
+    pointed at by several.
+    """
+    if ref.startswith("refs/pull/"):
+        pr_number = ref.split("/")[2]
+        return {
+            "sdk": sdk,
+            "alias": version,
+            "head": True,
+            "pr": pr_number,
+            "sha": sha,
+            "tag": f"pull-{pr_number}",
+        }
+
+    mq_match = re.match(MERGE_QUEUE_REGEX, ref)
+    if mq_match:
+        to_branch = mq_match.group("branch")
+        pr_number = mq_match.group("pr_number")
+        if to_branch and pr_number:
+            return {
+                "sdk": sdk,
+                "alias": version,
+                "head": True,
+                "pr": pr_number,
+                "sha": sha,
+                "tag": f"mq-{to_branch}-{pr_number}",
+            }
+        suffix = ref.split("refs/heads/gh-readonly-queue/")[-1]
+        return {
+            "sdk": sdk,
+            "alias": version,
+            "head": True,
+            "sha": sha,
+            "tag": "mq--" + suffix.replace("/", "--"),
+        }
+
+    if ref.startswith("refs/heads/"):
+        branch = ref.split("refs/heads/")[-1]
+        return {
+            "sdk": sdk,
+            "alias": version,
+            "head": True,
+            "sha": sha,
+            "tag": branch.replace("/", "--"),
+        }
+
+    tag = ref
+    if tag.startswith("refs/tags/"):
+        tag = tag.split("refs/tags/")[-1]
+    if infix:
+        tag = tag.split(f"{infix}/")[-1]
+    return {
+        "sdk": sdk,
+        "alias": version,
+        "sha": sha,
+        "tag": tag,
+    }
+
+
 def _try_resolve_js_npm(
     sdk: str,
     version: str,
@@ -170,72 +251,12 @@ def _resolve_against(
                     "sha": version,
                     "tag": version,
                 }
-            if len(matching_tags) > 1:
-                for sha, tag in matching_tags:
-                    if tag.startswith("refs/pull/"):
-                        pr_number = tag.split("/")[2]
-                        return {
-                            "sdk": sdk,
-                            "alias": version,
-                            "head": True,
-                            "sha": sha,
-                            "tag": f"pull-{pr_number}",
-                        }
-                for sha, tag in matching_tags:
-                    mq_match = re.match(MERGE_QUEUE_REGEX, tag)
-                    if mq_match:
-                        to_branch = mq_match.group("branch")
-                        pr_number = mq_match.group("pr_number")
-                        if to_branch and pr_number:
-                            return {
-                                "sdk": sdk,
-                                "alias": version,
-                                "head": True,
-                                "pr": pr_number,
-                                "sha": sha,
-                                "tag": f"mq-{to_branch}-{pr_number}",
-                            }
-                        suffix = tag.split("refs/heads/gh-readonly-queue/")[-1]
-                        flattag = "mq--" + suffix.replace("/", "--")
-                        return {
-                            "sdk": sdk,
-                            "alias": version,
-                            "head": True,
-                            "sha": sha,
-                            "tag": flattag,
-                        }
-                    head = False
-                    if tag.startswith("refs/heads/"):
-                        head = True
-                        tag = tag.split("refs/heads/")[-1]
-                    flattag = tag.replace("/", "--")
-                    return {
-                        "sdk": sdk,
-                        "alias": version,
-                        "head": head,
-                        "sha": sha,
-                        "tag": flattag,
-                    }
-
-                return {
-                    "sdk": sdk,
-                    "alias": version,
-                    "err": (
-                        f"SHA {version} points to multiple tags, unable to differentiate: "
-                        f"{', '.join(tag for _, tag in matching_tags)}"
-                    ),
-                }
-            (sha, tag) = matching_tags[0]
-            if tag.startswith("refs/tags/"):
-                tag = tag.split("refs/tags/")[-1]
-            if infix:
-                tag = tag.split(f"{infix}/")[-1]
-            return {
-                "sdk": sdk,
-                "alias": version,
-                "sha": sha,
-                "tag": tag,
-            }
+            # A SHA can be pointed at by several refs at once — e.g. a merge-queue
+            # commit that is both a branch tip and a `gh-readonly-queue` ref.
+            # Prefer the most specific (PR > merge-queue > branch/tag) so the dist
+            # tag is meaningful and source-built refs get flagged as heads.
+            sha, ref = min(matching_tags, key=lambda st: _ref_specificity(st[1]))
+            return _classify_sha_match(sdk, version, sha, ref, infix)
 
         if version.startswith("refs/pull/"):
             merge_heads = [

--- a/otdf-sdk-mgr/tests/test_resolve.py
+++ b/otdf-sdk-mgr/tests/test_resolve.py
@@ -159,6 +159,29 @@ class TestResolveSHA:
         assert result.get("head") is True
         assert result["tag"] == "feature--my-branch"
 
+    def test_single_match_merge_queue(self):
+        # A merge-queue commit is usually pointed at by exactly one ref (the
+        # gh-readonly-queue branch). It must still flatten to an mq tag and be
+        # flagged as a head so the caller builds it from source.
+        mq_ref = f"refs/heads/gh-readonly-queue/main/pr-3630-{SHA40}"
+        ls = make_ls_remote((SHA40, mq_ref))
+        with patch_git(ls):
+            result = resolve("go", SHA40, None)
+        assert is_resolve_success(result)
+        assert result["tag"] == "mq-main-3630"
+        assert result.get("pr") == "3630"
+        assert result.get("head") is True
+
+    def test_single_match_branch_flagged_head(self):
+        # A SHA that points at a single branch ref must flatten slashes and be
+        # flagged as a head (it has no released artifact to install).
+        ls = make_ls_remote((SHA40, "refs/heads/feature/my-branch"))
+        with patch_git(ls):
+            result = resolve("go", SHA40, None)
+        assert is_resolve_success(result)
+        assert result.get("head") is True
+        assert result["tag"] == "feature--my-branch"
+
 
 # ---------------------------------------------------------------------------
 # resolve() — refs/pull/NNN


### PR DESCRIPTION
## Problem

[xtest fails](https://github.com/opentdf/platform/actions/runs/27984367850/job/82822208378) for `merge_group` events from `opentdf/platform` during go CLI setup:

```
tdfs.py:483: in __init__
    raise FileNotFoundError(f"SDK executable not found at path: {self.path}")
E   FileNotFoundError: SDK executable not found at path:
    sdk/go/dist/refs/heads/gh-readonly-queue/main/pr-3630-8a006469dc6e55455a2ce4715415671d39670ef6/cli.sh
```

The `Prepare go cli` step only built `main`, yet the matrix value was `go@refs/heads/gh-readonly-queue/...`.

## Root cause

This is a version-resolution bug in `otdf_sdk_mgr/resolve.py`, not a workflow-config bug.

The platform caller (`opentdf/platform` → `checks.yaml`, `platform-xtest`) passes the go ref as a commit **SHA** (`otdfctl-ref: <merge-sha> main`). On a merge-queue run that SHA is pointed at by exactly **one** ref — the temporary `refs/heads/gh-readonly-queue/main/pr-<n>-<sha>` branch.

`resolve.py` had all the merge-queue / PR / branch normalization (→ `mq-main-N`, `pull-N`, flattened slashes, `head: true`) **only** in the `len(matching_tags) > 1` branch. The single-match path stripped just `refs/tags/`/infix, so it:

1. returned `tag = "refs/heads/gh-readonly-queue/main/pr-…"` — slashes become the bad nested `dist/refs/heads/…` path the test looked for, and
2. never set `head: true`, so `setup-cli-tool` skipped the source checkout/build entirely (only `main`, which *is* flagged head, got built).

## Fix

- Extract `_classify_sha_match()` — normalizes any matched `(sha, ref)` into a filesystem-safe `tag` (slashes → `--`) and flags PR / merge-queue / branch refs as `head`.
- Extract `_ref_specificity()` — when a SHA is pointed at by several refs, prefer PR > merge-queue > branch/tag.
- Route both single- and multi-match SHA lookups through the helper, so a merge-queue commit resolves identically regardless of how many refs point at it. This also drops the previously-dead "unable to differentiate" error path.

Now the example ref resolves to `tag = mq-main-3630`, `head = true`, `pr = 3630` — a clean dist dir that gets source-built, with matrix value `go@mq-main-3630`.

## Testing

- Added `test_single_match_merge_queue` and `test_single_match_branch_flagged_head` regression tests.
- `uv run pytest` — all 135 pass.
- `uv run ruff check .`, `uv run ruff format .`, `uv run pyright` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit SHA resolution to reliably identify pull requests, merge-queue branches, and git branch references with appropriate prioritization and tag formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->