### PR TITLE
fix(xtest): replace brittle per-SDK 403 regexes with shared PERMISSION_DENIED_RE

### DIFF
--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -380,6 +380,18 @@ _partial_version_re = re.compile(
     r"^(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:-([0-9a-zA-Z.-]*))?(?:\+([0-9a-zA-Z.-]*))?$"
 )
 
+# SDK-agnostic matcher for KAS 403 / policy-denial errors from any supported SDK.
+# Intentionally broad and case-insensitive so SDK message tweaks don't break xtest.
+# Current SDK phrasings covered:
+#   go:    "tdf: rewrap request 403"
+#   js:    "403 for [http://...]; rewrap permission denied: forbidden"
+#   gRPC:  "PermissionDenied" / "permission denied" / "permission_denied"
+#   multi-KAS aggregate: "unable to reconstruct split key"
+PERMISSION_DENIED_RE = re.compile(
+    r"403|forbidden|permission.?denied|unable to reconstruct split key",
+    re.IGNORECASE,
+)
+
 
 def manifest(tdf_file: Path) -> Manifest:
     with zipfile.ZipFile(tdf_file, "r") as tdfz:

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -11,9 +11,7 @@ from audit_logs import AuditLogAsserter
 from fixtures.encryption import EncryptFactory
 from test_policytypes import skip_rts_as_needed
 
-rewrap_403_pattern = (
-    "tdf: rewrap request 403|403 for \\[https?://[^\\]]+\\]; rewrap permission denied"
-)
+rewrap_403_pattern = tdfs.PERMISSION_DENIED_RE.pattern
 
 
 dspx1153Fails = []

--- a/xtest/test_policytypes.py
+++ b/xtest/test_policytypes.py
@@ -1,5 +1,4 @@
 import filecmp
-import re
 import subprocess
 from pathlib import Path
 
@@ -96,11 +95,7 @@ def decrypt_or_dont(
             assert isinstance(stderr_content, str)
 
             combined_output = output_content + stderr_content
-            assert re.search(
-                r"forbidden|unable to reconstruct split key",
-                combined_output,
-                re.IGNORECASE,
-            ), (
+            assert tdfs.PERMISSION_DENIED_RE.search(combined_output), (
                 f"decrypt failed with unexpected error: {exc}\nstdout: {output_content}\nstderr: {stderr_content}"
             )
 


### PR DESCRIPTION
## Problem

Several negative-decrypt tests assert on the exact wording of KAS 403 / policy-denial errors. Because each SDK (go, java, js) phrases the error differently, these regexes broke whenever an SDK updated its message — even though the behavior (correct policy denial) was unchanged.

Recent concrete example: the JS SDK changed its rewrap error message, breaking `test_policytypes` and `test_obligations_not_entitled` purely on wording.

**Brittle patterns replaced:**

| File | Location | Old pattern |
|------|----------|-------------|
| `test_policytypes.py` | `decrypt_or_dont()` | `r"forbidden\|unable to reconstruct split key"` |
| `test_abac.py` | module-level `rewrap_403_pattern`, used in 3 tests | `"tdf: rewrap request 403\|403 for \\[https?://[^\\]]+\\]; rewrap permission denied"` |

## Solution

Add `PERMISSION_DENIED_RE` to `tdfs.py` (already imported by every test file) — a single compiled, case-insensitive regex covering the union of current SDK phrasings:

```python
# SDK-agnostic matcher for KAS 403 / policy-denial errors from any supported SDK.
# Intentionally broad and case-insensitive so SDK message tweaks don't break xtest.
PERMISSION_DENIED_RE = re.compile(
    r"403|forbidden|permission.?denied|unable to reconstruct split key",
    re.IGNORECASE,
)
```

**Pattern coverage:**

| Sample string | Matched by |
|---|---|
| `tdf: rewrap request 403` (go) | `403` |
| `403 for [http://localhost:8484]; rewrap permission denied: forbidden` (js) | `403`, `forbidden`, `permission.?denied` |
| `desc = forbidden` | `forbidden` |
| `unable to reconstruct split key` (multi-KAS aggregate) | literal |
| `PermissionDenied` (gRPC) | `permission.?denied` (0-char separator) |
| `permission denied` / `permission_denied` | `permission.?denied` |

## Changes

- **`xtest/tdfs.py`**: add `PERMISSION_DENIED_RE` compiled regex constant
- **`xtest/test_policytypes.py`**: remove `import re`, replace inline regex with `tdfs.PERMISSION_DENIED_RE.search()`
- **`xtest/test_abac.py`**: replace `rewrap_403_pattern` string literal with `tdfs.PERMISSION_DENIED_RE.pattern` (the three call sites are unchanged)

No new dependencies. No test structure changes. Assertions still require a `CalledProcessError` (non-zero exit) before the pattern is checked — the change only makes the denial recognition tolerant of SDK wording differences.