### PR TITLE
fix(xtest): Removes support for not-yet-ready java-sdk mlkem feature

### DIFF
--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -96,11 +96,6 @@ if [ "$1" == "supports" ]; then
       exit 1
       ;;
 
-    mechanism-mlkem)
-      set -o pipefail
-      java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep -i "mlkem:768"
-      exit $?
-      ;;
     mechanism-rsa-4096 | mechanism-ec-curves-384-521)
       # rsa4096 support in >= 0.13.0
       set -o pipefail


### PR DESCRIPTION
While waiting for the catch-22 on the protocol buffer enums

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated feature detection in the command-line tool so it no longer reports support for one specific encryption mechanism check.
  * Improved how supported features are evaluated, with related checks now handled in a cleaner sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->