### PR TITLE
fix(xtest): Lets push-to-main SHA resolve bare HEAD right

### DIFF
--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
@@ -54,12 +54,24 @@ SHA_REGEX = r"^[a-f0-9]{7,64}$"
 
 
 def _ref_specificity(ref: str) -> int:
-    """Sort key for refs that share a SHA: PR head, then merge-queue, then rest."""
+    """Sort key for refs that share a SHA, lowest wins.
+
+    PR head, then merge-queue, then a branch, then a tag, then anything else
+    (e.g. the symbolic ``HEAD`` that ``ls-remote`` lists alongside the branch
+    it points at — never a useful dist tag on its own). A branch is preferred
+    over a tag because the SHA path resolves a commit-under-test: the branch
+    case flags it as a ``head`` so it is built from source, whereas a tag that
+    happens to point at the same commit would not be.
+    """
     if ref.startswith("refs/pull/"):
         return 0
     if re.match(MERGE_QUEUE_REGEX, ref):
         return 1
-    return 2
+    if ref.startswith("refs/heads/"):
+        return 2
+    if ref.startswith("refs/tags/"):
+        return 3
+    return 4
 
 
 def _classify_sha_match(

--- a/otdf-sdk-mgr/tests/test_resolve.py
+++ b/otdf-sdk-mgr/tests/test_resolve.py
@@ -182,6 +182,34 @@ class TestResolveSHA:
         assert result.get("head") is True
         assert result["tag"] == "feature--my-branch"
 
+    def test_head_and_branch_prefers_branch(self):
+        # On a push to main the tip SHA is listed by ls-remote as both the
+        # symbolic HEAD and refs/heads/main. Prefer the branch so the dist tag
+        # is "main" (built as a head), not the useless "HEAD".
+        ls = make_ls_remote(
+            (SHA40, "HEAD"),
+            (SHA40, "refs/heads/main"),
+        )
+        with patch_git(ls):
+            result = resolve("go", SHA40, None)
+        assert is_resolve_success(result)
+        assert result["tag"] == "main"
+        assert result.get("head") is True
+
+    def test_branch_preferred_over_tag(self):
+        # A commit-under-test that is both a branch tip and a release tag must
+        # resolve to the branch so it gets head=True (and a source build),
+        # rather than a tag that would not be built.
+        ls = make_ls_remote(
+            (SHA40, "refs/tags/otdfctl/v0.33.0"),
+            (SHA40, "refs/heads/main"),
+        )
+        with patch_git(ls):
+            result = resolve("go", SHA40, None)
+        assert is_resolve_success(result)
+        assert result["tag"] == "main"
+        assert result.get("head") is True
+
 
 # ---------------------------------------------------------------------------
 # resolve() — refs/pull/NNN


### PR DESCRIPTION
## Problem

Follow-up to #532. xtest still fails during go CLI setup, now on **push-to-main** events from `opentdf/platform`, as in [this example failure](https://github.com/opentdf/platform/actions/runs/28032142207/job/82975485936):

```
FileNotFoundError: SDK executable not found at path: sdk/go/dist/HEAD/cli.sh
```

The matrix value was `go@HEAD` and only `main` got built.

## Root cause

The platform caller passes the go ref as the main-tip commit **SHA** (`otdfctl-ref: <sha> main`). On a push to main, `git ls-remote` lists that SHA under **two** refs:

```
<sha>	HEAD
<sha>	refs/heads/main
```

`_ref_specificity` scored every non-PR/non-merge-queue ref equally (`2`), so `min()` kept the **first** entry — the symbolic `HEAD`. That fell through `_classify_sha_match` to the generic tag path, producing `tag = "HEAD"` with no `head` flag. So `setup-cli-tool` skipped the source build (only `main`, separately resolved as a head, was built) and the test looked for the non-existent `dist/HEAD/cli.sh`.

## Fix

Rank real refs above the bare `HEAD`: **PR > merge-queue > branch > tag > other**. Now `refs/heads/main` wins over `HEAD`, giving `tag = "main"`, `head = true` (built from source).

Branch is deliberately ranked **above** tag: the SHA path always resolves a commit-under-test, and only the branch case sets `head=true`. So a commit that is simultaneously a branch tip and a release tag (e.g. right after release-please) still gets a source build rather than resolving to a tag that wouldn't be built.

## Testing

- Added `test_head_and_branch_prefers_branch` and `test_branch_preferred_over_tag`.
- `uv run pytest` — 137 pass.
- `uv run ruff check .`, `uv run ruff format .`, `uv run pyright` — clean.
