### PR TITLE
fix(xtest): use head-built otdfctl for admin key ops so PQ/T tests run on branch refs

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -524,6 +524,7 @@ jobs:
         working-directory: otdftests/xtest
         env:
           PLATFORM_TAG: ${{ matrix.platform-tag }}
+          OTDFCTL_HEADS: ${{ steps.configure-go.outputs.heads }}
 
       - name: Validate otdf-local integration tests
         if: ${{ !inputs }}
@@ -543,6 +544,7 @@ jobs:
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           PLATFORM_TAG: ${{ matrix.platform-tag }}
+          OTDFCTL_HEADS: ${{ steps.configure-go.outputs.heads }}
 
       - name: Run all standard xtests
         if: ${{ env.FOCUS_SDK == 'all' }}
@@ -554,6 +556,7 @@ jobs:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           SCHEMA_FILE: "manifest.schema.json"
           PLATFORM_TAG: ${{ matrix.platform-tag }}
+          OTDFCTL_HEADS: ${{ steps.configure-go.outputs.heads }}
 
       - name: Run xtests focusing on a specific SDK
         if: ${{ env.FOCUS_SDK != 'all' }}
@@ -565,6 +568,7 @@ jobs:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           SCHEMA_FILE: "manifest.schema.json"
           PLATFORM_TAG: ${{ matrix.platform-tag }}
+          OTDFCTL_HEADS: ${{ steps.configure-go.outputs.heads }}
 
       ######## ATTRIBUTE BASED CONFIGURATION #############
 
@@ -674,6 +678,7 @@ jobs:
         env:
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           PLATFORM_TAG: ${{ matrix.platform-tag }}
+          OTDFCTL_HEADS: ${{ steps.configure-go.outputs.heads }}
           PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
           KAS_ALPHA_LOG_FILE: "../../${{ steps.kas-alpha.outputs.log-file }}"
           KAS_BETA_LOG_FILE: "../../${{ steps.kas-beta.outputs.log-file }}"

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -31,35 +31,16 @@ logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"))
 def pytest_report_header() -> list[str]:
     """Surface PlatformFeatureSet detection in the always-visible session header.
 
-    PQ/T mechanism detection (mechanism-xwing, mechanism-secpmlkem, ...) reads
-    km1's startup log and falls back to an HTTP probe. When a mechanism is
-    undetected the corresponding tests *skip*, and pytest does not show captured
-    log output for skipped tests -- so the per-step `pqc-detect:` DEBUG lines
-    would otherwise be invisible in CI. Forcing detection here and echoing the
-    captured `xtest` logs into the report header makes them always visible.
+    Feature detection drives skips (e.g. mechanism-xwing gates the PQ/T tests),
+    and pytest does not show captured output for skipped tests. Echoing the
+    detected version and feature set into the report header makes it visible in
+    CI even when every gated test skips.
     """
-    records: list[str] = []
-
-    class _Collector(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            records.append(self.format(record))
-
-    handler = _Collector()
-    handler.setLevel(logging.DEBUG)
-    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
-    xlog = logging.getLogger("xtest")
-    xlog.addHandler(handler)
-    try:
-        pfs = tdfs.get_platform_features()
-    finally:
-        xlog.removeHandler(handler)
-
-    lines = [
+    pfs = tdfs.get_platform_features()
+    return [
         f"platform version: {pfs.version} (semver={pfs.semver})",
         f"detected features: {', '.join(sorted(pfs.features))}",
     ]
-    lines += [f"  {r}" for r in records if "pqc-detect:" in r]
-    return lines
 
 
 # Load all fixture modules

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -27,6 +27,41 @@ from otdfctl import OpentdfCommandLineTool
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"))
 
+
+def pytest_report_header() -> list[str]:
+    """Surface PlatformFeatureSet detection in the always-visible session header.
+
+    PQ/T mechanism detection (mechanism-xwing, mechanism-secpmlkem, ...) reads
+    km1's startup log and falls back to an HTTP probe. When a mechanism is
+    undetected the corresponding tests *skip*, and pytest does not show captured
+    log output for skipped tests -- so the per-step `pqc-detect:` DEBUG lines
+    would otherwise be invisible in CI. Forcing detection here and echoing the
+    captured `xtest` logs into the report header makes them always visible.
+    """
+    records: list[str] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(self.format(record))
+
+    handler = _Collector()
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    xlog = logging.getLogger("xtest")
+    xlog.addHandler(handler)
+    try:
+        pfs = tdfs.get_platform_features()
+    finally:
+        xlog.removeHandler(handler)
+
+    lines = [
+        f"platform version: {pfs.version} (semver={pfs.semver})",
+        f"detected features: {', '.join(sorted(pfs.features))}",
+    ]
+    lines += [f"  {r}" for r in records if "pqc-detect:" in r]
+    return lines
+
+
 # Load all fixture modules
 pytest_plugins = [
     "fixtures.kas",

--- a/xtest/fixtures/keys.py
+++ b/xtest/fixtures/keys.py
@@ -62,9 +62,16 @@ def _get_or_create_key(
                 wrapping_key=root_key,
                 wrapping_key_id="root",
             )
-        except InvalidAlgorithm:
+        except InvalidAlgorithm as e:
             if required_features:
-                pytest.skip(f"Algorithm {algorithm} not supported by platform")
+                # Surface the underlying platform/otdfctl error so we can tell a
+                # client-side mapping rejection ("invalid algorithm" from
+                # otdfctl sdkHelpers) apart from a server-side protovalidate
+                # rejection ("key_algorithm_defined" CEL on the policy service).
+                pytest.skip(
+                    f"Algorithm {algorithm} not supported by platform "
+                    f"(features={required_features!r}): {e}"
+                )
             raise
     return key
 

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -26,9 +26,22 @@ logging.getLogger().setLevel(logging.DEBUG)
 def _km1_log_path() -> Path | None:
     """Return km1's log file path from env or auto-discovery, or None if absent."""
     if p := os.getenv("KAS_KM1_LOG_FILE"):
-        return Path(p)
+        resolved = Path(p)
+        logger.debug(
+            "pqc-detect: KAS_KM1_LOG_FILE=%r -> %s (cwd=%s, exists=%s)",
+            p,
+            resolved.resolve(),
+            Path.cwd(),
+            resolved.exists(),
+        )
+        return resolved
     platform_dir = os.getenv("PLATFORM_DIR", "../../platform")
     candidate = Path(platform_dir) / "logs" / "kas-km1.log"
+    logger.debug(
+        "pqc-detect: KAS_KM1_LOG_FILE unset; auto-discovery candidate=%s (exists=%s)",
+        candidate.resolve(),
+        candidate.exists(),
+    )
     return candidate if candidate.exists() else None
 
 
@@ -40,26 +53,50 @@ def _algs_from_km1_log() -> set[str]:
     """
     log = _km1_log_path()
     if not log or not log.exists():
+        logger.debug(
+            "pqc-detect: km1 log unavailable (path=%s); algs from log = {}",
+            log,
+        )
         return set()
     algs: set[str] = set()
+    lines_read = 0
+    json_lines = 0
     try:
         with log.open() as f:
             for line in f:
+                lines_read += 1
                 try:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                json_lines += 1
                 if (
                     entry.get("msg") == "kas trust mechanisms initialized"
                     and "mechanisms" in entry
                 ):
-                    return set(entry["mechanisms"])
+                    mechs = set(entry["mechanisms"])
+                    logger.debug(
+                        "pqc-detect: matched 'kas trust mechanisms initialized' "
+                        "after %d lines (%d json); mechanisms=%s",
+                        lines_read,
+                        json_lines,
+                        sorted(mechs),
+                    )
+                    return mechs
                 if entry.get("msg") == "kas config loaded" and "config" in entry:
                     for k in entry["config"].get("keyring", []):
                         if alg := k.get("alg"):
                             algs.add(alg)
     except Exception:
-        pass
+        logger.exception("pqc-detect: failed reading km1 log %s", log)
+    logger.debug(
+        "pqc-detect: no 'kas trust mechanisms initialized' line found in %s "
+        "(read %d lines, %d json); falling back to keyring algs=%s",
+        log,
+        lines_read,
+        json_lines,
+        sorted(algs),
+    )
     return algs
 
 
@@ -93,8 +130,16 @@ def _kas_supports_algorithm(algorithm: str) -> bool:
     )
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
-            return resp.status == 200
-    except Exception:
+            ok = resp.status == 200
+            logger.debug(
+                "pqc-detect: HTTP probe %s for %s -> status=%s",
+                url,
+                algorithm,
+                resp.status,
+            )
+            return ok
+    except Exception as e:
+        logger.debug("pqc-detect: HTTP probe %s for %s failed: %s", url, algorithm, e)
         return False
 
 
@@ -230,18 +275,37 @@ class PlatformFeatureSet(BaseModel):
         # Only attempt on platforms new enough to plausibly have PQ support.
         if self.semver is None or self.semver >= (0, 13, 0):
             algs = _algs_from_km1_log()
+            source = "km1-log"
             if not algs:
+                source = "http-probe"
                 algs = {
                     a
                     for a in ("hpqt:xwing", "hpqt:secp256r1-mlkem768", "mlkem:768")
                     if _kas_supports_algorithm(a)
                 }
+            added: set[str] = set()
             if "hpqt:xwing" in algs:
                 self.features.add("mechanism-xwing")
+                added.add("mechanism-xwing")
             if any(a.startswith("hpqt:secp") for a in algs):
                 self.features.add("mechanism-secpmlkem")
+                added.add("mechanism-secpmlkem")
             if any(a.startswith("mlkem:") for a in algs):
                 self.features.add("mechanism-mlkem")
+                added.add("mechanism-mlkem")
+            logger.debug(
+                "pqc-detect: semver=%s gate=open source=%s algs=%s -> added %s",
+                self.semver,
+                source,
+                sorted(algs),
+                sorted(added) or "<none>",
+            )
+        else:
+            logger.debug(
+                "pqc-detect: semver=%s < (0, 13, 0); skipping PQ/T mechanism "
+                "detection entirely (mechanism-xwing/secpmlkem/mlkem will be absent)",
+                self.semver,
+            )
 
         # DPoP capabilities via well-known. Branch builds report stale semver
         # so we probe the live endpoint instead of gating by version.

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -26,22 +26,9 @@ logging.getLogger().setLevel(logging.DEBUG)
 def _km1_log_path() -> Path | None:
     """Return km1's log file path from env or auto-discovery, or None if absent."""
     if p := os.getenv("KAS_KM1_LOG_FILE"):
-        resolved = Path(p)
-        logger.debug(
-            "pqc-detect: KAS_KM1_LOG_FILE=%r -> %s (cwd=%s, exists=%s)",
-            p,
-            resolved.resolve(),
-            Path.cwd(),
-            resolved.exists(),
-        )
-        return resolved
+        return Path(p)
     platform_dir = os.getenv("PLATFORM_DIR", "../../platform")
     candidate = Path(platform_dir) / "logs" / "kas-km1.log"
-    logger.debug(
-        "pqc-detect: KAS_KM1_LOG_FILE unset; auto-discovery candidate=%s (exists=%s)",
-        candidate.resolve(),
-        candidate.exists(),
-    )
     return candidate if candidate.exists() else None
 
 
@@ -53,50 +40,27 @@ def _algs_from_km1_log() -> set[str]:
     """
     log = _km1_log_path()
     if not log or not log.exists():
-        logger.debug(
-            "pqc-detect: km1 log unavailable (path=%s); algs from log = {}",
-            log,
-        )
+        logger.debug("km1 log not found (path=%s); no algs from log", log)
         return set()
     algs: set[str] = set()
-    lines_read = 0
-    json_lines = 0
     try:
         with log.open() as f:
             for line in f:
-                lines_read += 1
                 try:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                json_lines += 1
                 if (
                     entry.get("msg") == "kas trust mechanisms initialized"
                     and "mechanisms" in entry
                 ):
-                    mechs = set(entry["mechanisms"])
-                    logger.debug(
-                        "pqc-detect: matched 'kas trust mechanisms initialized' "
-                        "after %d lines (%d json); mechanisms=%s",
-                        lines_read,
-                        json_lines,
-                        sorted(mechs),
-                    )
-                    return mechs
+                    return set(entry["mechanisms"])
                 if entry.get("msg") == "kas config loaded" and "config" in entry:
                     for k in entry["config"].get("keyring", []):
                         if alg := k.get("alg"):
                             algs.add(alg)
     except Exception:
-        logger.exception("pqc-detect: failed reading km1 log %s", log)
-    logger.debug(
-        "pqc-detect: no 'kas trust mechanisms initialized' line found in %s "
-        "(read %d lines, %d json); falling back to keyring algs=%s",
-        log,
-        lines_read,
-        json_lines,
-        sorted(algs),
-    )
+        logger.debug("failed reading km1 log %s", log, exc_info=True)
     return algs
 
 
@@ -130,16 +94,9 @@ def _kas_supports_algorithm(algorithm: str) -> bool:
     )
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
-            ok = resp.status == 200
-            logger.debug(
-                "pqc-detect: HTTP probe %s for %s -> status=%s",
-                url,
-                algorithm,
-                resp.status,
-            )
-            return ok
+            return resp.status == 200
     except Exception as e:
-        logger.debug("pqc-detect: HTTP probe %s for %s failed: %s", url, algorithm, e)
+        logger.debug("KAS algorithm probe for %s at %s failed: %s", algorithm, url, e)
         return False
 
 
@@ -275,37 +232,18 @@ class PlatformFeatureSet(BaseModel):
         # Only attempt on platforms new enough to plausibly have PQ support.
         if self.semver is None or self.semver >= (0, 13, 0):
             algs = _algs_from_km1_log()
-            source = "km1-log"
             if not algs:
-                source = "http-probe"
                 algs = {
                     a
                     for a in ("hpqt:xwing", "hpqt:secp256r1-mlkem768", "mlkem:768")
                     if _kas_supports_algorithm(a)
                 }
-            added: set[str] = set()
             if "hpqt:xwing" in algs:
                 self.features.add("mechanism-xwing")
-                added.add("mechanism-xwing")
             if any(a.startswith("hpqt:secp") for a in algs):
                 self.features.add("mechanism-secpmlkem")
-                added.add("mechanism-secpmlkem")
             if any(a.startswith("mlkem:") for a in algs):
                 self.features.add("mechanism-mlkem")
-                added.add("mechanism-mlkem")
-            logger.debug(
-                "pqc-detect: semver=%s gate=open source=%s algs=%s -> added %s",
-                self.semver,
-                source,
-                sorted(algs),
-                sorted(added) or "<none>",
-            )
-        else:
-            logger.debug(
-                "pqc-detect: semver=%s < (0, 13, 0); skipping PQ/T mechanism "
-                "detection entirely (mechanism-xwing/secpmlkem/mlkem will be absent)",
-                self.semver,
-            )
 
         # DPoP capabilities via well-known. Branch builds report stale semver
         # so we probe the live endpoint instead of gating by version.


### PR DESCRIPTION
## Problem

PQ/T tests (`test_pqc.py`: X-Wing, secp+ML-KEM hybrids) **silently skipped on every branch/PR run**, only ever exercised on `main`/nightly. They skipped with:

```
Algorithm hpqt:xwing not supported by platform
```

even when the platform fully supported it (km1's keyring loads `hpqt:*`, and the policy-service `key_algorithm_defined` CEL allows the enum values).

## Root cause

The PQ tests register their keys via the **admin `otdfctl` fixture** (`conftest.load_otdfctl()`), which picks the CLI in this order:

1. `OTDFCTL_HEADS[0]` → `sdk/go/dist/{tag}/otdfctl.sh` (the head build)
2. `sdk/go/dist/main/otdfctl.sh`
3. fallback → `go run github.com/opentdf/otdfctl@latest`

**`OTDFCTL_HEADS` was never set by the workflow.** For any platform/go ref that is a branch (not `main`), `dist/main/otdfctl.sh` doesn't exist either, so the admin CLI fell through to the **released `otdfctl@latest`** — which predates the `hpqt:*` algorithm mapping. It rejected `--algorithm=hpqt:xwing` **client-side, before the request reached the (fully capable) platform**. (Older algorithms like rsa-4096 / ec-384-521 still passed because `@latest` knows them — which is why only hpqt skipped.)

## Fix

Set `OTDFCTL_HEADS: ${{ steps.configure-go.outputs.heads }}` on each pytest step so the admin otdfctl uses the head build (`sdk/go/dist/{tag}/otdfctl`) that matches what's under test. `heads` is `[.tag]`, which matches the `dist/{tag}` build-dir naming.

## Supporting changes

- **`fixtures/keys.py`** — include the underlying otdfctl/platform error in the PQ key-create skip reason. The previous opaque "not supported" message is what hid this for so long; the enriched message is what surfaced the `go run …@latest` smoking gun. Worth keeping permanently.
- **`conftest.py`** — `pytest_report_header` echoes the detected platform version + feature set into the always-visible session header (feature detection gates skips, and pytest hides captured output for skipped tests).
- **`tdfs.py`** — lightweight `logger.debug` breadcrumbs on the PQ-detection failure paths (km1 log missing/unreadable, KAS algorithm probe failure).

## Validation

Dispatched `xtest.yml` against platform branch `revert-3625-DSPX-3396-disable-hybrid` (platform + go both): the `mechanism-xwing` / `mechanism-secpmlkem` tests went from **SKIPPED → PASSED**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Test reports now display detected platform version and feature set in session headers.
  * Enhanced skip messages with detailed feature requirements and error context.
  * Improved debug logging for test diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->