### PR TITLE
feat(pages): community conformance homepage for all SDK conformance

### DIFF
--- a/.github/actions/start-up-with-containers-macos/action.yml
+++ b/.github/actions/start-up-with-containers-macos/action.yml
@@ -1,0 +1,429 @@
+name: 'start-up-platform-macos-native'
+
+description: >-
+  Start OpenTDF platform dependencies natively on macOS (no Docker/Colima):
+  Homebrew PostgreSQL, Keycloak JVM distribution, then platform binary.
+  Outputs match opentdf/platform test/start-up-with-containers for xtest.
+
+inputs:
+  platform-ref:
+    required: false
+    description: 'The ref to check out for the platform'
+    default: 'main'
+  extra-keys:
+    required: false
+    description: >-
+      JSON array of extra KAS keys (kid, alg, privateKey, cert). Stage-1 may pass [].
+    default: '[]'
+  ec-tdf-enabled:
+    default: 'false'
+    description: 'Whether to enable ECC wrapping for TDFs'
+    required: false
+  pqc-enabled:
+    default: 'false'
+    description: 'Whether to enable post-quantum / hybrid wrapping'
+    required: false
+  log-level:
+    default: 'debug'
+    description: 'Log level for the platform'
+    required: false
+  log-type:
+    default: 'json'
+    description: 'Log format type (text, json)'
+    required: false
+  provision-policy-fixtures:
+    default: 'true'
+    description: 'Whether to provision fixture policy data'
+    required: false
+  keycloak-version:
+    default: '25.0.6'
+    description: 'Keycloak release version (must match platform CI image major)'
+    required: false
+
+outputs:
+  platform-working-dir:
+    description: 'Working directory for the running platform instance'
+    value: 'otdf-test-platform'
+  platform-log-file:
+    description: 'Path to the main platform/KAS log file'
+    value: ${{ steps.log-path.outputs.log-file }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        PLATFORM_REF: ${{ inputs.platform-ref }}
+        EXTRA_KEYS: ${{ inputs.extra-keys }}
+        EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
+        PQC_ENABLED: ${{ inputs.pqc-enabled }}
+        LOG_LEVEL: ${{ inputs.log-level }}
+        LOG_TYPE: ${{ inputs.log-type }}
+        PROVISION_POLICY_FIXTURES: ${{ inputs.provision-policy-fixtures }}
+      run: |
+        set -euo pipefail
+        if [[ ! "${PLATFORM_REF}" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+          echo "Error: platform-ref has invalid characters."
+          exit 1
+        fi
+        if ! jq -e 'type == "array"' <<< "${EXTRA_KEYS}" >/dev/null 2>&1; then
+          echo "Error: extra-keys must be a JSON array."
+          exit 1
+        fi
+        case "${EC_TDF_ENABLED}" in true|false) ;; *) echo "bad ec-tdf-enabled"; exit 1 ;; esac
+        case "${PQC_ENABLED}" in true|false) ;; *) echo "bad pqc-enabled"; exit 1 ;; esac
+        case "${LOG_LEVEL}" in audit|debug|info|warn|error) ;; *) echo "bad log-level"; exit 1 ;; esac
+        case "${LOG_TYPE}" in text|json) ;; *) echo "bad log-type"; exit 1 ;; esac
+        case "${PROVISION_POLICY_FIXTURES}" in true|false) ;; *) echo "bad provision-policy-fixtures"; exit 1 ;; esac
+
+    - name: Check out platform
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: opentdf/platform
+        path: otdf-test-platform
+        ref: ${{ inputs.platform-ref }}
+        persist-credentials: false
+
+    - name: Ensure jq / yq / openssl tooling
+      shell: bash
+      run: |
+        set -euo pipefail
+        command -v jq >/dev/null || brew install jq
+        command -v yq >/dev/null || brew install yq
+        command -v openssl >/dev/null || brew install openssl@3
+        jq --version
+        yq --version
+
+    - name: Install OpenJDK (keytool + Keycloak)
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew install openjdk@21
+        # Intel Homebrew: /usr/local ; Apple Silicon: /opt/homebrew
+        if [[ -d "$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home" ]]; then
+          echo "JAVA_HOME=$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home" >> "$GITHUB_ENV"
+          echo "$(brew --prefix openjdk@21)/bin" >> "$GITHUB_PATH"
+        else
+          echo "JAVA_HOME=$(/usr/libexec/java_home -v 21)" >> "$GITHUB_ENV"
+        fi
+
+    - name: Install and start PostgreSQL 15 (native)
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew install postgresql@15
+        export PATH="$(brew --prefix postgresql@15)/bin:$PATH"
+        echo "$(brew --prefix postgresql@15)/bin" >> "$GITHUB_PATH"
+
+        PGDATA="${RUNNER_TEMP}/opentdf-pgdata"
+        echo "PGDATA=$PGDATA" >> "$GITHUB_ENV"
+        rm -rf "$PGDATA"
+        initdb -D "$PGDATA" --username=postgres --auth=trust --no-locale --encoding=UTF8
+        pg_ctl -D "$PGDATA" -l "${RUNNER_TEMP}/postgres.log" -o "-p 5432 -k ${RUNNER_TEMP}" start
+        # Wait for accept
+        for i in $(seq 1 30); do
+          if pg_isready -h localhost -p 5432 -U postgres; then break; fi
+          sleep 1
+        done
+        # Platform defaults: user postgres / password changeme / db opentdf
+        psql -h localhost -p 5432 -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
+        ALTER USER postgres WITH PASSWORD 'changeme';
+        SELECT 'ok' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'opentdf');
+        SQL
+        psql -h localhost -p 5432 -U postgres -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='opentdf'" | grep -q 1 \
+          || psql -h localhost -p 5432 -U postgres -d postgres -c "CREATE DATABASE opentdf OWNER postgres;"
+        echo "PostgreSQL ready on localhost:5432 (db=opentdf)"
+
+    - name: Set up Go (platform go.work)
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      with:
+        go-version-file: 'otdf-test-platform/go.work'
+        check-latest: false
+        cache-dependency-path: |
+          otdf-test-platform/service/go.sum
+          otdf-test-platform/protocol/go/go.sum
+          otdf-test-platform/sdk/go.sum
+
+    - name: Lookup platform version
+      shell: bash
+      id: platform-version
+      working-directory: otdf-test-platform
+      run: |
+        set -euo pipefail
+        if ! go run ./service version; then
+          echo "semver=0.0.0" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        raw_version=$(go run ./service version 2>&1)
+        sanitized_version=$(echo "$raw_version" | tr -cd '0-9a-zA-Z.+-')
+        if [[ "$sanitized_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          echo "semver=$sanitized_version" >> "$GITHUB_OUTPUT"
+        else
+          echo "semver=0.0.0" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Generate KAS / TLS keys (no Docker)
+      shell: bash
+      working-directory: otdf-test-platform
+      run: |
+        set -euo pipefail
+        # Same crypto as init-temp-keys.sh, but keytool runs on the host JDK
+        # (upstream script shells out to docker for keytool only).
+        opt_output="."
+        openssl genpkey -algorithm RSA -out "$opt_output/kas-private.pem" -pkeyopt rsa_keygen_bits:2048
+        openssl rsa -in "$opt_output/kas-private.pem" -pubout -out "$opt_output/kas-cert.pem"
+        openssl ecparam -name prime256v1 >ecparams.tmp
+        openssl req -x509 -nodes -newkey ec:ecparams.tmp -subj "/CN=kas" \
+          -keyout "$opt_output/kas-ec-private.pem" -out "$opt_output/kas-ec-cert.pem" -days 365
+        go run ./service/cmd/keygen -output "$opt_output"
+
+        mkdir -p keys
+        openssl req -x509 -nodes -newkey RSA:2048 -subj "/CN=ca" \
+          -keyout keys/keycloak-ca-private.pem -out keys/keycloak-ca.pem -days 365
+        printf "subjectAltName=DNS:localhost,IP:127.0.0.1" >keys/sanX509.conf
+        printf "[req]\ndistinguished_name=req_distinguished_name\n[req_distinguished_name]\n[alt_names]\nDNS.1=localhost\nIP.1=127.0.0.1" >keys/req.conf
+        openssl req -new -nodes -newkey rsa:2048 -keyout keys/localhost.key -out keys/localhost.req \
+          -batch -subj "/CN=localhost" -config keys/req.conf
+        openssl x509 -req -in keys/localhost.req -CA keys/keycloak-ca.pem -CAkey keys/keycloak-ca-private.pem \
+          -CAcreateserial -out keys/localhost.crt -days 3650 -sha256 -extfile keys/sanX509.conf
+        openssl pkcs12 -export -in keys/keycloak-ca.pem -inkey keys/keycloak-ca-private.pem \
+          -out keys/ca.p12 -nodes -passout pass:password
+        keytool -importkeystore \
+          -srckeystore keys/ca.p12 -srcstoretype PKCS12 \
+          -destkeystore keys/ca.jks -deststoretype JKS \
+          -srcstorepass password -deststorepass password -noprompt
+        # Place default RSA/EC key material next to config for cryptoProvider paths
+        cp -f kas-private.pem kas-cert.pem kas-ec-private.pem kas-ec-cert.pem keys/ 2>/dev/null || true
+        chmod -R a+rX keys
+        ls -la keys | head -30
+
+    - name: Map config keys + enable Stage-1 options
+      shell: bash
+      working-directory: otdf-test-platform
+      env:
+        EXTRA_KEYS: ${{ inputs.extra-keys }}
+        PLATFORM_VERSION: ${{ steps.platform-version.outputs.semver }}
+        EC_TDF_ENABLED: ${{ inputs.ec-tdf-enabled }}
+        PQC_ENABLED: ${{ inputs.pqc-enabled }}
+        LOG_LEVEL: ${{ inputs.log-level }}
+        LOG_TYPE: ${{ inputs.log-type }}
+      run: |
+        set -euo pipefail
+        allowed_algorithms=(ec:secp256r1 rsa:2048)
+        if echo "$PLATFORM_VERSION" | awk -F. '{ if ($1 > 0 || ($1 == 0 && $2 > 7) || ($1 == 0 && $2 == 7 && $3 >= 1)) exit 0; else exit 1; }'; then
+          allowed_algorithms+=(rsa:4096 ec:secp384r1 ec:secp521r1 hpqt:xwing hpqt:secp256r1-mlkem768 hpqt:secp384r1-mlkem1024)
+        fi
+        keyring='[{"kid":"ec1","alg":"ec:secp256r1"},{"kid":"r1","alg":"rsa:2048"}]'
+        keys='[{"kid":"e1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"ec1","alg":"ec:secp256r1","private":"kas-ec-private.pem","cert":"kas-ec-cert.pem"},{"kid":"r1","alg":"rsa:2048","private":"kas-private.pem","cert":"kas-cert.pem"}]'
+        while IFS= read -r key_json; do
+          [[ -z "$key_json" || "$key_json" == "null" ]] && continue
+          alg="$(jq -r '.alg' <<< "${key_json}")"
+          kid="$(jq -r '.kid' <<< "${key_json}")"
+          if [[ ! " ${allowed_algorithms[*]} " =~ " ${alg} " ]]; then
+            echo "skip extra key alg=$alg kid=$kid"
+            continue
+          fi
+          if [[ ! "${kid}" =~ ^[-0-9a-zA-Z_]+$ ]]; then
+            echo "invalid kid $kid" >&2
+            exit 1
+          fi
+          private_pem="$(jq -r '.privateKey' <<< "${key_json}")"
+          cert_pem="$(jq -r '.cert' <<< "${key_json}")"
+          private_path="${kid}.pem"
+          cert_path="${kid}-cert.pem"
+          echo "${private_pem}" >"${private_path}"
+          echo "${cert_pem}" >"${cert_path}"
+          chmod a+r "${private_path}" "${cert_path}"
+          key_obj="$(jq '{kid, alg, private: $private, cert: $cert}' --arg private "${private_path}" --arg cert "${cert_path}" <<< "${key_json}")"
+          keys="$(jq '. + [$key_obj]' --argjson key_obj "${key_obj}" <<< "${keys}")"
+          keyring_obj="$(jq '{kid, alg}' <<< "${key_json}")"
+          keyring="$(jq '. + [$keyring_obj]' --argjson keyring_obj "${keyring_obj}" <<< "${keyring}")"
+        done < <(jq -c '.[]?' <<< "${EXTRA_KEYS}")
+
+        yq_command="$(printf '(.services.kas.keyring = %s) | (.server.cryptoProvider.standard.keys = %s)' "${keyring}" "${keys}")"
+        <opentdf-dev.yaml >opentdf.yaml yq e "${yq_command}"
+
+        # Explicit local DB (platform defaults, but be clear for native postgres)
+        yq e '
+          (.db.host = "localhost")
+          | (.db.port = 5432)
+          | (.db.user = "postgres")
+          | (.db.password = "changeme")
+          | (.db.database = "opentdf")
+          | (.db.sslmode = "disable")
+        ' -i opentdf.yaml || \
+        yq e '
+          (.db.host = "localhost")
+          | (.db.port = 5432)
+          | (.db.user = "postgres")
+          | (.db.password = "changeme")
+          | (.db.sslmode = "disable")
+        ' -i opentdf.yaml
+
+        if [[ "${EC_TDF_ENABLED}" == "true" ]]; then
+          yq e '.services.kas.ec_tdf_enabled = true' -i opentdf.yaml || \
+            yq e '.services.kas.preview.ec_tdf_enabled = true' -i opentdf.yaml || true
+        fi
+        if [[ "${PQC_ENABLED}" == "true" ]]; then
+          yq e '
+            (.services.kas.preview.hybrid_tdf_enabled = true)
+            | (.services.kas.keyring += [{"kid":"x1","alg":"hpqt:xwing"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024"}])
+            | (.server.cryptoProvider.standard.keys += [{"kid":"x1","alg":"hpqt:xwing","private":"kas-xwing-private.pem","cert":"kas-xwing-public.pem"},{"kid":"h1","alg":"hpqt:secp256r1-mlkem768","private":"kas-p256mlkem768-private.pem","cert":"kas-p256mlkem768-public.pem"},{"kid":"h2","alg":"hpqt:secp384r1-mlkem1024","private":"kas-p384mlkem1024-private.pem","cert":"kas-p384mlkem1024-public.pem"}])
+          ' -i opentdf.yaml || true
+        fi
+        yq e '(.logger.level = env(LOG_LEVEL)) | (.logger.type = env(LOG_TYPE))' -i opentdf.yaml
+        # Prefer 127.0.0.1 over localhost so Go clients don't hit [::1] while KC is IPv4-only.
+        yq e '
+          (.server.auth.issuer = "http://127.0.0.1:8888/auth/realms/opentdf")
+          | (.services.entityresolution.url = "http://127.0.0.1:8888/auth")
+        ' -i opentdf.yaml
+        echo "--- opentdf.yaml kas/auth snippet ---"
+        yq e '.services.kas.keyring, .server.auth.issuer, .db' opentdf.yaml || true
+
+    - name: Download and start Keycloak (native JVM)
+      shell: bash
+      env:
+        KEYCLOAK_VERSION: ${{ inputs.keycloak-version }}
+      run: |
+        set -euo pipefail
+        KC_ROOT="${RUNNER_TEMP}/keycloak"
+        mkdir -p "$KC_ROOT"
+        archive="keycloak-${KEYCLOAK_VERSION}.tar.gz"
+        url="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/${archive}"
+        echo "Downloading $url"
+        curl -fsSL -o "${RUNNER_TEMP}/${archive}" "$url"
+        tar -xzf "${RUNNER_TEMP}/${archive}" -C "$KC_ROOT" --strip-components=1
+
+        export KEYCLOAK_ADMIN=admin
+        export KEYCLOAK_ADMIN_PASSWORD=changeme
+        export KC_HTTP_ENABLED=true
+        export KC_HTTP_PORT=8888
+        export KC_HTTP_RELATIVE_PATH=/auth
+        export KC_HOSTNAME_STRICT=false
+        export KC_HOSTNAME_STRICT_HTTPS=false
+        export KC_PROXY=edge
+        export KC_FEATURES=preview,token-exchange
+        export KC_HEALTH_ENABLED=true
+        # Stage-1 uses HTTP IdP URLs in test.env (no container TLS path needed).
+        # Bind HTTP explicitly; prefer 127.0.0.1 for readiness/provision (avoid ::1).
+        nohup "$KC_ROOT/bin/kc.sh" start-dev --verbose \
+          --http-enabled=true \
+          --http-port=8888 \
+          --http-host=0.0.0.0 \
+          --http-relative-path=/auth \
+          --hostname-strict=false \
+          >"${RUNNER_TEMP}/keycloak.log" 2>&1 &
+        echo $! >"${RUNNER_TEMP}/keycloak.pid"
+        echo "Keycloak pid=$(cat "${RUNNER_TEMP}/keycloak.pid")"
+
+        # Ready when admin password grant succeeds (what provision keycloak needs).
+        # Do NOT treat curl http_code 000 as success: `curl ... || echo 000` can yield
+        # "000000" (code 000 + fallback 000) and falsely pass `!= 000`.
+        echo "Waiting for Keycloak admin token on http://127.0.0.1:8888/auth/ ..."
+        ready=0
+        token_url="http://127.0.0.1:8888/auth/realms/master/protocol/openid-connect/token"
+        for i in $(seq 1 120); do
+          code=$(curl -4 -sS -o /tmp/kc-token.out -w "%{http_code}" --connect-timeout 2 \
+            -X POST "$token_url" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "client_id=admin-cli" \
+            --data-urlencode "username=admin" \
+            --data-urlencode "password=changeme" \
+            --data-urlencode "grant_type=password" 2>/dev/null || true)
+          # Strip non-digits; only a real 3-digit response counts.
+          code=$(echo "$code" | tr -cd '0-9' | tail -c 3)
+          if [[ "$code" == "200" ]] && grep -q access_token /tmp/kc-token.out 2>/dev/null; then
+            echo "Keycloak admin token OK after attempt $i"
+            ready=1
+            break
+          fi
+          if (( i % 6 == 0 )); then
+            echo "  still waiting ($i) token_http=$code"
+            tail -8 "${RUNNER_TEMP}/keycloak.log" || true
+          fi
+          sleep 5
+        done
+        if [[ "$ready" != "1" ]]; then
+          echo "::error::Keycloak failed to become ready for admin login"
+          tail -200 "${RUNNER_TEMP}/keycloak.log" || true
+          exit 1
+        fi
+
+    - name: Provision Keycloak realm / clients
+      shell: bash
+      working-directory: otdf-test-platform
+      run: |
+        set -euo pipefail
+        # Force IPv4 loopback — Go's localhost can prefer ::1 and get connection refused
+        # while Keycloak is only (or first) bound for IPv4.
+        go run ./service provision keycloak \
+          --endpoint "http://127.0.0.1:8888/auth" \
+          --username admin \
+          --password changeme
+
+    - name: Provision policy fixtures
+      if: ${{ inputs.provision-policy-fixtures == 'true' }}
+      shell: bash
+      working-directory: otdf-test-platform
+      run: go run ./service provision fixtures
+
+    - name: Set platform log path
+      id: log-path
+      shell: bash
+      run: |
+        LOG_FILE="otdf-test-platform/logs/kas-main.log"
+        mkdir -p otdf-test-platform/logs
+        echo "log-file=$LOG_FILE" >> "$GITHUB_OUTPUT"
+        echo "Platform log file: $LOG_FILE"
+
+    - name: Fetch platform watch.sh helper
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p otdf-test-platform/.github/scripts
+        curl -fsSL \
+          "https://raw.githubusercontent.com/opentdf/platform/refs/tags/pqc-enabled/.github/scripts/watch.sh" \
+          -o otdf-test-platform/.github/scripts/watch.sh
+        chmod +x otdf-test-platform/.github/scripts/watch.sh
+
+    - name: Start platform server in background
+      uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1.0.7
+      with:
+        run: >
+          go build -o opentdf -v service/main.go
+          && mkdir -p logs
+          && .github/scripts/watch.sh --tee-err-to logs/kas-main.log opentdf.yaml ./opentdf start
+        wait-on: |
+          tcp:localhost:8080
+        log-output-if: true
+        wait-for: 120s
+        working-directory: otdf-test-platform
+
+    # Platform server.auth.issuer is http://127.0.0.1:8888/auth/realms/opentdf.
+    # stock xtest/test.env uses localhost:8888 — tokens minted there carry
+    # iss=http://localhost:8888/... and KAS rejects them as unauthenticated.
+    # Only rewrite the Keycloak/IdP host (port 8888). Leave PLATFORMURL/KASURL
+    # on localhost so manifest key-access hosts still match go@latest encrypt.
+    - name: Align test.env IdP host with platform issuer (IPv4)
+      shell: bash
+      run: |
+        set -euo pipefail
+        patched=0
+        for f in \
+          otdftests/xtest/test.env \
+          xtest/test.env \
+          "${GITHUB_WORKSPACE:-}/otdftests/xtest/test.env" \
+          "${GITHUB_WORKSPACE:-}/xtest/test.env"
+        do
+          [[ -f "$f" ]] || continue
+          tmp="${f}.aligned"
+          sed -e 's#http://localhost:8888#http://127.0.0.1:8888#g' "$f" >"$tmp"
+          mv "$tmp" "$f"
+          echo "Aligned Keycloak hosts in $f:"
+          grep -E '^(KCHOST|KCFULLURL|TOKENENDPOINT)=' "$f" || true
+          patched=1
+        done
+        if [[ "$patched" != "1" ]]; then
+          echo "Warning: no test.env found to align (ok if caller exports env another way)"
+        fi

--- a/.github/workflows/community-pages.yml
+++ b/.github/workflows/community-pages.yml
@@ -1,5 +1,8 @@
-# Deploy community conformance report to GitHub Pages (main branch only).
-# Consumes artifacts from Community X-Test runs or regenerates from a dispatch.
+# Deploy the community SDK conformance homepage to GitHub Pages (main only).
+# Consumes every community-* artifact (python/rust/swift stage-1 + stage-2)
+# from the triggering Community X-Test run, or from the latest completed
+# main-branch run on manual dispatch. Deploys on failure conclusions too, so
+# the page honestly shows red instead of going stale.
 name: Community Conformance Pages
 
 on:
@@ -22,6 +25,7 @@ jobs:
   build-site:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -32,74 +36,67 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Download latest community artifacts
+      - name: Locate source Community X-Test run
+        id: source-run
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
-            fs.mkdirSync('artifact-download', { recursive: true });
-            let runId = context.payload.workflow_run?.id;
-            if (!runId) {
+            let run = context.payload.workflow_run;
+            if (!run) {
               const runs = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'community-xtest.yml',
                 branch: 'main',
+                status: 'completed',
                 per_page: 1,
               });
-              runId = runs.data.workflow_runs[0]?.id;
+              run = runs.data.workflow_runs[0];
             }
-            if (!runId) {
-              core.warning('No Community X-Test run found; generating empty site shell');
+            if (!run) {
+              core.warning('No completed Community X-Test run found; publishing empty site shell');
               return;
             }
-            core.info(`Using run ${runId}`);
-            const arts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: runId,
-            });
-            for (const art of arts.data.artifacts) {
-              if (!art.name.includes('community-python')) continue;
-              const { data } = await github.rest.actions.downloadArtifact({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                artifact_id: art.id,
-                archive_format: 'zip',
-              });
-              const zipPath = path.join('artifact-download', `${art.id}.zip`);
-              fs.writeFileSync(zipPath, Buffer.from(data));
-              const { execSync } = require('child_process');
-              execSync(`unzip -o "${zipPath}" -d artifact-download/unpacked`, { stdio: 'inherit' });
-            }
+            core.info(`Using run ${run.id} (${run.html_url})`);
+            core.setOutput('run-id', run.id);
+            core.setOutput('run-url', run.html_url);
+
+      # Artifact names look like "✅ community-python-stage1"; the stage filter
+      # excludes the failure-only community-*-server-logs artifacts.
+      - name: Download community artifacts
+        if: steps.source-run.outputs.run-id != ''
+        continue-on-error: true # a run with no artifacts still gets a page
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: "*community-*stage*"
+          run-id: ${{ steps.source-run.outputs.run-id }}
+          github-token: ${{ github.token }}
+          path: artifact-download
 
       - name: Generate site
         working-directory: xtest
+        env:
+          SOURCE_RUN_ID: ${{ steps.source-run.outputs.run-id }}
+          SOURCE_RUN_URL: ${{ steps.source-run.outputs.run-url }}
         run: |
           uv sync
-          mkdir -p test-results
-          if [ -d ../artifact-download/unpacked ]; then
-            find ../artifact-download/unpacked -name 'supports.json' -print
-            mkdir -p test-results/report-python-ubuntu-latest
-            find ../artifact-download/unpacked -name 'supports.json' -exec cp {} test-results/report-python-ubuntu-latest/ \;
-            find ../artifact-download/unpacked -name '*.junit.xml' -exec cp {} test-results/report-python-ubuntu-latest/ \; || true
-          fi
+          mkdir -p ../artifact-download
           uv run python -m reporting.generate_site \
-            --input-dir test-results \
+            --input-dir ../artifact-download \
             --output-dir site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: xtest/site
 
   deploy:
     needs: build-site
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/community-pages.yml
+++ b/.github/workflows/community-pages.yml
@@ -1,0 +1,105 @@
+# Deploy community conformance report to GitHub Pages (main branch only).
+# Consumes artifacts from Community X-Test runs or regenerates from a dispatch.
+name: Community Conformance Pages
+
+on:
+  workflow_run:
+    workflows: ["Community X-Test"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: community-pages
+  cancel-in-progress: false
+
+jobs:
+  build-site:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.14"
+
+      - name: Download latest community artifacts
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            fs.mkdirSync('artifact-download', { recursive: true });
+            let runId = context.payload.workflow_run?.id;
+            if (!runId) {
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'community-xtest.yml',
+                branch: 'main',
+                per_page: 1,
+              });
+              runId = runs.data.workflow_runs[0]?.id;
+            }
+            if (!runId) {
+              core.warning('No Community X-Test run found; generating empty site shell');
+              return;
+            }
+            core.info(`Using run ${runId}`);
+            const arts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            for (const art of arts.data.artifacts) {
+              if (!art.name.includes('community-python')) continue;
+              const { data } = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: art.id,
+                archive_format: 'zip',
+              });
+              const zipPath = path.join('artifact-download', `${art.id}.zip`);
+              fs.writeFileSync(zipPath, Buffer.from(data));
+              const { execSync } = require('child_process');
+              execSync(`unzip -o "${zipPath}" -d artifact-download/unpacked`, { stdio: 'inherit' });
+            }
+
+      - name: Generate site
+        working-directory: xtest
+        run: |
+          uv sync
+          mkdir -p test-results
+          if [ -d ../artifact-download/unpacked ]; then
+            find ../artifact-download/unpacked -name 'supports.json' -print
+            mkdir -p test-results/report-python-ubuntu-latest
+            find ../artifact-download/unpacked -name 'supports.json' -exec cp {} test-results/report-python-ubuntu-latest/ \;
+            find ../artifact-download/unpacked -name '*.junit.xml' -exec cp {} test-results/report-python-ubuntu-latest/ \; || true
+          fi
+          uv run python -m reporting.generate_site \
+            --input-dir test-results \
+            --output-dir site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: xtest/site
+
+  deploy:
+    needs: build-site
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/community-xtest.yml
+++ b/.github/workflows/community-xtest.yml
@@ -592,6 +592,11 @@ jobs:
           path: otdftests
           persist-credentials: false
 
+      # OpenTDFKit requires swift-tools-version 6.2; pin Xcode so runners with 6.1 fail closed.
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
+
       - id: load-extra-keys
         run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
 
@@ -874,6 +879,11 @@ jobs:
         with:
           path: otdftests
           persist-credentials: false
+
+      # OpenTDFKit requires swift-tools-version 6.2; pin Xcode so runners with 6.1 fail closed.
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
 
       - id: load-extra-keys
         run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/community-xtest.yml
+++ b/.github/workflows/community-xtest.yml
@@ -1,14 +1,16 @@
 # Community SDK cross-tests (fork of opentdf/tests).
 #
-# Stage-1 (this workflow): community SDK ↔ go@latest (floating release), Base TDF
-# (tdf) only, -m stage1. (Not NATO ZTDF; not NanoTDF. See docs/FORMATS.md.)
-# Enabled: python (ubuntu), rust (ubuntu), swift (macos-latest, native platform deps).
-# Swift stays on macOS (CryptoKit). Platform stack is native Postgres+Keycloak+go
-# (no Docker/Colima — nested virt / Keycloak healthchecks are unreliable on GHA macOS).
-# No nanoTDF in Stage-1.
+# Stage-1: community SDK ↔ go@latest (floating release), Base TDF (tdf) only,
+# -m stage1. (Not NATO ZTDF; not NanoTDF. See docs/FORMATS.md.)
+#   - python (ubuntu), rust (ubuntu), swift (macos-latest, native platform deps)
 #
-# Defaults are floating `latest` (resolved each run to the current stable release).
-# Pass an explicit branch/tag/SHA via workflow_dispatch to override (e.g. main).
+# Stage-2: community × community Base TDF interop (same -m stage1 roundtrip),
+# criterion-gated when ≥2 community SDKs are kas-ready (all three are now):
+#   - python × rust (ubuntu)
+#   - python × rust × swift (macos; CryptoKit for OpenTDFKit)
+#
+# Swift stays on macOS (CryptoKit). macOS platform is native Postgres+Keycloak+go
+# (no Docker/Colima). Defaults float on `latest` release tags.
 #
 # Does NOT expand the official xtest.yml matrix.
 name: Community X-Test
@@ -21,10 +23,20 @@ on:
       - ".github/workflows/community-xtest.yml"
       - ".github/actions/**"
       - "docs/community-xtest-design.md"
+      - "docs/community-conformance.md"
   push:
-    branches: [main, community-xtest-stage1]
+    branches: [main, community-xtest-stage1, community-xtest-stage2]
   workflow_dispatch:
     inputs:
+      stage:
+        required: false
+        type: choice
+        options:
+          - all
+          - "1"
+          - "2"
+        default: all
+        description: "Which stages to run (all = Stage-1 + Stage-2)"
       python-ref:
         required: false
         type: string
@@ -201,6 +213,7 @@ jobs:
   community-python:
     name: "python ↔ go@latest stage1"
     needs: [resolve-refs]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.stage == 'all' || inputs.stage == '1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -420,6 +433,7 @@ jobs:
   community-rust:
     name: "rust ↔ go@latest stage1"
     needs: [resolve-refs]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.stage == 'all' || inputs.stage == '1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -557,6 +571,7 @@ jobs:
   community-swift:
     name: "swift ↔ go@latest stage1"
     needs: [resolve-refs]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.stage == 'all' || inputs.stage == '1' }}
     runs-on: macos-latest
     timeout-minutes: 90
     permissions:
@@ -688,22 +703,363 @@ jobs:
           name: ${{ job.status == 'success' && '✅' || '❌' }} community-swift-stage1
           path: otdftests/xtest/test-results/**
 
-  # Capstone: require python + rust + swift Stage-1 (all kas-ready peers).
+  # ---------------------------------------------------------------------------
+  # Stage-2: community × community (Base TDF, live KAS). go is only used for
+  # otdfctl attribute fixtures, not as encrypt/decrypt peer.
+  # ---------------------------------------------------------------------------
+  community-stage2-python-rust:
+    name: "python × rust stage2"
+    needs: [resolve-refs]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.stage == 'all' || inputs.stage == '2' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+      pull-requests: write
+    env:
+      PYTHON_REF: ${{ needs.resolve-refs.outputs.python-ref }}
+      RUST_REF: ${{ needs.resolve-refs.outputs.rust-ref }}
+      PLATFORM_REF: ${{ needs.resolve-refs.outputs.platform-ref }}
+      PLATFORM_TAG: ${{ needs.resolve-refs.outputs.platform-tag }}
+      OTDFCTL_REF: ${{ needs.resolve-refs.outputs.go-ref }}
+      GO_CHANNEL: ${{ needs.resolve-refs.outputs.go-channel }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: otdftests
+          persist-credentials: false
+
+      - id: load-extra-keys
+        run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
+
+      - id: run-platform
+        uses: opentdf/platform/test/start-up-with-containers@11af44a5d4826ed281bf2e0e4e31d6ff6154b393
+        with:
+          platform-ref: ${{ env.PLATFORM_REF }}
+          ec-tdf-enabled: true
+          extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
+          log-type: json
+          pqc-enabled: true
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: "1.24.x"
+      - uses: dtolnay/rust-toolchain@stable
+
+      - id: platform-otdfctl
+        run: |-
+          if [ -d "$PLATFORM_DIR/otdfctl" ] && [ -f "$PLATFORM_DIR/otdfctl/go.mod" ]; then
+            echo "dir=$(pwd)/$PLATFORM_DIR/otdfctl" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git -C "$PLATFORM_DIR" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
+
+      - id: resolve-go
+        working-directory: otdftests
+        run: |-
+          INFO=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve go "${OTDFCTL_REF}")
+          echo "version-info=$INFO" >> "$GITHUB_OUTPUT"
+
+      - id: configure-go
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: go
+          version-info: ${{ steps.resolve-go.outputs.version-info }}
+          platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
+          platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
+
+      - if: fromJson(steps.configure-go.outputs.heads)[0] != null
+        run: make
+        working-directory: otdftests/xtest/sdk/go
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: b-long/opentdf-python-sdk
+          ref: ${{ env.PYTHON_REF }}
+          path: otdftests/xtest/sdk/python/src/main
+          persist-credentials: false
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: arkavo-org/opentdf-rs
+          ref: ${{ env.RUST_REF }}
+          path: otdftests/xtest/sdk/rust/src/main
+          persist-credentials: false
+
+      - name: Build python + rust CLIs
+        run: |-
+          make -C otdftests/xtest/sdk/python VERSIONS=main
+          make -C otdftests/xtest/sdk/rust VERSIONS=main
+
+      - name: Probe community supports
+        working-directory: otdftests/xtest
+        run: |-
+          ./sdk/python/dist/main/cli.sh supports hexless
+          ./sdk/rust/dist/main/cli.sh supports hexless
+          ./sdk/rust/dist/main/cli.sh supports connectrpc
+
+      - name: Platform version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: |-
+          if PLATFORM_VERSION=$(go run ./service version 2>&1); then
+            echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "PLATFORM_VERSION=${PLATFORM_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - run: uv sync
+        working-directory: otdftests/xtest
+
+      - name: Run Stage-2 (python × rust)
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
+          SCHEMA_FILE: "manifest.schema.json"
+        run: |-
+          mkdir -p test-results
+          # Community-only encrypt/decrypt matrix; go remains for attribute fixtures.
+          uv run pytest -n auto --dist loadscope \
+            --html=test-results/community-stage2-python-rust.html \
+            --self-contained-html \
+            --junitxml=test-results/community-stage2-python-rust.junit.xml \
+            --sdks-encrypt "python@main rust@main" \
+            --sdks-decrypt "python@main rust@main" \
+            --containers tdf \
+            --focus "python rust" \
+            -m stage1 \
+            -ra -v \
+            test_tdfs.py \
+            | tee test-results/community-stage2-python-rust.log
+
+      - if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ job.status == 'success' && '✅' || '❌' }} community-stage2-python-rust
+          path: otdftests/xtest/test-results/**
+
+  community-stage2-swift-peers:
+    name: "python × rust × swift stage2"
+    needs: [resolve-refs]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.stage == 'all' || inputs.stage == '2' }}
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+      pull-requests: write
+    env:
+      PYTHON_REF: ${{ needs.resolve-refs.outputs.python-ref }}
+      RUST_REF: ${{ needs.resolve-refs.outputs.rust-ref }}
+      SWIFT_REF: ${{ needs.resolve-refs.outputs.swift-ref }}
+      PLATFORM_REF: ${{ needs.resolve-refs.outputs.platform-ref }}
+      PLATFORM_TAG: ${{ needs.resolve-refs.outputs.platform-tag }}
+      OTDFCTL_REF: ${{ needs.resolve-refs.outputs.go-ref }}
+      GO_CHANNEL: ${{ needs.resolve-refs.outputs.go-channel }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: otdftests
+          persist-credentials: false
+
+      - id: load-extra-keys
+        run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
+
+      - id: run-platform
+        uses: ./otdftests/.github/actions/start-up-with-containers-macos
+        with:
+          platform-ref: ${{ env.PLATFORM_REF }}
+          ec-tdf-enabled: true
+          extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
+          log-type: json
+          pqc-enabled: true
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: "1.24.x"
+      - uses: dtolnay/rust-toolchain@stable
+
+      - id: platform-otdfctl
+        run: |-
+          if [ -d "$PLATFORM_DIR/otdfctl" ] && [ -f "$PLATFORM_DIR/otdfctl/go.mod" ]; then
+            echo "dir=$(pwd)/$PLATFORM_DIR/otdfctl" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git -C "$PLATFORM_DIR" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
+
+      - id: resolve-go
+        working-directory: otdftests
+        run: |-
+          INFO=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve go "${OTDFCTL_REF}")
+          echo "version-info=$INFO" >> "$GITHUB_OUTPUT"
+
+      - id: configure-go
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: go
+          version-info: ${{ steps.resolve-go.outputs.version-info }}
+          platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
+          platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
+
+      - if: fromJson(steps.configure-go.outputs.heads)[0] != null
+        run: make
+        working-directory: otdftests/xtest/sdk/go
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: b-long/opentdf-python-sdk
+          ref: ${{ env.PYTHON_REF }}
+          path: otdftests/xtest/sdk/python/src/main
+          persist-credentials: false
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: arkavo-org/opentdf-rs
+          ref: ${{ env.RUST_REF }}
+          path: otdftests/xtest/sdk/rust/src/main
+          persist-credentials: false
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: arkavo-org/OpenTDFKit
+          ref: ${{ env.SWIFT_REF }}
+          path: otdftests/xtest/sdk/swift/src/main
+          persist-credentials: false
+
+      - name: Build community CLIs (python + rust + swift)
+        run: |-
+          make -C otdftests/xtest/sdk/python VERSIONS=main
+          make -C otdftests/xtest/sdk/rust VERSIONS=main
+          make -C otdftests/xtest/sdk/swift VERSIONS=main
+
+      - name: Probe community supports
+        working-directory: otdftests/xtest
+        run: |-
+          ./sdk/python/dist/main/cli.sh supports hexless
+          ./sdk/rust/dist/main/cli.sh supports hexless
+          ./sdk/swift/dist/main/cli.sh supports hexless
+
+      - name: Platform version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: |-
+          if PLATFORM_VERSION=$(go run ./service version 2>&1); then
+            echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "PLATFORM_VERSION=${PLATFORM_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - run: uv sync
+        working-directory: otdftests/xtest
+
+      - name: Run Stage-2 (python × rust × swift)
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
+          SCHEMA_FILE: "manifest.schema.json"
+        run: |-
+          mkdir -p test-results
+          uv run pytest -n auto --dist loadscope \
+            --html=test-results/community-stage2-swift-peers.html \
+            --self-contained-html \
+            --junitxml=test-results/community-stage2-swift-peers.junit.xml \
+            --sdks-encrypt "python@main rust@main swift@main" \
+            --sdks-decrypt "python@main rust@main swift@main" \
+            --containers tdf \
+            --focus "python rust swift" \
+            -m stage1 \
+            -ra -v \
+            test_tdfs.py \
+            | tee test-results/community-stage2-swift-peers.log
+
+      - if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ job.status == 'success' && '✅' || '❌' }} community-stage2-swift-peers
+          path: otdftests/xtest/test-results/**
+
+  # Capstone: Stage-1 (community ↔ go) + Stage-2 (community × community).
+  # Skipped jobs (workflow_dispatch stage filter) count as success via if: always()
+  # and explicit result checks that allow 'skipped' when that stage was not selected.
   community-xtest:
     runs-on: ubuntu-latest
-    needs: [resolve-refs, community-python, community-rust, community-swift]
+    needs:
+      - resolve-refs
+      - community-python
+      - community-rust
+      - community-swift
+      - community-stage2-python-rust
+      - community-stage2-swift-peers
     if: always()
     permissions:
       contents: read
     steps:
       - name: Assert required community jobs passed
-        if: ${{ needs.community-python.result != 'success' || needs.community-rust.result != 'success' || needs.community-swift.result != 'success' }}
+        env:
+          PY: ${{ needs.community-python.result }}
+          RS: ${{ needs.community-rust.result }}
+          SW: ${{ needs.community-swift.result }}
+          S2PR: ${{ needs.community-stage2-python-rust.result }}
+          S2SW: ${{ needs.community-stage2-swift-peers.result }}
+          STAGE: ${{ inputs.stage || 'all' }}
         run: |
-          echo "python=${{ needs.community-python.result }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "rust=${{ needs.community-rust.result }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "swift=${{ needs.community-swift.result }}" >> "$GITHUB_STEP_SUMMARY"
-          exit 1
-      - name: Success
-        if: ${{ needs.community-python.result == 'success' && needs.community-rust.result == 'success' && needs.community-swift.result == 'success' }}
-        run: |
-          echo "Community Stage-1 required jobs (python + rust + swift) succeeded." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Community X-Test gate"
+            echo "| Job | Result |"
+            echo "|-----|--------|"
+            echo "| python stage1 | \`${PY}\` |"
+            echo "| rust stage1 | \`${RS}\` |"
+            echo "| swift stage1 | \`${SW}\` |"
+            echo "| stage2 python×rust | \`${S2PR}\` |"
+            echo "| stage2 python×rust×swift | \`${S2SW}\` |"
+            echo ""
+            echo "stage filter: \`${STAGE}\` (workflow_dispatch only; push/PR run all)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
+          fail=0
+          # Stage-1 required unless dispatch selected stage=2 only
+          if [[ "${STAGE}" != "2" ]]; then
+            ok "$PY" || fail=1
+            ok "$RS" || fail=1
+            ok "$SW" || fail=1
+          fi
+          # Stage-2 required unless dispatch selected stage=1 only
+          if [[ "${STAGE}" != "1" ]]; then
+            ok "$S2PR" || fail=1
+            ok "$S2SW" || fail=1
+          fi
+          # Never allow failure; skipped ok when filtered
+          for r in "$PY" "$RS" "$SW" "$S2PR" "$S2SW"; do
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              fail=1
+            fi
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            echo "Community gate failed." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Community gate succeeded." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/community-xtest.yml
+++ b/.github/workflows/community-xtest.yml
@@ -350,6 +350,7 @@ jobs:
           SCHEMA_FILE: "manifest.schema.json"
           # Dist channel stays `main` (single under-test build); peer is go@GO_CHANNEL.
         run: |-
+          set -o pipefail
           mkdir -p test-results
           GO_CH="${GO_CHANNEL}"
           uv run pytest -n auto --dist loadscope \
@@ -369,50 +370,19 @@ jobs:
         if: success() || failure()
         working-directory: otdftests/xtest
         run: |-
-          mkdir -p test-results/report-python-ubuntu-latest
-          uv run python - <<'PY'
-          import json, subprocess, os
-          from pathlib import Path
-          from datetime import UTC, datetime
+          uv run python -m reporting.export_supports \
+            --sdk python --sdk-ref "${PYTHON_REF}" --os ubuntu-latest
 
-          features = [
-              "assertions","assertion_verification","attribute_traversal","audit_logging",
-              "autoconfigure","better-messages-2024","bulk_rewrap","connectrpc","dpop",
-              "dpop_nonce_challenge","ecwrap","hexless","hexaflexible","kasallowlist",
-              "key_management","mechanism-rsa-4096","mechanism-ec-curves-384-521",
-              "mechanism-xwing","mechanism-secpmlkem","mechanism-mlkem","ns_grants","obligations",
-          ]
-          cli = Path("sdk/python/dist/main/cli.sh")
-          supports = {}
-          for f in features:
-              try:
-                  r = subprocess.run([str(cli), "supports", f], capture_output=True, timeout=30)
-                  supports[f] = "supported" if r.returncode == 0 else ("unsupported" if r.returncode == 1 else "unknown")
-              except Exception as e:
-                  supports[f] = f"error:{e}"
-
-          out = {
-              "schema_version": 1,
-              "generated_at": datetime.now(UTC).isoformat(),
-              "sdk": "python",
-              "sdk_ref": os.environ.get("PYTHON_REF", "latest"),
-              "platform_ref": os.environ.get("PLATFORM_REF", "latest"),
-              "go_channel": os.environ.get("GO_CHANNEL", "latest"),
-              "tier": "kas-ready",
-              "stage": 1,
-              "supports": supports,
-              "run_id": os.environ.get("GITHUB_RUN_ID"),
-              "repo": os.environ.get("GITHUB_REPOSITORY"),
-          }
-          dest = Path("test-results/report-python-ubuntu-latest")
-          dest.mkdir(parents=True, exist_ok=True)
-          (dest / "supports.json").write_text(json.dumps(out, indent=2))
-          (dest / "meta.json").write_text(json.dumps({
-              "sdk": "python", "os": "ubuntu-latest", "stage": 1,
-              "run_id": os.environ.get("GITHUB_RUN_ID"),
-          }, indent=2))
-          print(json.dumps(out, indent=2))
-          PY
+      # The go reference peer gets a snapshot too (only here, to avoid
+      # duplicate exports across jobs), so the capability matrix can compare
+      # community SDKs against the reference implementation.
+      - name: Export go peer capability snapshot
+        if: success() || failure()
+        working-directory: otdftests/xtest
+        run: |-
+          uv run python -m reporting.export_supports \
+            --sdk go --version "${GO_CHANNEL}" --sdk-ref "${OTDFCTL_REF}" \
+            --tier reference --os ubuntu-latest
 
       - name: Upload results
         if: success() || failure()
@@ -559,6 +529,13 @@ jobs:
             -ra -v \
             test_tdfs.py
 
+      - name: Export capability snapshot
+        if: success() || failure()
+        working-directory: otdftests/xtest
+        run: |-
+          uv run python -m reporting.export_supports \
+            --sdk rust --sdk-ref "${RUST_REF}" --os ubuntu-latest
+
       - if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -702,6 +679,13 @@ jobs:
             -ra -v \
             test_tdfs.py
 
+      - name: Export capability snapshot
+        if: success() || failure()
+        working-directory: otdftests/xtest
+        run: |-
+          uv run python -m reporting.export_supports \
+            --sdk swift --sdk-ref "${SWIFT_REF}" --os macos-latest
+
       - if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -834,6 +818,7 @@ jobs:
           PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
           SCHEMA_FILE: "manifest.schema.json"
         run: |-
+          set -o pipefail
           mkdir -p test-results
           # Community-only encrypt/decrypt matrix; go remains for attribute fixtures.
           uv run pytest -n auto --dist loadscope \
@@ -991,6 +976,7 @@ jobs:
           PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
           SCHEMA_FILE: "manifest.schema.json"
         run: |-
+          set -o pipefail
           mkdir -p test-results
           uv run pytest -n auto --dist loadscope \
             --html=test-results/community-stage2-swift-peers.html \

--- a/.github/workflows/community-xtest.yml
+++ b/.github/workflows/community-xtest.yml
@@ -1,0 +1,709 @@
+# Community SDK cross-tests (fork of opentdf/tests).
+#
+# Stage-1 (this workflow): community SDK ↔ go@latest (floating release), Base TDF
+# (tdf) only, -m stage1. (Not NATO ZTDF; not NanoTDF. See docs/FORMATS.md.)
+# Enabled: python (ubuntu), rust (ubuntu), swift (macos-latest, native platform deps).
+# Swift stays on macOS (CryptoKit). Platform stack is native Postgres+Keycloak+go
+# (no Docker/Colima — nested virt / Keycloak healthchecks are unreliable on GHA macOS).
+# No nanoTDF in Stage-1.
+#
+# Defaults are floating `latest` (resolved each run to the current stable release).
+# Pass an explicit branch/tag/SHA via workflow_dispatch to override (e.g. main).
+#
+# Does NOT expand the official xtest.yml matrix.
+name: Community X-Test
+
+on:
+  pull_request:
+    paths:
+      - "xtest/**"
+      - "otdf-sdk-mgr/**"
+      - ".github/workflows/community-xtest.yml"
+      - ".github/actions/**"
+      - "docs/community-xtest-design.md"
+  push:
+    branches: [main, community-xtest-stage1]
+  workflow_dispatch:
+    inputs:
+      python-ref:
+        required: false
+        type: string
+        default: latest
+        description: "opentdf-python-sdk ref: 'latest' (floating release), branch, tag, or SHA"
+      rust-ref:
+        required: false
+        type: string
+        # opentdf-rs 0.14.0+ is Stage-1 capable (hexless + RSA wrap/rewrap).
+        # Floating latest tracks current stable release.
+        default: latest
+        description: "opentdf-rs ref: 'latest' (floating release), branch, tag, or SHA"
+      swift-ref:
+        required: false
+        type: string
+        # OpenTDFKit 4.0.0+ is Stage-1 capable (KAS well-known fallback, OAEP-SHA1,
+        # GMAC integrity). Floating latest tracks current stable release.
+        default: latest
+        description: "OpenTDFKit ref: 'latest' (floating release), branch, tag, or SHA"
+      platform-ref:
+        required: false
+        type: string
+        default: latest
+        description: "opentdf/platform ref: 'latest'/'lts', branch, tag (service/vX.Y.Z), or SHA"
+      otdfctl-ref:
+        required: false
+        type: string
+        default: latest
+        description: "otdfctl / go peer ref: 'latest'/'lts', branch, tag, or SHA"
+
+# One run per branch: push + PR + workflow_dispatch share the same group so a
+# new commit cancels both the prior push run and the prior PR run (avoids
+# double macos/ubuntu spend when the branch has an open PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Expand floating `latest`/`lts` aliases once per workflow run. Concrete tags
+  # are pinned only for this run (not hard-coded in YAML).
+  resolve-refs:
+    name: Resolve floating release pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      platform-ref: ${{ steps.resolve.outputs.platform-ref }}
+      platform-tag: ${{ steps.resolve.outputs.platform-tag }}
+      go-ref: ${{ steps.resolve.outputs.go-ref }}
+      go-channel: ${{ steps.resolve.outputs.go-channel }}
+      python-ref: ${{ steps.resolve.outputs.python-ref }}
+      rust-ref: ${{ steps.resolve.outputs.rust-ref }}
+      swift-ref: ${{ steps.resolve.outputs.swift-ref }}
+    env:
+      PLATFORM_REF_IN: ${{ inputs.platform-ref || 'latest' }}
+      OTDFCTL_REF_IN: ${{ inputs.otdfctl-ref || 'latest' }}
+      PYTHON_REF_IN: ${{ inputs.python-ref || 'latest' }}
+      RUST_REF_IN: ${{ inputs.rust-ref || 'latest' }}
+      SWIFT_REF_IN: ${{ inputs.swift-ref || 'latest' }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: otdftests
+          persist-credentials: false
+          sparse-checkout: |
+            otdf-sdk-mgr
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.14"
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Resolve latest → concrete refs
+        id: resolve
+        working-directory: otdftests
+        run: |
+          set -euo pipefail
+
+          # Official platform/go: otdf-sdk-mgr understands latest/lts.
+          resolve_mgr() {
+            local sdk="$1" alias="$2"
+            local info
+            info=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve "$sdk" "$alias")
+            echo "$info" | jq -e '.[0] | select(.err == null)' >/dev/null \
+              || { echo "$info" | jq .; echo "failed to resolve $sdk@$alias" >&2; exit 1; }
+            echo "$info"
+          }
+
+          # Community SDKs: floating GitHub latest non-prerelease release tag.
+          # Falls back to highest pure-semver git tag if the repo has no Releases.
+          resolve_github_latest() {
+            local repo="$1"
+            local tag=""
+            if tag=$(gh api "repos/${repo}/releases/latest" --jq .tag_name 2>/dev/null); then
+              if [[ -n "$tag" && "$tag" != "null" ]]; then
+                echo "$tag"
+                return 0
+              fi
+            fi
+            # Fallback: max stable x.y.z / vX.Y.Z tag (full-string match only).
+            git ls-remote --tags --refs "https://github.com/${repo}.git" \
+              | awk '{print $2}' | sed 's#refs/tags/##' \
+              | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -t. -k1,1V -k2,2V -k3,3V \
+              | tail -1
+          }
+
+          resolve_or_pass() {
+            local input="$1" repo="$2"
+            if [[ "$input" == "latest" ]]; then
+              resolve_github_latest "$repo"
+            else
+              echo "$input"
+            fi
+          }
+
+          if [[ "$PLATFORM_REF_IN" == "latest" || "$PLATFORM_REF_IN" == "lts" ]]; then
+            PINFO=$(resolve_mgr platform "$PLATFORM_REF_IN")
+            PLATFORM_REF=$(echo "$PINFO" | jq -r '.[0].release // .[0].tag')
+            PLATFORM_TAG=$(echo "$PINFO" | jq -r '.[0].alias')
+          else
+            PLATFORM_REF="$PLATFORM_REF_IN"
+            PLATFORM_TAG="$PLATFORM_REF_IN"
+          fi
+
+          if [[ "$OTDFCTL_REF_IN" == "latest" || "$OTDFCTL_REF_IN" == "lts" ]]; then
+            GINFO=$(resolve_mgr go "$OTDFCTL_REF_IN")
+            GO_REF=$(echo "$GINFO" | jq -r '.[0].release // .[0].tag')
+            GO_CHANNEL=$(echo "$GINFO" | jq -r '.[0].tag // .[0].alias')
+          else
+            GO_REF="$OTDFCTL_REF_IN"
+            GO_CHANNEL="$OTDFCTL_REF_IN"
+          fi
+
+          PYTHON_REF=$(resolve_or_pass "$PYTHON_REF_IN" "b-long/opentdf-python-sdk")
+          RUST_REF=$(resolve_or_pass "$RUST_REF_IN" "arkavo-org/opentdf-rs")
+          SWIFT_REF=$(resolve_or_pass "$SWIFT_REF_IN" "arkavo-org/OpenTDFKit")
+
+          {
+            echo "platform-ref=${PLATFORM_REF}"
+            echo "platform-tag=${PLATFORM_TAG}"
+            echo "go-ref=${GO_REF}"
+            echo "go-channel=${GO_CHANNEL}"
+            echo "python-ref=${PYTHON_REF}"
+            echo "rust-ref=${RUST_REF}"
+            echo "swift-ref=${SWIFT_REF}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Resolved floating pins"
+            echo ""
+            echo "| Component | Input | Resolved |"
+            echo "|---|---|---|"
+            echo "| platform | \`${PLATFORM_REF_IN}\` | \`${PLATFORM_REF}\` |"
+            echo "| go/otdfctl | \`${OTDFCTL_REF_IN}\` | \`${GO_REF}\` (channel \`${GO_CHANNEL}\`) |"
+            echo "| python | \`${PYTHON_REF_IN}\` | \`${PYTHON_REF}\` |"
+            echo "| rust | \`${RUST_REF_IN}\` | \`${RUST_REF}\` |"
+            echo "| swift | \`${SWIFT_REF_IN}\` | \`${SWIFT_REF}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Resolved pins:"
+          echo "  platform=${PLATFORM_REF} (tag alias=${PLATFORM_TAG})"
+          echo "  go=${GO_REF} (channel=${GO_CHANNEL})"
+          echo "  python=${PYTHON_REF}"
+          echo "  rust=${RUST_REF}"
+          echo "  swift=${SWIFT_REF}"
+
+  community-python:
+    name: "python ↔ go@latest stage1"
+    needs: [resolve-refs]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+      pull-requests: write
+    env:
+      PYTHON_REF: ${{ needs.resolve-refs.outputs.python-ref }}
+      PLATFORM_REF: ${{ needs.resolve-refs.outputs.platform-ref }}
+      PLATFORM_TAG: ${{ needs.resolve-refs.outputs.platform-tag }}
+      OTDFCTL_REF: ${{ needs.resolve-refs.outputs.go-ref }}
+      GO_CHANNEL: ${{ needs.resolve-refs.outputs.go-channel }}
+      FOCUS_SDK: python
+
+    steps:
+      - name: Checkout tests fork
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: otdftests
+          persist-credentials: false
+
+      - name: Load extra keys
+        id: load-extra-keys
+        run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
+
+      - name: Start platform with containers
+        id: run-platform
+        uses: opentdf/platform/test/start-up-with-containers@11af44a5d4826ed281bf2e0e4e31d6ff6154b393
+        with:
+          platform-ref: ${{ env.PLATFORM_REF }}
+          ec-tdf-enabled: true
+          extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
+          log-type: json
+          pqc-enabled: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.14"
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: "1.24.x"
+
+      - name: Set up Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "22.x"
+
+      ######## go peer (otdfctl from floating latest / platform checkout) #############
+      - name: Capture platform otdfctl location
+        id: platform-otdfctl
+        run: |-
+          if [ -d "$PLATFORM_DIR/otdfctl" ] && [ -f "$PLATFORM_DIR/otdfctl/go.mod" ]; then
+            echo "dir=$(pwd)/$PLATFORM_DIR/otdfctl" >> "$GITHUB_OUTPUT"
+            sha=$(git -C "$PLATFORM_DIR" rev-parse HEAD)
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
+
+      - name: Resolve go peer
+        id: resolve-go
+        working-directory: otdftests
+        run: |-
+          INFO=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve go "${OTDFCTL_REF}")
+          echo "version-info=$INFO" >> "$GITHUB_OUTPUT"
+          echo "$INFO" | jq .
+
+      - name: Configure otdfctl (go)
+        id: configure-go
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: go
+          version-info: ${{ steps.resolve-go.outputs.version-info }}
+          platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
+          platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
+
+      - name: Build go CLI
+        if: fromJson(steps.configure-go.outputs.heads)[0] != null
+        run: make
+        working-directory: otdftests/xtest/sdk/go
+
+      ######## Community Python SDK #############
+      - name: Checkout python SDK
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: b-long/opentdf-python-sdk
+          ref: ${{ env.PYTHON_REF }}
+          path: otdftests/xtest/sdk/python/src/main
+          persist-credentials: false
+
+      - name: Build python CLI dist
+        run: make VERSIONS=main
+        working-directory: otdftests/xtest/sdk/python
+
+      - name: Probe python supports
+        working-directory: otdftests/xtest
+        run: |-
+          set -e
+          ./sdk/python/dist/main/cli.sh supports autoconfigure
+          ./sdk/python/dist/main/cli.sh supports hexless
+          ! ./sdk/python/dist/main/cli.sh supports ecwrap || { echo "python should not claim ecwrap yet"; exit 1; }
+
+      - name: Platform version
+        id: platform-version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: |-
+          if PLATFORM_VERSION=$(go run ./service version 2>&1); then
+            echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "PLATFORM_VERSION=${PLATFORM_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install xtest deps
+        run: uv sync
+        working-directory: otdftests/xtest
+
+      - name: Run Stage-1 community tests (python × go)
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
+          SCHEMA_FILE: "manifest.schema.json"
+          # Dist channel stays `main` (single under-test build); peer is go@GO_CHANNEL.
+        run: |-
+          mkdir -p test-results
+          GO_CH="${GO_CHANNEL}"
+          uv run pytest -n auto --dist loadscope \
+            --html=test-results/community-python-stage1.html \
+            --self-contained-html \
+            --junitxml=test-results/community-python-stage1.junit.xml \
+            --sdks-encrypt "python@main go@${GO_CH}" \
+            --sdks-decrypt "python@main go@${GO_CH}" \
+            --containers tdf \
+            --focus python \
+            -m stage1 \
+            -ra -v \
+            test_tdfs.py \
+            | tee test-results/community-python-stage1.log
+
+      - name: Export capability snapshot
+        if: success() || failure()
+        working-directory: otdftests/xtest
+        run: |-
+          mkdir -p test-results/report-python-ubuntu-latest
+          uv run python - <<'PY'
+          import json, subprocess, os
+          from pathlib import Path
+          from datetime import UTC, datetime
+
+          features = [
+              "assertions","assertion_verification","attribute_traversal","audit_logging",
+              "autoconfigure","better-messages-2024","bulk_rewrap","connectrpc","dpop",
+              "dpop_nonce_challenge","ecwrap","hexless","hexaflexible","kasallowlist",
+              "key_management","mechanism-rsa-4096","mechanism-ec-curves-384-521",
+              "mechanism-xwing","mechanism-secpmlkem","mechanism-mlkem","ns_grants","obligations",
+          ]
+          cli = Path("sdk/python/dist/main/cli.sh")
+          supports = {}
+          for f in features:
+              try:
+                  r = subprocess.run([str(cli), "supports", f], capture_output=True, timeout=30)
+                  supports[f] = "supported" if r.returncode == 0 else ("unsupported" if r.returncode == 1 else "unknown")
+              except Exception as e:
+                  supports[f] = f"error:{e}"
+
+          out = {
+              "schema_version": 1,
+              "generated_at": datetime.now(UTC).isoformat(),
+              "sdk": "python",
+              "sdk_ref": os.environ.get("PYTHON_REF", "latest"),
+              "platform_ref": os.environ.get("PLATFORM_REF", "latest"),
+              "go_channel": os.environ.get("GO_CHANNEL", "latest"),
+              "tier": "kas-ready",
+              "stage": 1,
+              "supports": supports,
+              "run_id": os.environ.get("GITHUB_RUN_ID"),
+              "repo": os.environ.get("GITHUB_REPOSITORY"),
+          }
+          dest = Path("test-results/report-python-ubuntu-latest")
+          dest.mkdir(parents=True, exist_ok=True)
+          (dest / "supports.json").write_text(json.dumps(out, indent=2))
+          (dest / "meta.json").write_text(json.dumps({
+              "sdk": "python", "os": "ubuntu-latest", "stage": 1,
+              "run_id": os.environ.get("GITHUB_RUN_ID"),
+          }, indent=2))
+          print(json.dumps(out, indent=2))
+          PY
+
+      - name: Upload results
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ job.status == 'success' && '✅' || '❌' }} community-python-stage1
+          path: |
+            otdftests/xtest/test-results/**
+
+      - name: Upload server logs on failure
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: community-python-server-logs
+          path: ${{ steps.run-platform.outputs.platform-log-file }}
+          if-no-files-found: ignore
+
+  community-rust:
+    name: "rust ↔ go@latest stage1"
+    needs: [resolve-refs]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+      pull-requests: write
+    env:
+      RUST_REF: ${{ needs.resolve-refs.outputs.rust-ref }}
+      PLATFORM_REF: ${{ needs.resolve-refs.outputs.platform-ref }}
+      PLATFORM_TAG: ${{ needs.resolve-refs.outputs.platform-tag }}
+      OTDFCTL_REF: ${{ needs.resolve-refs.outputs.go-ref }}
+      GO_CHANNEL: ${{ needs.resolve-refs.outputs.go-channel }}
+      FOCUS_SDK: rust
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: otdftests
+          persist-credentials: false
+
+      - id: load-extra-keys
+        run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
+
+      - id: run-platform
+        uses: opentdf/platform/test/start-up-with-containers@11af44a5d4826ed281bf2e0e4e31d6ff6154b393
+        with:
+          platform-ref: ${{ env.PLATFORM_REF }}
+          ec-tdf-enabled: true
+          extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
+          log-type: json
+          pqc-enabled: true
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: "1.24.x"
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Capture platform otdfctl location
+        id: platform-otdfctl
+        run: |-
+          if [ -d "$PLATFORM_DIR/otdfctl" ] && [ -f "$PLATFORM_DIR/otdfctl/go.mod" ]; then
+            echo "dir=$(pwd)/$PLATFORM_DIR/otdfctl" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git -C "$PLATFORM_DIR" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
+
+      - id: resolve-go
+        working-directory: otdftests
+        run: |-
+          INFO=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve go "${OTDFCTL_REF}")
+          echo "version-info=$INFO" >> "$GITHUB_OUTPUT"
+
+      - id: configure-go
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: go
+          version-info: ${{ steps.resolve-go.outputs.version-info }}
+          platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
+          platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
+
+      - if: fromJson(steps.configure-go.outputs.heads)[0] != null
+        run: make
+        working-directory: otdftests/xtest/sdk/go
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: arkavo-org/opentdf-rs
+          ref: ${{ env.RUST_REF }}
+          path: otdftests/xtest/sdk/rust/src/main
+          persist-credentials: false
+
+      - name: Build rust CLI
+        run: make VERSIONS=main
+        working-directory: otdftests/xtest/sdk/rust
+
+      - name: Probe rust supports
+        working-directory: otdftests/xtest
+        run: |-
+          ./sdk/rust/dist/main/cli.sh supports hexless
+          ./sdk/rust/dist/main/cli.sh supports connectrpc
+          ! ./sdk/rust/dist/main/cli.sh supports ecwrap || exit 1
+
+      - name: Platform version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: |-
+          if PLATFORM_VERSION=$(go run ./service version 2>&1); then
+            echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "PLATFORM_VERSION=${PLATFORM_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - run: uv sync
+        working-directory: otdftests/xtest
+
+      - name: Run Stage-1 community tests (rust × go)
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
+          SCHEMA_FILE: "manifest.schema.json"
+        run: |-
+          mkdir -p test-results
+          GO_CH="${GO_CHANNEL}"
+          uv run pytest -n auto --dist loadscope \
+            --html=test-results/community-rust-stage1.html \
+            --self-contained-html \
+            --junitxml=test-results/community-rust-stage1.junit.xml \
+            --sdks-encrypt "rust@main go@${GO_CH}" \
+            --sdks-decrypt "rust@main go@${GO_CH}" \
+            --containers tdf \
+            --focus rust \
+            -m stage1 \
+            -ra -v \
+            test_tdfs.py
+
+      - if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ job.status == 'success' && '✅' || '❌' }} community-rust-stage1
+          path: otdftests/xtest/test-results/**
+
+  # OpenTDFKit needs Apple CryptoKit/Security — macOS only (not Linux Swift).
+  # Platform deps run natively on the runner (Postgres + Keycloak JVM + platform binary).
+  # No Docker/Colima: nested virt unavailable on arm64 GHA, and Keycloak compose healthchecks flake.
+  community-swift:
+    name: "swift ↔ go@latest stage1"
+    needs: [resolve-refs]
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+      pull-requests: write
+    env:
+      SWIFT_REF: ${{ needs.resolve-refs.outputs.swift-ref }}
+      PLATFORM_REF: ${{ needs.resolve-refs.outputs.platform-ref }}
+      PLATFORM_TAG: ${{ needs.resolve-refs.outputs.platform-tag }}
+      OTDFCTL_REF: ${{ needs.resolve-refs.outputs.go-ref }}
+      GO_CHANNEL: ${{ needs.resolve-refs.outputs.go-channel }}
+      FOCUS_SDK: swift
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: otdftests
+          persist-credentials: false
+
+      - id: load-extra-keys
+        run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
+
+      # Native macOS platform bootstrap (Homebrew Postgres, Keycloak release tarball).
+      - id: run-platform
+        uses: ./otdftests/.github/actions/start-up-with-containers-macos
+        with:
+          platform-ref: ${{ env.PLATFORM_REF }}
+          ec-tdf-enabled: true
+          extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
+          log-type: json
+          pqc-enabled: true
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: "1.24.x"
+
+      - name: Capture platform otdfctl location
+        id: platform-otdfctl
+        run: |-
+          if [ -d "$PLATFORM_DIR/otdfctl" ] && [ -f "$PLATFORM_DIR/otdfctl/go.mod" ]; then
+            echo "dir=$(pwd)/$PLATFORM_DIR/otdfctl" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git -C "$PLATFORM_DIR" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
+
+      - id: resolve-go
+        working-directory: otdftests
+        run: |-
+          INFO=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve go "${OTDFCTL_REF}")
+          echo "version-info=$INFO" >> "$GITHUB_OUTPUT"
+
+      - id: configure-go
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: go
+          version-info: ${{ steps.resolve-go.outputs.version-info }}
+          platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
+          platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
+
+      - if: fromJson(steps.configure-go.outputs.heads)[0] != null
+        run: make
+        working-directory: otdftests/xtest/sdk/go
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: arkavo-org/OpenTDFKit
+          ref: ${{ env.SWIFT_REF }}
+          path: otdftests/xtest/sdk/swift/src/main
+          persist-credentials: false
+
+      - name: Build swift CLI
+        run: make VERSIONS=main
+        working-directory: otdftests/xtest/sdk/swift
+
+      - name: Probe swift supports
+        working-directory: otdftests/xtest
+        run: |-
+          ./sdk/swift/dist/main/cli.sh supports tdf || ./sdk/swift/dist/main/cli.sh supports ztdf
+          ./sdk/swift/dist/main/cli.sh supports hexless
+          ! ./sdk/swift/dist/main/cli.sh supports ecwrap || exit 1
+
+      - name: Platform version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: |-
+          if PLATFORM_VERSION=$(go run ./service version 2>&1); then
+            echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "PLATFORM_VERSION=${PLATFORM_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - run: uv sync
+        working-directory: otdftests/xtest
+
+      - name: Run Stage-1 community tests (swift × go)
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
+          SCHEMA_FILE: "manifest.schema.json"
+        run: |-
+          mkdir -p test-results
+          GO_CH="${GO_CHANNEL}"
+          uv run pytest -n auto --dist loadscope \
+            --html=test-results/community-swift-stage1.html \
+            --self-contained-html \
+            --junitxml=test-results/community-swift-stage1.junit.xml \
+            --sdks-encrypt "swift@main go@${GO_CH}" \
+            --sdks-decrypt "swift@main go@${GO_CH}" \
+            --containers tdf \
+            --focus swift \
+            -m stage1 \
+            -ra -v \
+            test_tdfs.py
+
+      - if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ job.status == 'success' && '✅' || '❌' }} community-swift-stage1
+          path: otdftests/xtest/test-results/**
+
+  # Capstone: require python + rust + swift Stage-1 (all kas-ready peers).
+  community-xtest:
+    runs-on: ubuntu-latest
+    needs: [resolve-refs, community-python, community-rust, community-swift]
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - name: Assert required community jobs passed
+        if: ${{ needs.community-python.result != 'success' || needs.community-rust.result != 'success' || needs.community-swift.result != 'success' }}
+        run: |
+          echo "python=${{ needs.community-python.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "rust=${{ needs.community-rust.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "swift=${{ needs.community-swift.result }}" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+      - name: Success
+        if: ${{ needs.community-python.result == 'success' && needs.community-rust.result == 'success' && needs.community-swift.result == 'success' }}
+        run: |
+          echo "Community Stage-1 required jobs (python + rust + swift) succeeded." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -41,8 +41,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Skip dependency review on forks
+        if: ${{ github.event_name != 'merge_group' && github.event.repository.fork }}
+        run: |
+          echo "Skipping dependency-review on fork (enable Dependency graph in repo settings to re-enable)." >> "$GITHUB_STEP_SUMMARY"
+
+      # Forks often lack dependency-graph enablement; skip rather than fail the PR.
       - name: 'Dependency Review'
-        if: ${{ github.event_name != 'merge_group' }}
+        if: ${{ github.event_name != 'merge_group' && !github.event.repository.fork }}
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: ${{ inputs.fail-on-severity }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,9 @@ xtest/sdk/java/cmdline.jar
 /xtest/sdk/go/platform-src/
 /xtest/otdfctl/
 
+# Community + official SDK checkouts and build products
+/xtest/sdk/*/src/
+/xtest/sdk/*/dist/
+/xtest/test-results/
+
 /tmp/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # Tests for OpenTDF
 
-## [Cross-client compatibility tests](xtests)
+> **Fork note:** This is `arkavo-org/opentdf-tests`, a fork of [`opentdf/tests`](https://github.com/opentdf/tests) that adds **community SDK** conformance (Rust, Swift, Python). Official go/java/js paths stay upstream-compatible.
+
+## [Cross-client compatibility tests](xtest)
 
 See the [xtest docs](xtest/README.md) for instructions on running the tests.
+
+### Community SDK Stage-1
+
+See [docs/community-conformance.md](docs/community-conformance.md) and the design [docs/community-xtest-design.md](docs/community-xtest-design.md).
+
+| Workflow | Purpose |
+|----------|---------|
+| `xtest.yml` | Official go / java / js matrix (unchanged core) |
+| `community-xtest.yml` | Community python ↔ go@main Stage-1 (tdf) |
 
 ## [Vulnerability](vulnerability)
 

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -1,0 +1,57 @@
+# OpenTDF format naming (specs vs software)
+
+This fork uses **official OpenTDF / Virtru terminology** for format profiles
+and software stacks. See also [opentdf.io/spec](https://opentdf.io/spec) and
+[Virtru Trusted Data Format](https://www.virtru.com/data-security-platform/trusted-data-format).
+
+## Format naming (specifications)
+
+| Official name | Test slug | What it is |
+|---------------|-----------|------------|
+| **Base TDF** / **Standard TDF** | `tdf` (aliases: `base-tdf`, legacy `ztdf`) | Foundational open format: JSON manifest inside a ZIP archive plus encrypted payload. This is what OpenTDF SDKs implement by default. |
+| **ZTDF** (Zero Trust Data Format) | `ztdf` *(reserved; not Stage-1)* | Open specialized profile (NATO / Five Eyes heritage) that builds on OpenTDF with strict cryptographic assertions and metadata bindings (STANAG-oriented). **Not** a synonym for “ZIP TDF”. |
+| **NanoTDF** | `nanotdf` *(not Stage-1)* | Binary compact variant for constrained / streaming environments. |
+| **IC-TDF** | — | Older XML-based Intelligence Community variant (out of scope here). |
+
+### Base TDF variants in this suite
+
+| Slug | Meaning |
+|------|---------|
+| `tdf` | Base TDF, default RSA wrap |
+| `tdf-ecwrap` | Base TDF with EC key wrapping |
+
+Legacy OpenTDF tooling (including official `cli.sh` 4th-argument wire format)
+often used the string `ztdf` for Base TDF ZIP containers. The harness still
+**accepts** that alias and still **emits** `ztdf` on the wire to go/java/js
+shims. Canonical names in pytest, docs, and CI are `tdf` / `tdf-ecwrap`.
+
+```bash
+# Preferred
+pytest --containers tdf tdf-ecwrap
+
+# Still works (legacy alias → Base TDF)
+pytest --containers ztdf ztdf-ecwrap
+```
+
+## Implementation naming (software)
+
+| Name | Role |
+|------|------|
+| **OpenTDF** | Open-source platform, KAS, policy, and SDKs ([github.com/opentdf](https://github.com/opentdf)). Enforces Base TDF. |
+| **Virtru Data Security Platform (DSP)** | Commercial product that builds on OpenTDF and adds enterprise / government capabilities (including environments that consume ZTDF, STANAG tagging, HSMs, etc.). |
+
+Do **not** use “Virtru TDF” or “OpenTDF format” as if they were interchangeable format names. Prefer **Base TDF** for the open ZIP+JSON format and **OpenTDF** for the software stack under test.
+
+## Stage-1 community conformance
+
+| In scope | Out of scope |
+|----------|----------------|
+| Base TDF (`tdf`) community ↔ `go@main` | NATO ZTDF profile |
+| | NanoTDF |
+| | Full ABAC / PQC / multi-KAS matrix |
+
+## References
+
+- OpenTDF specification: https://opentdf.io/spec  
+- OpenTDF architecture: https://opentdf.io/architecture  
+- Virtru TDF overview: https://www.virtru.com/data-security-platform/trusted-data-format  

--- a/docs/community-conformance.md
+++ b/docs/community-conformance.md
@@ -2,12 +2,13 @@
 
 This fork (`arkavo-org/opentdf-tests`) extends official OpenTDF `xtest` with **community SDKs**:
 
-| SDK | Repo | Stage-1 status |
-|-----|------|----------------|
-| **Python** | [b-long/opentdf-python-sdk](https://github.com/b-long/opentdf-python-sdk) | **Enabled** — ubuntu, python ↔ go@latest, Base TDF (`python-ref` default `latest`) |
-| **Rust** | [arkavo-org/opentdf-rs](https://github.com/arkavo-org/opentdf-rs) | **Enabled** — ubuntu, RSA wrap + KasClient rewrap (`rust-ref` default `latest`, 0.14.0+) |
-| **Swift** | [arkavo-org/OpenTDFKit](https://github.com/arkavo-org/OpenTDFKit) | **Enabled** — `macos-latest`, native Postgres+Keycloak (no Docker/Colima); CryptoKit; pin default `latest` (4.0.0+) |
+| SDK | Repo | Stage-1 (↔ go) | Stage-2 (community × community) |
+|-----|------|----------------|----------------------------------|
+| **Python** | [b-long/opentdf-python-sdk](https://github.com/b-long/opentdf-python-sdk) | ubuntu ↔ go@latest | ubuntu ↔ rust; macos ↔ rust/swift |
+| **Rust** | [arkavo-org/opentdf-rs](https://github.com/arkavo-org/opentdf-rs) | ubuntu ↔ go@latest (`0.14.0+`) | ubuntu ↔ python; macos ↔ python/swift |
+| **Swift** | [arkavo-org/OpenTDFKit](https://github.com/arkavo-org/OpenTDFKit) | macos ↔ go@latest (`4.0.0+`) | macos ↔ python/rust |
 
+Pins default to floating **`latest`** GitHub releases.  
 Full design: [community-xtest-design.md](./community-xtest-design.md).  
 **Format naming:** [FORMATS.md](./FORMATS.md) (Base TDF vs ZTDF vs NanoTDF).
 
@@ -19,6 +20,16 @@ For each **kas-ready** community SDK:
 2. **Go encrypt → Community decrypt** (interop)
 3. Container: **Base TDF (`tdf`) only** — not NATO ZTDF, not NanoTDF, not full ABAC/PQC
 4. Feature honesty: `cli.sh supports <feature>` must not advertise features that fail tests
+
+## What Stage-2 proves
+
+When ≥2 community SDKs are kas-ready (criterion met for python + rust + swift):
+
+1. **Community A encrypt → Community B decrypt** (and reverse), live KAS
+2. Same Base TDF / `stage1` roundtrip cell as Stage-1 — go is fixture-only (otdfctl attributes), not an encrypt/decrypt peer
+3. Jobs:
+   - `python × rust` on ubuntu
+   - `python × rust × swift` on macos (CryptoKit)
 
 ## Local setup (Python)
 
@@ -34,8 +45,8 @@ ln -sfn "$(pwd)/../opentdf-python-sdk" xtest/sdk/python/src/main
 # Build dist/cli
 make -C xtest/sdk/python VERSIONS=main
 
-# Also need go@main for peer + attribute fixtures (see official xtest README)
-# Then:
+# Also need go for attribute fixtures (see official xtest README)
+# Then Stage-1:
 cd xtest
 uv sync
 set -a && source test.env && set +a
@@ -44,18 +55,26 @@ uv run pytest -m stage1 --containers tdf \
   --sdks-decrypt "python@main go@main" \
   --focus python \
   test_tdfs.py
+
+# Stage-2 (python × rust) — also build rust CLI first:
+# make -C sdk/rust VERSIONS=main
+uv run pytest -m stage1 --containers tdf \
+  --sdks-encrypt "python@main rust@main" \
+  --sdks-decrypt "python@main rust@main" \
+  --focus "python rust" \
+  test_tdfs.py
 ```
 
 ## CI
 
 Workflow: `.github/workflows/community-xtest.yml`
 
-- Runs on PRs that touch xtest / otdf-sdk-mgr / the workflow
-- Spins up platform via `opentdf/platform` composite action
-- Builds go@latest (floating otdfctl release) + community CLI(s)
+- Runs on PRs that touch xtest / otdf-sdk-mgr / the workflow / docs
+- Spins up platform via `opentdf/platform` composite (ubuntu) or native macOS action (swift)
+- Builds go@latest (fixtures) + community CLI(s)
+- Stage-1 + Stage-2 by default; `workflow_dispatch` input `stage` = `all` | `1` | `2`
 - Publishes HTML + junit + `supports.json` artifacts
 - Human report: https://arkavo-org.github.io/opentdf-tests/ (branch Pages)
-
 ## Badge ownership
 
 | Failure class | Owner |

--- a/docs/community-conformance.md
+++ b/docs/community-conformance.md
@@ -1,0 +1,70 @@
+# Community SDK Conformance
+
+This fork (`arkavo-org/opentdf-tests`) extends official OpenTDF `xtest` with **community SDKs**:
+
+| SDK | Repo | Stage-1 status |
+|-----|------|----------------|
+| **Python** | [b-long/opentdf-python-sdk](https://github.com/b-long/opentdf-python-sdk) | **Enabled** — ubuntu, python ↔ go@latest, Base TDF (`python-ref` default `latest`) |
+| **Rust** | [arkavo-org/opentdf-rs](https://github.com/arkavo-org/opentdf-rs) | **Enabled** — ubuntu, RSA wrap + KasClient rewrap (`rust-ref` default `latest`, 0.14.0+) |
+| **Swift** | [arkavo-org/OpenTDFKit](https://github.com/arkavo-org/OpenTDFKit) | **Enabled** — `macos-latest`, native Postgres+Keycloak (no Docker/Colima); CryptoKit; pin default `latest` (4.0.0+) |
+
+Full design: [community-xtest-design.md](./community-xtest-design.md).  
+**Format naming:** [FORMATS.md](./FORMATS.md) (Base TDF vs ZTDF vs NanoTDF).
+
+## What Stage-1 proves
+
+For each **kas-ready** community SDK:
+
+1. **Community encrypt → Go decrypt** (interop)
+2. **Go encrypt → Community decrypt** (interop)
+3. Container: **Base TDF (`tdf`) only** — not NATO ZTDF, not NanoTDF, not full ABAC/PQC
+4. Feature honesty: `cli.sh supports <feature>` must not advertise features that fail tests
+
+## Local setup (Python)
+
+```bash
+# Prerequisites: go, python 3.14, uv, docker + running platform (or CI)
+
+cd opentdf-tests
+
+# Link or checkout python SDK
+mkdir -p xtest/sdk/python/src
+ln -sfn "$(pwd)/../opentdf-python-sdk" xtest/sdk/python/src/main
+
+# Build dist/cli
+make -C xtest/sdk/python VERSIONS=main
+
+# Also need go@main for peer + attribute fixtures (see official xtest README)
+# Then:
+cd xtest
+uv sync
+set -a && source test.env && set +a
+uv run pytest -m stage1 --containers tdf \
+  --sdks-encrypt "python@main go@main" \
+  --sdks-decrypt "python@main go@main" \
+  --focus python \
+  test_tdfs.py
+```
+
+## CI
+
+Workflow: `.github/workflows/community-xtest.yml`
+
+- Runs on PRs that touch xtest / otdf-sdk-mgr / the workflow
+- Spins up platform via `opentdf/platform` composite action
+- Builds go@latest (floating otdfctl release) + community CLI(s)
+- Publishes HTML + junit + `supports.json` artifacts
+- Human report: https://arkavo-org.github.io/opentdf-tests/ (branch Pages)
+
+## Badge ownership
+
+| Failure class | Owner |
+|---------------|--------|
+| Harness / workflow / report bugs | `arkavo-org/opentdf-tests` |
+| Encrypt/decrypt/supports lies or crypto bugs | respective community SDK maintainers |
+
+## Offline probes (Rust / Swift)
+
+```bash
+./sdk/rust/dist/main/cli.sh supports tdf   # or legacy: supports ztdf
+```

--- a/docs/community-xtest-design.md
+++ b/docs/community-xtest-design.md
@@ -646,7 +646,7 @@ sequenceDiagram
 
 **Stage-0 (optional, offline SDKs):** golden/fixture decrypt-only or offline self-roundtrip under `XT_ALLOW_OFFLINE=1` — **not** branded as KAS interop on Pages (label `offline`).
 
-**Stage-2:** when ≥2 community SDKs are `kas-partial`+ for ztdf; optional nightly; not a blocking plan item if only python is ready.
+**Stage-2:** when ≥2 community SDKs are kas-ready for Base TDF — **enabled** (python × rust on ubuntu; python × rust × swift on macos). Same `test_tdf_roundtrip` / `-m stage1` cell; encrypt/decrypt peers are community-only (go remains for attribute fixtures).
 
 ### Python hybrid mode (detailed)
 

--- a/docs/community-xtest-design.md
+++ b/docs/community-xtest-design.md
@@ -1,0 +1,1329 @@
+# Community OpenTDF SDKs → xtest Conformance Integration
+
+| Field | Value |
+|-------|-------|
+| **Author** | arkavo-org / OpenTDF community (design owner: tests-fork maintainers) |
+| **Date** | 2026-07-12 |
+| **Status** | Draft (rev 3 — minor re-review fixes) |
+| **Workspace** | `/Users/arkavo/Projects/opentdf` |
+| **Primary target** | `opentdf-tests/` (fork of `opentdf/tests` → `arkavo-org/opentdf-tests`) |
+| **Community SDKs** | `opentdf-rs/`, `OpenTDFKit/`, `opentdf-python-sdk/` |
+
+---
+
+## Overview
+
+OpenTDF's official cross-SDK suite (`xtest`) currently exercises only the three first-party CLI adapters—Go (`otdfctl`), Java (`cmdline.jar`), and JS (`@opentdf/ctl`)—through a uniform `cli.sh` contract. Community SDKs (Rust, Swift, Python) implement substantial TDF crypto and, in Python's case, full platform auth via CLI—but they are not wired into the shared interop matrix. Adopters therefore cannot see, in one place, which platform features each SDK actually delivers, whether community encrypt×official decrypt (and the reverse) works, or how conformance is trending over time.
+
+This design extends the fork's xtest harness with a **community tier**: three additional SDK adapters under `xtest/sdk/{rust,swift,python}/`, `otdf-sdk-mgr` checkout/install support (without changing default official install targets), a **separate** `community-xtest.yml` workflow that does not explode the official matrix, data-driven capability and interop reports published to GitHub Pages, and an honesty gate for false `supports` claims with flake/infra/peer classification.
+
+**Near-term green path is Python only.** Rust ztdf and Swift ztdf are both **offline-style** today (static PEM / symmetric material, no client-credentials driven KAS PublicKey fetch + rewrap in the CLI). Each requires an SDK-repo PR series before Stage-1 KAS interop with `go@main`. Python hybrid mode (CLI default in CI; optional in-process for local speed) remains the velocity path for bugfix loops.
+
+---
+
+## Background & Motivation
+
+### Current official architecture
+
+The harness is centered on three layers:
+
+```mermaid
+flowchart TB
+  subgraph CI[".github/workflows/xtest.yml"]
+    RV[resolve-versions via otdf-sdk-mgr]
+    XCT["xct matrix: platform-tag × sdk-version"]
+    PLAT[opentdf/platform start-up-with-containers]
+    PY["pytest -n auto (xdist loadscope/worksteal) + pytest-html"]
+    ART[upload HTML artifacts + PR comment]
+    RV --> XCT --> PLAT --> PY --> ART
+  end
+
+  subgraph Harness["xtest/"]
+    CF[conftest.py: --sdks / --focus / parametrize]
+    TDFS["tdfs.py: SDK.encrypt/decrypt/supports"]
+    CLI["sdk/{go,java,js}/cli.sh → dist/<ver>/cli.sh"]
+    CF --> TDFS --> CLI
+  end
+
+  PY --> CF
+```
+
+**CLI contract** (documented in every `cli.sh`, invoked by `tdfs.SDK`):
+
+```text
+cli.sh encrypt <src> <dst> <fmt>
+cli.sh decrypt <src> <dst> <fmt>
+cli.sh supports <feature>    # exit 0 = yes, 1 = no, 2 = unknown
+```
+
+Configuration is environment-driven (`xtest/test.env` plus `XT_WITH_*` overrides):
+
+| Variable | Role |
+|----------|------|
+| `CLIENTID` / `CLIENTSECRET` | OAuth client credentials |
+| `PLATFORMURL` / `PLATFORMENDPOINT` | Platform base |
+| `KASURL` / `KCFULLURL` / `TOKENENDPOINT` | KAS / IdP / token URL |
+| `XT_WITH_ATTRIBUTES` | Comma-separated attribute FQNs |
+| `XT_WITH_ASSERTIONS` | Assertions JSON or path |
+| `XT_WITH_ECWRAP` | EC key wrapping |
+| `XT_WITH_ECDSA_BINDING` | ECDSA policy binding |
+| `XT_WITH_TARGET_MODE` | Spec target (`4.2.2` / `4.3.0`) |
+| `XT_WITH_KAS_ALLOWLIST` **and** `XT_WITH_KAS_ALLOW_LIST` | Decrypt allowlist (**both names**; see § Env naming) |
+| `XT_WITH_IGNORE_KAS_ALLOWLIST` | Bypass allowlist |
+| `XT_WITH_VERIFY_ASSERTIONS` / `XT_WITH_ASSERTION_VERIFICATION_KEYS` | Assertion verification |
+| `XT_WITH_MIME_TYPE` / `XT_WITH_PLAINTEXT_POLICY` | Encrypt options |
+
+#### Env naming: KAS allowlist inconsistency (harness debt)
+
+| Producer / consumer | Variable name |
+|---------------------|---------------|
+| `tdfs.SDK.decrypt` sets | `XT_WITH_KAS_ALLOWLIST` (no underscore between ALLOW and LIST) |
+| go / java / js `cli.sh` read | `XT_WITH_KAS_ALLOW_LIST` (underscore between ALLOW and LIST) |
+| OpenTDFKit `Config.swift` | Accepts **both** |
+
+**Community shims MUST accept either name** (Swift pattern). Optional follow-up (upstreamable, out of community critical path): make `tdfs.py` set both, or align official `cli.sh` to one name.
+
+**Type system** today (`xtest/tdfs.py`):
+
+```python
+sdk_type = Literal["go", "java", "js"]
+feature_type = Literal[
+    "assertions", "assertion_verification", "attribute_traversal",
+    "audit_logging", "autoconfigure", "better-messages-2024", "bulk_rewrap",
+    "connectrpc", "dpop", "dpop_nonce_challenge", "ecwrap", "hexless",
+    "hexaflexible", "kasallowlist", "key_management",
+    "mechanism-rsa-4096", "mechanism-ec-curves-384-521",
+    "mechanism-xwing", "mechanism-secpmlkem", "mechanism-mlkem",
+    "ns_grants", "obligations",
+]
+```
+
+`SDK.supports()` probes `cli.sh supports <feature>` (with a few hard-coded overrides for known false positives, e.g. JS `v0.2.0` + `key_management`). Tests parametrize `encrypt_sdk × decrypt_sdk × container` (`ztdf`, `ztdf-ecwrap`) via `conftest.py`.
+
+**otdf-sdk-mgr** (`config.py`) knows only official SDKs; `cli_install.py` uses `sdks or ALL_SDKS` for `stable` / `lts` / `tip`:
+
+```python
+ALL_SDKS = ["go", "js", "java"]  # must remain official-only
+```
+
+**CI matrix** (`.github/workflows/xtest.yml`): `platform-tag × sdk-version`. Official jobs already run **`pytest -n auto`** with `--dist loadscope` / `worksteal` (xdist is production, not aspirational). TESTING.md still notes historical flake risk and that earlier xdist attempts needed refactoring—both can be true. HTML reports are workflow artifacts with PR comment links. There is **no** GitHub Pages capability matrix and **no** historical bug-metrics store.
+
+**TESTING.md** flags: ~1200 tests when all combos run, decrypt I/O-heavy, HTML readability, data-driven feature config for reports.
+
+### Community SDK readiness (as of workspace review)
+
+#### Python — `opentdf-python-sdk` (`b-long/opentdf-python-sdk`) — **Stage-1 candidate**
+
+| Area | State |
+|------|--------|
+| CLI | `python -m otdf_python`: `encrypt` / `decrypt` / `inspect` |
+| Auth | Full platform client credentials + KAS allowlist + autoconfigure flag |
+| Contract gap | Flag shape differs from xtest positional contract; **no `supports` subcommand** |
+| Global vs subcommand flags | Parent-parser globals (`--platform-url`, `--client-id`, …) must appear **before** the subcommand |
+| Speed | Process-per-call re-inits SDK/auth |
+
+**Implication:** Only community SDK near-term ready for Stage-1 KAS interop with go after modest CLI work (`supports` + env credential fallbacks).
+
+#### Rust — `opentdf-rs` (`arkavo-org/opentdf-rs`) — **offline-only until R1+R2**
+
+| Area | State |
+|------|--------|
+| CLI surface | `examples/xtest_cli.rs`: `encrypt` / `decrypt` / `supports` for `tdf|ztdf|json|cbor` |
+| Auth / rewrap | **Offline path**: `TDF_KAS_URL`, `TDF_KAS_PUBLIC_KEY_PATH`, `TDF_SYMMETRIC_KEY_PATH` — not `CLIENTID`/`PLATFORMURL` OAuth |
+| ZIP encrypt | Builds manifest + segments; **does not wrap payload key with KAS public key** (`encrypt_zip`); JSON/CBOR EC-wrap with provided PEM |
+| KAS library | `KasClient` needs a **pre-acquired** `oauth_token` (passthrough); no client-credentials inside `KasClient` |
+| Token acquisition | Exists in tests (`tests/platform_integration.rs::get_access_token`) and docs—not in `xtest_cli` |
+| PublicKey fetch | `create_tdf_platform.rs` uses Connect `{root}/kas.AccessService/PublicKey` + RSA-OAEP wrap — **not wired into xtest_cli** |
+| Feature names | Custom (`tdf`, `kas-rewrap`, `aes-256-gcm`, …) — **do not match** `feature_type` |
+| **Honesty hazard** | `supports("kas-rewrap")` currently returns **true** while ZIP cannot be rewrapped by go — **R0 must flip this before any capability reporting** |
+| Cargo features | Example requires `kas-client` (+ `cbor` for current example); docs sometimes say `kas` — pin `kas-client,cbor` |
+
+#### Swift — `OpenTDFKit` (`arkavo-org/OpenTDFKit`) — **offline-only for ztdf until S1+S2**
+
+| Area | State |
+|------|--------|
+| Production CLI | `OpenTDFKitCLI`: `encrypt` / `decrypt` / `supports` / `verify` |
+| Config surface | `Config.swift` / help text **parse** `CLIENTID`, `CLIENTSECRET`, `KASURL`, `PLATFORMURL` |
+| **ztdf encrypt reality** | `buildTDFConfiguration` requires `TDF_KAS_PUBLIC_KEY` / `TDF_KAS_PUBLIC_KEY_PATH` (static PEM); uses `TDF_KAS_URL`/`KASURL` only as URL string — **no PublicKey fetch, no OAuth client-credentials** |
+| **ztdf decrypt reality** | Requires `TDF_SYMMETRIC_KEY_*` **or** (`TDF_PRIVATE_KEY`/`TDF_CLIENT_PRIVATE_KEY` PEM **plus** oauth token from `TDF_OAUTH_TOKEN` / `TDF_OAUTH_TOKEN_PATH` / `fresh_token.txt`) — **not** env-driven `CLIENTID`/`CLIENTSECRET` token acquisition |
+| Client-credentials | Exists only in `OpenTDFKitTests/IntegrationTests.swift` (`getOAuthToken`), not CLI |
+| Feature honesty | `supports` returns true for formats; false for almost all official `feature_type` values |
+| Stub | `xtest/cli.swift` — incomplete; **not for CI** |
+| Makefile | Kit-side `xtest/sdk/swift/Makefile` builds `OpenTDFKitCLI` → `dist/main` |
+| Manifest | `TDFManifest.swift` camelCase `CodingKeys` — snake_case bug appears fixed; `opentdf-rs/docs/INTEROPERABILITY.md` still claims snake_case (**stale docs chore**) |
+
+**Implication:** Prefer packaging `OpenTDFKitCLI` over the stub—but **do not** treat Swift as Stage-1 KAS-ready. Treat ztdf like Rust offline tier until an explicit OpenTDFKit PR implements OAuth + RSA KAS wrap/rewrap.
+
+### Pain points this design addresses
+
+1. Adopters cannot compare platform capabilities vs community SDK delivery in one report.
+2. No go↔community encrypt×decrypt confidence for SDKs that actually speak KAS (python near-term; rust/swift after SDK work).
+3. HTML artifacts are per-matrix-cell dumps; no durable capability/interop/bug-metrics dashboard.
+4. Official matrix is already large; naively adding 3 SDKs multiplies cost.
+5. Python process-per-call latency slows maintainer feedback loops.
+6. Offline CLIs (rust/swift ztdf) would produce false confidence if branded as full KAS interop.
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+
+1. Extend `sdk_type` with community tier: `rust`, `swift`, `python` (fork-first; acceptable for eventual upstream PR as a small Literal merge).
+2. Provide `xtest/sdk/{rust,swift,python}/` shims matching official `Makefile` + `cli.sh` + `dist/<ver>/`.
+3. Extend `otdf-sdk-mgr` for community checkout/install **without** expanding default `ALL_SDKS` install targets.
+4. Data-driven capability matrix + interop matrix + bug metrics on GitHub Pages.
+5. Keep official `xtest.yml` matrix size stable via separate `community-xtest.yml`.
+6. Stage interop: (1) community ↔ go@main for **kas-ready** SDKs only; (2) community × community when ≥2 community SDKs are kas-ready.
+7. Python hybrid execution modes (CLI CI / in-process local).
+8. Honesty gate for false `supports`, with infra/peer/flake classification and staged severity.
+9. Explicit Rust and Swift KAS CLI plans; honest offline tiers until rewrap lands.
+10. Prefer Swift `OpenTDFKitCLI` over stub; document that ztdf is offline today.
+
+### Non-Goals
+
+1. Merging community SDKs into upstream `opentdf/tests` in the first delivery.
+2. Full official ABAC/PQC/DPoP matrices for community on day one.
+3. Implementing all platform features inside community SDKs (measure and stage).
+4. Changing official go/java/js `cli.sh` contracts beyond optional shared report plumbing / allowlist dual-set in `tdfs.py`.
+5. NanoTDF / CBOR / JSON container coverage in Stage-1 (ztdf only).
+6. Making community SDKs part of official LTS release matrix.
+7. Hard-gating honesty on day one of community-xtest (warn first).
+
+### Success metrics (phased)
+
+| Horizon | Metric |
+|---------|--------|
+| **30 days** | Python Stage-1 basic ztdf green on main; report export artifacts on every community job; Pages skeleton with python-only data |
+| **60 days** | Honesty gate in **warn** with classification; Pages history ≥14 days; optional offline rust/swift capability probes only |
+| **90 days** | Honesty **error** for Stage-1 python cells; Rust **or** Swift kas-partial Stage-1 if SDK PRs land (not both required); open critical failures trending down |
+| **Stretch** | Second community SDK kas-ready → Stage-2 optional nightly |
+
+---
+
+## Proposed Design
+
+### Architecture layers
+
+```mermaid
+flowchart TB
+  subgraph CommunityCI["community-xtest.yml"]
+    CRV[resolve community + go pins]
+    CMAT["matrix: kas-ready community SDK × OS"]
+    CBUILD[build community CLI + go@main]
+    CTEST["pytest -m stage1"]
+    CPROBE[feature probe + junit/json export]
+    CPAGES[single-writer aggregate → Pages]
+    CRV --> CMAT --> CBUILD --> CTEST --> CPROBE --> CPAGES
+  end
+
+  subgraph OfficialCI["xtest.yml (unchanged core)"]
+    OXT[go/java/js matrix]
+  end
+
+  subgraph Shared["Shared harness"]
+    TDFS2["tdfs.py: sdk_type + python hybrid"]
+    MGR["otdf-sdk-mgr: COMMUNITY_SDKS separate from ALL_SDKS"]
+    RPT["xtest/reporting/"]
+    CAP["feature catalog from feature_type SSOT"]
+  end
+
+  subgraph SDKs["CLI adapters"]
+    GO[sdk/go]
+    JAVA[sdk/java]
+    JS[sdk/js]
+    RUST[sdk/rust]
+    SWIFT[sdk/swift]
+    PY[sdk/python]
+  end
+
+  CTEST --> TDFS2
+  OXT --> TDFS2
+  TDFS2 --> GO & JAVA & JS & RUST & SWIFT & PY
+  MGR --> RUST & SWIFT & PY
+  CPROBE --> RPT
+```
+
+**Design principle:** Keep go/java/js paths upstream-mergeable. Community code is additive. Shared `tdfs.py` / `conftest.py` changes stay small.
+
+### SDK tier model
+
+```python
+OfficialSDK = Literal["go", "java", "js"]
+CommunitySDK = Literal["rust", "swift", "python"]
+sdk_type = Literal[OfficialSDK, CommunitySDK]
+
+SDK_TIER = {
+    "go": "official", "java": "official", "js": "official",
+    "rust": "community", "swift": "community", "python": "community",
+}
+
+# Matrix inclusion readiness (orthogonal to supports())
+InteropTier = Literal[
+    "kas-full",      # Official env + KAS rewrap encrypt/decrypt for ztdf
+    "kas-partial",   # Stage-1 basic ztdf works; advanced features limited
+    "offline-only",  # PEM/symmetric path — excluded from Stage-1 KAS interop
+]
+```
+
+| SDK | Initial interop tier | Stage-1 KAS eligible |
+|-----|----------------------|----------------------|
+| go / java / js | `kas-full` | Yes (go is peer) |
+| **python** | `kas-partial` | **Yes** (after PR4 supports + env) |
+| **swift** | `offline-only` for ztdf | **No** until OpenTDFKit S1+S2 (PR10a) |
+| **rust** | `offline-only` | **No** until Rust R1+R2 (PR12a/b) |
+
+### CLI shim layout (tests fork)
+
+```text
+xtest/sdk/
+  Makefile                 # all: js go java   |   community: rust swift python
+  go/ java/ js/            # upstream-compatible
+  rust/  {Makefile, cli.sh}
+  swift/ {Makefile, cli.sh}
+  python/{Makefile, cli.sh}
+```
+
+Each `cli.sh` must:
+
+1. Locate xtest root (`pyproject.toml` name = `"xtest"`).
+2. Source `test.env`.
+3. Implement `supports` against canonical `feature_type` (unknown → exit 2).
+4. Map `XT_WITH_*` including **both** allowlist env names.
+5. Invoke dist-local binary/interpreter; never echo secrets.
+
+#### Rust `cli.sh`
+
+```bash
+# R0: supports for every official feature_type → exit 1
+# Offline encrypt/decrypt only if XT_ALLOW_OFFLINE=1
+# Post-R2: CLIENTID/CLIENTSECRET/PLATFORMURL/KASURL/TOKENENDPOINT path
+BINARY="$SCRIPT_DIR/xtest_cli"
+"$BINARY" "$@"
+```
+
+Makefile pin (Key Decision):
+
+```make
+cargo build --release --example xtest_cli --features kas-client,cbor
+```
+
+#### Swift `cli.sh`
+
+```bash
+BINARY="$SCRIPT_DIR/OpenTDFKitCLI"
+# Accept XT_WITH_KAS_ALLOWLIST or XT_WITH_KAS_ALLOW_LIST
+# Until S2: offline ztdf only under XT_ALLOW_OFFLINE=1; Stage-1 job disabled
+"$BINARY" "$1" "$2" "$3" "$4"
+```
+
+Do **not** use `xtest/cli.swift` stub for CI.
+
+#### Python `cli.sh` (canonical invocation order)
+
+Parent-parser globals **before** subcommand (argparse default; no `parse_intermixed_args` today):
+
+```bash
+PY="${SCRIPT_DIR}/.venv/bin/python"
+# Prefer env credential fallbacks added in PR4; never put CLIENTSECRET on argv
+export CLIENTID CLIENTSECRET PLATFORMURL KASURL
+
+case "$1" in
+  supports)
+    exec "$PY" -m otdf_python supports "$2"
+    ;;
+  encrypt)
+    args=(--platform-url "$PLATFORMURL" --kas-endpoint "$KASURL" --plaintext)
+    # credentials via env (PR4) or temp creds file written 0600 if needed
+    [[ -n "${XT_WITH_ATTRIBUTES:-}" ]] && args+=(--attributes "$XT_WITH_ATTRIBUTES")
+    [[ "${XT_WITH_ECDSA_BINDING:-}" == "true" ]] && args+=(--policy-binding ecdsa)
+    exec "$PY" -m otdf_python "${args[@]}" encrypt "$2" -o "$3"
+    ;;
+  decrypt)
+    args=(--platform-url "$PLATFORMURL" --kas-endpoint "$KASURL" --plaintext)
+    allow="${XT_WITH_KAS_ALLOWLIST:-${XT_WITH_KAS_ALLOW_LIST:-}}"
+    [[ -n "$allow" ]] && args+=(--kas-allowlist "$allow")
+    [[ "${XT_WITH_IGNORE_KAS_ALLOWLIST:-}" == "true" ]] && args+=(--ignore-kas-allowlist)
+    exec "$PY" -m otdf_python "${args[@]}" decrypt "$2" -o "$3"
+    ;;
+esac
+```
+
+Notes:
+
+- `--plaintext` means **HTTP** (not TLS), matching Python CLI—not attributes.
+- Many official `feature_type` values have no CLI flag yet → PR4 `supports` must stay conservative (return 1).
+
+### otdf-sdk-mgr extensions
+
+**Keep `ALL_SDKS` official-only** so `otdf-sdk-mgr install tip|stable|lts` without args does not try rust/swift/python and fail on missing toolchains.
+
+```python
+# config.py
+OFFICIAL_SDKS = ["go", "js", "java"]
+ALL_SDKS = OFFICIAL_SDKS  # unchanged semantics for install tip/stable/lts defaults
+
+COMMUNITY_SDKS = ["rust", "swift", "python"]
+
+SDK_GIT_URLS |= {
+    "rust": os.environ.get("OTDF_RUST_GIT_URL", "https://github.com/arkavo-org/opentdf-rs.git"),
+    "swift": os.environ.get("OTDF_SWIFT_GIT_URL", "https://github.com/arkavo-org/OpenTDFKit.git"),
+    "python": os.environ.get("OTDF_PYTHON_GIT_URL", "https://github.com/b-long/opentdf-python-sdk.git"),
+}
+
+SDK_BARE_REPOS |= {
+    "rust": "opentdf-rs.git",
+    "swift": "OpenTDFKit.git",
+    "python": "opentdf-python-sdk.git",
+}
+
+def get_sdk_dirs() -> dict[str, Path]:
+    sdk_dir = get_sdk_dir()
+    names = OFFICIAL_SDKS + COMMUNITY_SDKS
+    return {name: sdk_dir / name for name in names}
+```
+
+**CLI:**
+
+```bash
+otdf-sdk-mgr install tip              # go, js, java only
+otdf-sdk-mgr install tip rust         # explicit community
+otdf-sdk-mgr checkout python main
+otdf-sdk-mgr versions resolve swift main
+```
+
+`install stable` / release installers remain official-only until community packages exist on crates.io / PyPI / GitHub Releases. Community head builds: `checkout` + `make -C xtest/sdk/<lang>` (not `INSTALLERS` map).
+
+Unit tests: mock `make`/git; assert default tip does not include community.
+
+### Feature catalog (single source of truth)
+
+Do **not** hand-maintain a partial YAML that drifts from `feature_type`.
+
+```text
+xtest/capabilities/
+  generate_catalog.py   # emits feature_catalog.json from typing.get_args(tdfs.feature_type)
+  feature_catalog.json  # generated in CI and optionally committed
+```
+
+Descriptions may live in a small optional overlay map for human text only; **ids always come from `feature_type`**.
+
+### Reporting layout (flat suite — not `python -m xtest.…`)
+
+xtest is an **unpackaged flat suite** (`pyproject.toml`: “not a distributable package”). Modules live at the suite root (`tdfs.py`, `conftest.py`); there is **no** installable `xtest` Python package namespace. Reporting code must follow the same pattern:
+
+```text
+xtest/                          # cwd for uv run / pytest
+  tdfs.py
+  conftest.py
+  reporting/                    # regular package (reporting/__init__.py)
+    __init__.py
+    probe_supports.py
+    honesty.py                  # pytest plugin (listed in conftest pytest_plugins or -p)
+    generate_site.py
+    junit_interop.py
+    metrics.py
+    flake_quarantine.txt
+  capabilities/
+    generate_catalog.py
+```
+
+**Canonical invocations** (always `working-directory: …/xtest`, after `uv sync`):
+
+```bash
+# Pre-test feature probe
+uv run python -m reporting.probe_supports \
+  --sdk python --version main \
+  --cli sdk/python/dist/main/cli.sh \
+  -o report-out/supports.json
+
+# Catalog (CI or pre-commit)
+uv run python capabilities/generate_catalog.py -o capabilities/feature_catalog.json
+
+# Pages aggregate (pages-aggregate job; inputs = downloaded report-* dirs)
+uv run python -m reporting.generate_site \
+  --inputs ../artifacts \
+  --out _site
+
+# pytest discovers honesty via conftest (preferred):
+#   pytest_plugins = [..., "reporting.honesty"]
+# or: uv run pytest -p reporting.honesty ...
+```
+
+Do **not** use `python -m xtest.reporting.*` — that path does not exist unless someone later packages the suite (out of scope). Optional later: `[project.scripts]` entry points only if packaging is adopted; default remains flat `-m reporting.*` from cwd.
+
+### Report artifact contract
+
+Each `community-xct` matrix job uploads **one** artifact directory:
+
+```text
+report-{sdk}-{os}/          # artifact name: report-python-ubuntu-latest
+  junit.xml                 # pytest --junitxml=
+  pytest.html               # pytest-html self-contained
+  supports.json             # pre-test probe of all feature_type values
+  honesty.json              # session plugin output (may be empty findings)
+  meta.json                 # sdk, version, sha, platform ref/sha, go sha, run_id, interop_tier
+```
+
+**Who builds what:**
+
+| File | Producer |
+|------|----------|
+| `supports.json` | Pre-pytest step: `uv run python -m reporting.probe_supports …` (cwd = `xtest/`) |
+| `junit.xml` / `pytest.html` | pytest |
+| `honesty.json` | pytest plugin `reporting.honesty` (xdist-safe; workers send to controller) |
+| `interop.json` | **Aggregate job only** — `python -m reporting.junit_interop` over all `junit.xml` |
+| `capability.json` | Aggregate — merge `supports.json` + honesty classifications |
+| `versions.json` | Aggregate — from all `meta.json` |
+
+#### junit → interop mapping
+
+Parametrized nodeids look like:
+
+```text
+test_tdfs.py::test_tdf_roundtrip[python@main-go@main-ztdf-small-…]
+```
+
+Parser rules:
+
+1. Only count tests marked `stage1` (or nodeids matching the Stage-1 allowlist).
+2. Extract `encrypt_sdk`, `decrypt_sdk`, `container` from pytest param names / properties.
+3. Bucket outcomes: `passed` / `failed` / `skipped` / `error`.
+4. Emit one matrix cell per `(encrypt, decrypt, container)`.
+
+Example cell:
+
+```json
+{
+  "encrypt": "python@main",
+  "decrypt": "go@main",
+  "container": "ztdf",
+  "passed": 1,
+  "failed": 0,
+  "skipped": 0,
+  "errors": 0,
+  "tests": ["test_tdf_roundtrip[python@main-go@main-ztdf-…]"]
+}
+```
+
+**Skip policy for Pages:** display skip counts but **health badge** uses `failed+errors == 0` among non-skipped stage1 tests. Mass-skips (unsupported features) do not red-badge.
+
+#### Capability status transitions
+
+| Status | Rule |
+|--------|------|
+| `unsupported` | probe exit 1 (or 2 → unsupported + warning) |
+| `untested` | probe said supported (or not run) but no stage1 test exercised feature |
+| `supported` | probe exit 0 **and** at least one claiming-actor test passed for that feature **and** no `broken` |
+| `partial` | probe exit 0; subset of related tests skipped with documented reason (manual/override list) |
+| `broken` | classified honesty failure (see below) |
+
+### Honesty gate (false-advertising) — full classification
+
+```mermaid
+flowchart TD
+  FAIL[Test failed] --> INFRA{Infra signature?}
+  INFRA -->|yes| I[class: infra — not honesty]
+  INFRA -->|no| PEER{Claiming SDK was peer-only?}
+  PEER -->|go failed on community ciphertext; community encrypt OK| P[class: peer — attribute to go/platform]
+  PEER -->|no| ACTOR{Did claiming community SDK act?}
+  ACTOR -->|community encrypt failed after supports F| B1[broken candidate]
+  ACTOR -->|community decrypt of go golden failed after supports F| B2[broken candidate]
+  B1 --> FLAKE{N consecutive mains OR quarantine list?}
+  B2 --> FLAKE
+  FLAKE -->|flaky nodeid| F[class: flaky — track metrics, no gate]
+  FLAKE -->|stable| BR[class: broken]
+```
+
+**Rules:**
+
+1. **Only the claiming actor** can earn `broken`. If community encrypt succeeded and go decrypt failed, classify `peer` (or `infra` if KAS logs show rewrap errors from platform). Do not mark community `broken` for peer decrypt failure of a well-formed TDF.
+2. **Infra signatures:** connection refused, token endpoint 5xx, docker/platform health fail, missing `PLATFORMURL`, setup timeouts. Plugin reads pytest longrepr + optional env `XT_INFRA_HINT=1` set by workflow when platform step fails.
+3. **Flake detection:** fingerprint = normalized nodeid (sdk channel not SHA). `flaky` if fails then passes within 3 consecutive main runs, or nodeid on quarantine list `reporting/flake_quarantine.txt`. Require **N≥2 consecutive main failures** before honesty `error` severity counts a `broken`.
+4. **xdist safety:** use `pytest_sessionfinish` on controller only; workers report via `workeroutput` / `pytest-xdist` node hooks. Never `sys.exit` from worker.
+5. **Severity rollout (Key Decision):** `XT_COMMUNITY_HONESTY=warn` for first **4 weeks** after community-xtest is enabled on main; then `error` for Stage-1 python cells. Offline-tier jobs never error on honesty for official features they correctly reject.
+6. **Rollback:** set `XT_COMMUNITY_HONESTY=warn` or `off` in workflow env without code revert.
+
+#### Actor-vs-peer detection for monadic `test_tdf_roundtrip`
+
+Stage-1 still uses a **single** test that encrypts then decrypts. On failure the honesty plugin must classify **which leg failed** before applying actor/peer rules. Detection order (first match wins):
+
+| Priority | Signal | How | Classification hint |
+|----------|--------|-----|---------------------|
+| 1 | `subprocess.CalledProcessError.cmd` in longrepr / `reprcrash` | Look for `cli.sh` (or binary) argv containing `encrypt` vs `decrypt` as the subcommand token | encrypt leg → actor = `encrypt_sdk`; decrypt leg → actor = `decrypt_sdk` |
+| 2 | xtest log lines in captured stdout/stderr | `tdfs.py` logs `enc […]` before encrypt and `dec […]` before decrypt; if failure follows an `enc` line with no successful `dec`, treat as encrypt leg; if `dec` appears, treat as decrypt leg | same as above |
+| 3 | Ciphertext artifact existence | `EncryptFactory` / test tmp path: if `ct_file` missing or empty → encrypt leg; if `ct_file` exists and `rt_file` missing/mismatch → decrypt leg | same |
+| 4 | Ambiguous | No clear enc/dec signal | class = **`unclassified`** (during warn soak) or **`infra`** — **never** `broken` |
+
+**Pair with Stage-1 1a/1b** (narrows roles but does not replace leg detection):
+
+- **1a** `--sdks-encrypt community --sdks-decrypt go`: community is only blamed for `broken` on **encrypt-leg** failures (or if community claimed a feature required only on encrypt). Go decrypt-leg failure → `peer` (or `infra`).
+- **1b** `--sdks-encrypt go --sdks-decrypt community`: community is only blamed on **decrypt-leg** failures. Go encrypt-leg failure → `peer`.
+
+**Optional later hardening (not required for PR6):** split stage1 into `test_stage1_community_encrypt` (assert manifest/schema only) + `test_stage1_peer_decrypt` so junit nodeids encode the leg. Until then, use the table above.
+
+**Pseudo for plugin:**
+
+```python
+def classify_leg(report: pytest.TestReport) -> Literal["encrypt", "decrypt", "unknown"]:
+    text = (report.longreprtext or "") + "".join(report.sections and …)
+    # 1) cmd path
+    if re.search(r"cli\.sh['\"]?\s+encrypt\b|/encrypt\b", text):
+        if not re.search(r"cli\.sh['\"]?\s+decrypt\b", text):
+            return "encrypt"
+    if re.search(r"cli\.sh['\"]?\s+decrypt\b", text):
+        return "decrypt"
+    # 2) tdfs log markers
+    if "enc [" in text and "dec [" not in text:
+        return "encrypt"
+    if "dec [" in text:
+        return "decrypt"
+    return "unknown"
+```
+
+### Stage-1 test selection
+
+Do **not** run full `test_tdfs.py` for community Stage-1.
+
+```python
+# conftest.py or pytest.ini
+# marker: stage1 — basic ztdf roundtrip community ↔ go only
+
+# test_tdfs.py
+@pytest.mark.stage1
+def test_tdf_roundtrip(...):
+    ...
+```
+
+Community CI:
+
+```bash
+uv run pytest -n auto --dist loadscope \
+  -m stage1 \
+  --containers ztdf \
+  --sdks-encrypt "python@main" --sdks-decrypt "go@main" \
+  --junitxml=report-out/junit.xml \
+  --html=report-out/pytest.html --self-contained-html \
+  --export-report report-out \
+  test_tdfs.py
+
+# inverted 1b
+uv run pytest -n auto --dist loadscope -m stage1 \
+  --containers ztdf \
+  --sdks-encrypt "go@main" --sdks-decrypt "python@main" \
+  ...
+```
+
+Optional explicit allowlist if markers are too invasive for upstream merge:
+
+```text
+xtest/reporting/stage1_nodeids.txt
+test_tdfs.py::test_tdf_roundtrip
+```
+
+Later: expand markers for assertions/ecwrap only when community claims those features.
+
+### Interop stages
+
+```mermaid
+sequenceDiagram
+  participant C as Community CLI (kas-ready)
+  participant G as go@main
+  participant K as Platform + KAS
+
+  Note over C,K: Stage 1a — community encrypt → go decrypt
+  C->>K: OAuth + encrypt ztdf
+  C-->>G: ciphertext.tdf
+  G->>K: rewrap decrypt
+  G-->>G: plaintext match
+
+  Note over C,K: Stage 1b — go encrypt → community decrypt
+  G->>K: encrypt
+  G-->>C: ciphertext.tdf
+  C->>K: rewrap decrypt
+  C-->>C: plaintext match
+```
+
+**Stage-0 (optional, offline SDKs):** golden/fixture decrypt-only or offline self-roundtrip under `XT_ALLOW_OFFLINE=1` — **not** branded as KAS interop on Pages (label `offline`).
+
+**Stage-2:** when ≥2 community SDKs are `kas-partial`+ for ztdf; optional nightly; not a blocking plan item if only python is ready.
+
+### Python hybrid mode (detailed)
+
+| Mode | When | Requires dist cli.sh? |
+|------|------|------------------------|
+| `cli` (default) | CI, parity | Yes — full path `sdk/python/dist/<ver>/cli.sh` |
+| `inprocess` | Local bugfix | **Supports** still via CLI if present; encrypt/decrypt may use import path |
+
+**Constructor change:**
+
+```python
+class SDK:
+    def __init__(self, sdk: sdk_type, version: str = "main", *, require_cli: bool | None = None):
+        self.sdk = sdk
+        self.version = version
+        self.path = f"sdk/{sdk}/dist/{version}/cli.sh"
+        cli_required = require_cli if require_cli is not None else (
+            not (sdk == "python" and _python_mode() == "inprocess")
+        )
+        if cli_required and not os.path.isfile(self.path):
+            raise FileNotFoundError(...)
+        # inprocess: path optional; supports() falls back to inprocess feature table
+```
+
+**Import / install for inprocess:**
+
+- Optional extra in `xtest/pyproject.toml`: `[project.optional-dependencies] python-sdk = ["otdf-python"]`  
+- Or local: `uv pip install -e ../opentdf-python-sdk/packages/otdf-python` and `XT_PYTHON_MODE=inprocess`.
+- CI Stage-1 **always** `XT_PYTHON_MODE=cli`.
+
+**In-process mapping (PR9):**
+
+| XT_WITH / env | Builder / API |
+|---------------|---------------|
+| `PLATFORMURL` | `SDKBuilder.platform_endpoint` / `set_platform_endpoint` |
+| `KASURL` | KAS info on encrypt config |
+| `CLIENTID`/`CLIENTSECRET` | `client_secret(...)` |
+| `XT_WITH_ATTRIBUTES` | attributes on TDF config |
+| `XT_WITH_ECDSA_BINDING` | policy binding where supported |
+
+**Lifecycle:** per-call `SDKBuilder` with a **session-scoped token source cache** (reuse access token until expiry). Avoid sharing mutable SDK clients across tests to limit state bugs; cache only tokens/http transport if available.
+
+### Rust KAS path plan (expanded)
+
+#### Phase R0 — Offline tier + honesty baseline (blocking for any reporting)
+
+Acceptance:
+
+1. Official `feature_type` probes via `cli.sh supports` → **all exit 1**.
+2. Custom names (`kas-rewrap`, `tdf`, …) either removed from default `supports` or only true when `XT_ALLOW_OFFLINE=1` and **never** mixed into capability.json official grid.
+3. `interop_tier: offline-only`; excluded from Stage-1 matrix.
+4. Cargo: `cargo build --release --example xtest_cli --features kas-client,cbor`.
+
+#### Phase R1 — Encrypt with KAS PublicKey wrap (SDK PR12a)
+
+Port from `create_tdf_platform.rs`:
+
+1. Async runtime: convert `main` to `#[tokio::main]` (or `block_on`).
+2. Read `KASURL` / `PLATFORMURL` (official names; keep `TDF_*` aliases).
+3. Connect PublicKey: `{platform_root}/kas.AccessService/PublicKey` (strip trailing `/kas` as in example)—**not** legacy REST `/kas/v2/kas_public_key` from older tests.
+4. RSA-OAEP wrap payload key into `wrapped_key` on key access object; camelCase manifest.
+5. Optional `XT_WITH_ECWRAP=true` → EC wrap path when ready (may lag RSA).
+6. Write ztdf; go@main must decrypt (manual or Stage-1a preview).
+
+Files: `examples/xtest_cli.rs`, reuse `opentdf::kas_key::fetch_kas_public_key_connect`, `wrap_key_with_rsa_oaep`.
+
+#### Phase R2 — Decrypt via KasClient + token acquisition (SDK PR12b)
+
+`KasClient::new` does **not** do OAuth. Implement helper (new module e.g. `examples/xtest_oauth.rs` or `src/oauth_client_credentials.rs`):
+
+```text
+resolve_token_endpoint():
+  1. TOKENENDPOINT if set (test.env)
+  2. else KCFULLURL + "/protocol/openid-connect/token"
+  3. else PLATFORMURL well-known opentdf-configuration / OIDC discovery if available
+
+client_credentials_grant(token_url, CLIENTID, CLIENTSECRET) -> access_token
+  POST application/x-www-form-urlencoded
+  grant_type=client_credentials
+
+KasClient::new(config, access_token)
+  rewrap_standard_tdf / per-key-access rewrap
+  decrypt segments → plaintext file
+```
+
+Reference: `tests/platform_integration.rs::get_access_token` (form POST pattern). Prefer `TOKENENDPOINT` from `test.env` for xtest parity.
+
+#### Phase R3 — Feature alignment
+
+Only flip `supports` for official features after stage1 tests pass.
+
+### Swift KAS path plan (mirror Rust; **blocks Stage-1**)
+
+#### Phase S0 — Offline documentation
+
+- Prefer OpenTDFKitCLI; mark `xtest/cli.swift` deprecated for CI.
+- ztdf remains PEM/symmetric offline; capability tier `offline-only`.
+- `supports` stays false for official platform features.
+
+#### Phase S1 — Encrypt: OAuth optional + RSA PublicKey fetch + wrap (SDK PR10a part 1)
+
+1. Port client-credentials from `IntegrationTests.getOAuthToken` into CLI (shared helper).
+2. Fetch KAS public key (Connect preferred for platform main; align with kit's `KASService` / rewrap client).
+3. RSA-OAEP wrap for go interop (not nano EC-only path).
+4. Stop requiring `TDF_KAS_PUBLIC_KEY` when `CLIENTID`+`PLATFORMURL`+`KASURL` present.
+
+#### Phase S2 — Decrypt: client-credentials + correct KAS rewrap unwrap (SDK PR10a part 2)
+
+**Problem today:** `Commands.decryptTDF` generates a **P256** ephemeral for `rewrapTDF`, then unwraps `kasWrappedKey` with **RSA** `TDF_PRIVATE_KEY` via `TDFCrypto.unwrapSymmetricKeyWithRSA`, and **ignores** session/public material returned by rewrap. Nano paths already do the right thing with `KASRewrapClient.unwrapKey(wrappedKey:sessionPublicKey:clientPrivateKey:)`. S2 must **not** re-ship the RSA-private-key shortcut for Stage-1 ztdf.
+
+**S2 acceptance criteria (all required):**
+
+1. **OAuth:** acquire access token via client-credentials (`CLIENTID`/`CLIENTSECRET` + `TOKENENDPOINT`/`KCFULLURL`); do not require `TDF_OAUTH_TOKEN` / `fresh_token.txt` for Stage-1.
+2. **No pre-provisioned payload key:** Stage-1 ztdf decrypt must work **without** `TDF_SYMMETRIC_KEY` / `TDF_SYMMETRIC_KEY_PATH`.
+3. **No pre-provisioned KAS private key for rewrap unwrap:** must **not** require `TDF_PRIVATE_KEY` / `TDF_CLIENT_PRIVATE_KEY` to finish rewrap-based decrypt (those remain optional only for pure offline / local unwrap experiments under `XT_ALLOW_OFFLINE=1`).
+4. **Ephemeral session keypair matches rewrap algorithm:**
+   - Inspect each KAO (`wrapped` RSA vs `ec-wrapped`).
+   - Generate the client ephemeral keypair required by that rewrap mode (EC-P256 session for standard go-compatible rewrap; RSA only if protocol demands it).
+   - Pass the matching **public** key into `KASRewrapClient.rewrapTDF` (or successor API).
+5. **Unwrap with the matching ephemeral private key**, not a static RSA PEM:
+   - Prefer `KASRewrapClient.unwrapKey(wrappedKey:sessionPublicKey:clientPrivateKey:)` (already used for nano) using the **session public key from the rewrap response** (or the local ephemeral public) and the **local ephemeral private**.
+   - If split keys / multi-KAO, combine per existing TDF rules after each unwrap.
+6. **Payload decrypt:** feed recovered symmetric key into `TDFDecryptor` / streaming decrypt; write plaintext file for xtest.
+
+**Files to touch:** `OpenTDFKitCLI/Commands.swift` (`decryptTDF`), possibly `KASRewrapClient.swift` if ztdf rewrap result needs to expose `sessionPublicKey` the way nano does. Port token helper from `IntegrationTests.getOAuthToken`.
+
+**Non-goals for S2:** implementing every official `feature_type`; nano-only paths already closer—do not let nano success count as S2.
+
+Gate: S1+S2 green against go@main (community encrypt→go decrypt and go encrypt→community decrypt) before Swift matrix cell in community-xtest.
+
+### Swift / macOS platform ops (v1 procedure)
+
+**Decision:** v1 Swift Stage-1 runs on `macos-latest (native Postgres+Keycloak, no Docker)` **self-contained** (Colima + platform + OpenTDFKitCLI). arm64 `macos-latest` cannot run Colima nested virt on GHA.
+
+| Step | Detail |
+|------|--------|
+| Platform | Install Docker (or Colima) on macOS runner **or** build/run platform Go binary natively if composite is linux-only |
+| Default procedure | **Try** `opentdf/platform/test/start-up-with-containers` on macOS with Docker; if composite assumes Linux-only cgroup/network, fall back to **`otdf-local up`** with Docker Desktop/Colima (fork already vendors otdf-local) |
+| Timeout budget | 25 min platform boot + provision; 15 min SPM build (cache `~/.swiftpm`, DerivedData); 15 min pytest; job timeout 60–75 min |
+| Caches | SPM, Go modules, platform image layers |
+| Failure modes | Docker daemon not ready → retry 3×; port bind conflicts → `otdf-local down`; SPM resolve fail → clear cache |
+| Stretch | Linux Swift container on ubuntu sharing network with platform sidecars |
+
+Ubuntu jobs (python/rust Stage-1) keep official composite action unchanged.
+
+### CI strategy
+
+#### Official `xtest.yml`
+
+Unchanged matrix. Optional PR comment link to Pages URL on main.
+
+#### New `community-xtest.yml`
+
+Stage-1 still runs `test_tdf_roundtrip` (marked `stage1`), which needs the **same platform/fixture env as official “Run all standard xtests”**—not the multi-KAS ABAC job. Without these wires, fixtures fail before any interop assertion.
+
+**Required env / fixtures (parity with official xtest.yml standard jobs):**
+
+| Need | Source in official workflow | Community PR5 requirement |
+|------|----------------------------|---------------------------|
+| Platform process + ports | `opentdf/platform/test/start-up-with-containers` | Same composite (ubuntu) |
+| `PLATFORM_DIR` | `../../${{ steps.run-platform.outputs.platform-working-dir }}` | **Required** — fixtures (`fixtures/kas.py`) load `kas-cert.pem` from `$PLATFORM_DIR`; audit auto-discovers `$PLATFORM_DIR/logs` |
+| `PLATFORM_VERSION` | `go run ./service version` in platform dir | Set for `PlatformFeatureSet` |
+| `test.env` | sourced by each `cli.sh` | Ensure `CLIENTID`/`CLIENTSECRET`/`PLATFORMURL`/`KASURL`/`TOKENENDPOINT`/`KCFULLURL` present (default file in suite) |
+| go@main / otdfctl | setup-cli-tool + `make` in `sdk/go` | **Required** — `attribute_default_rsa` and related fixtures use otdfctl policy setup via go CLI |
+| `SCHEMA_FILE` | `manifest.schema.json` on standard xtest step | Set when schema validation runs (roundtrip path uses manifest helpers) |
+| Audit / rewrap asserts | `PLATFORM_LOG_FILE` or auto-discovery under `PLATFORM_DIR/logs` | Prefer explicit `PLATFORM_LOG_FILE` from composite platform log output when available; else rely on `PLATFORM_DIR` auto-discovery (`fixtures/audit.py` / `audit_logs.py`). Stage-1 does **not** need multi-KAS (`KAS_ALPHA_LOG_FILE`, …) or ABAC/PQC jobs |
+| Optional escape hatch | `--no-audit-logs` / `DISABLE_AUDIT_ASSERTIONS=1` | Only for local offline debugging—not default in community CI |
+
+**Not required for Stage-1:** additional KAS (alpha/beta/…), `test_abac.py` / `test_pqc.py` / `test_dpop.py`, key-management root-key matrix.
+
+```yaml
+name: Community X-Test
+on:
+  pull_request:
+    paths: [xtest/**, otdf-sdk-mgr/**, .github/workflows/community-xtest.yml]
+  schedule: [{ cron: "0 7 * * *" }]
+  workflow_dispatch:
+    inputs:
+      community-sdks: { default: "python" }  # expand when kas-ready
+      stage: { default: "1" }
+      honesty: { default: "warn" }           # warn | error | off
+
+permissions:
+  contents: read
+  packages: read
+  checks: write
+  pull-requests: write
+  pages: write          # only pages-aggregate job needs this
+  id-token: write       # deploy-pages
+
+jobs:
+  community-xct:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sdk: python
+            os: ubuntu-latest
+            interop_tier: kas-partial
+          # rust Stage-1: only after PR12b + tier flip
+          # swift Stage-1: only after PR10a + tier flip
+    steps:
+      - checkout tests fork
+      - uses: opentdf/platform/test/start-up-with-containers@…  # same pin family as official
+        id: run-platform
+      - setup-python / uv / go / (java|node only if needed for go peer tooling)
+      - install go@main CLI into xtest/sdk/go/dist/main   # otdfctl for attribute fixtures
+      - install community SDK into xtest/sdk/${{ matrix.sdk }}/dist/main
+      - name: Platform version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: echo "PLATFORM_VERSION=$(go run ./service version 2>&1)" >> "$GITHUB_ENV"
+      - name: Probe supports
+        working-directory: otdftests/xtest
+        run: |
+          mkdir -p report-out
+          uv run python -m reporting.probe_supports \
+            --sdk "${{ matrix.sdk }}" --version main \
+            --cli "sdk/${{ matrix.sdk }}/dist/main/cli.sh" \
+            -o report-out/supports.json
+      - name: Stage-1a community encrypt → go decrypt
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          SCHEMA_FILE: "manifest.schema.json"
+          XT_COMMUNITY_HONESTY: ${{ inputs.honesty || 'warn' }}
+          # test.env values applied via cli.sh source; PLATFORMURL/KASURL must match composite ports
+        run: |
+          uv run pytest -n auto --dist loadscope -m stage1 \
+            --containers ztdf \
+            --sdks-encrypt "${{ matrix.sdk }}@main" --sdks-decrypt "go@main" \
+            --junitxml=report-out/junit-1a.xml \
+            --html=report-out/pytest-1a.html --self-contained-html \
+            --export-report report-out \
+            test_tdfs.py
+      - name: Stage-1b go encrypt → community decrypt
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          SCHEMA_FILE: "manifest.schema.json"
+          XT_COMMUNITY_HONESTY: ${{ inputs.honesty || 'warn' }}
+        run: |
+          uv run pytest -n auto --dist loadscope -m stage1 \
+            --containers ztdf \
+            --sdks-encrypt "go@main" --sdks-decrypt "${{ matrix.sdk }}@main" \
+            --junitxml=report-out/junit-1b.xml \
+            --html=report-out/pytest-1b.html --self-contained-html \
+            --export-report report-out \
+            test_tdfs.py
+      - upload-artifact name: report-${{ matrix.sdk }}-${{ matrix.os }}
+        path: otdftests/xtest/report-out/
+
+  pages-aggregate:
+    if: github.ref == 'refs/heads/main' && always()
+    needs: community-xct
+    environment: github-pages
+    steps:
+      - download-artifact: report-*
+      - working-directory: otdftests/xtest
+        run: uv run python -m reporting.generate_site --inputs ../artifacts --out _site
+      - actions/upload-pages-artifact@v3
+      - actions/deploy-pages@v4
+```
+
+**PR visibility:** PR authors get **workflow artifact** links (junit/html/supports) via existing comment pattern—not live Pages. Pages = **main trend store only**.
+
+**Bootstrap (one-time):**
+
+1. Repo Settings → Pages → Source: GitHub Actions.
+2. Create `github-pages` environment (optional protection rules).
+3. Seed empty `_site/index.html` via first aggregate or manual workflow.
+
+**History / race:** **Single writer** `pages-aggregate` job only. Do **not** let matrix jobs commit history. Aggregate writes:
+
+```text
+_site/data/latest/{capability,interop,versions,honesty}.json
+_site/data/history/{run_id}.json          # immutable per run_id
+_site/data/history/daily/YYYY-MM-DD.json  # last aggregate of that UTC day overwrites once
+```
+
+Prefer **Pages artifact deploy** over `gh-pages` force-push. Daily rollup is computed in aggregate from current run + previously deployed `latest` downloaded via `actions/checkout` of Pages URL or cached artifact from last successful deploy (store `history/` inside uploaded Pages artifact by downloading previous pages artifact if available; if not, start fresh with warning).
+
+Simpler v1: keep last **30 run_id** histories inside each deploy artifact by downloading the previous pages build artifact when present; no git commit races.
+
+### Bug metrics model
+
+```json
+{
+  "schema_version": 1,
+  "date": "2026-07-12",
+  "open_failures": [
+    {
+      "id": "py-go-ztdf-roundtrip",
+      "fingerprint": "stage1|test_tdf_roundtrip|python@main|go@main|ztdf",
+      "class": "sdk|peer|infra|flaky|broken",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-07-12",
+      "consecutive_fails": 2,
+      "severity": "critical"
+    }
+  ],
+  "summary": { "open": 7, "resolved_7d": 2, "new_7d": 1, "flaky": 1, "infra": 0 }
+}
+```
+
+Fingerprinting normalizes version channels (`main` vs semver). Severity: Stage-1 ztdf fail = critical; honesty broken = medium/high; peer = tracked under go; infra excluded from open SDK failure counts.
+
+### Minimal changes to official paths
+
+| File | Change |
+|------|--------|
+| `xtest/tdfs.py` | `sdk_type`; python hybrid; optional dual allowlist env set; lazy cli path |
+| `xtest/conftest.py` | validators; `--python-mode`; `stage1` marker registration |
+| `xtest/sdk/Makefile` | `community` target only; `all` stays official |
+| `otdf-sdk-mgr/config.py` | `COMMUNITY_SDKS`; **do not** expand `ALL_SDKS` |
+| `otdf-sdk-mgr` checkout/resolve | community URLs |
+| `.github/workflows/xtest.yml` | no community matrix |
+| New: reporting, community workflow, community sdk dirs | primary surface |
+
+---
+
+## API / Interface Changes
+
+### `tdfs.sdk_type`
+
+```python
+sdk_type = Literal["go", "java", "js", "rust", "swift", "python"]
+```
+
+Fork-first; eventual upstream PR is a mechanical Literal merge (Key Decision: acceptable).
+
+### New pytest options
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `--python-mode {cli,inprocess}` | `cli` | Python backend |
+| `--interop-tier …` | `any` | Filter by readiness |
+| `--export-report DIR` | unset | Write supports/honesty sidecar files |
+| `-m stage1` | n/a | Minimal community interop tests |
+
+### `otdf-sdk-mgr`
+
+```bash
+otdf-sdk-mgr install tip           # official only
+otdf-sdk-mgr install tip python    # explicit
+```
+
+### Community SDK-side work
+
+| SDK | Work |
+|-----|------|
+| **Python** | `supports`; env fallbacks for `CLIENTID`/`CLIENTSECRET`/`PLATFORMURL`/`KASURL`; conservative feature claims |
+| **Rust** | R0 honesty flip; R1 encrypt Connect+RSA; R2 token helper + KasClient decrypt; async main |
+| **Swift** | S1/S2 OpenTDFKitCLI KAS path; port `getOAuthToken`; RSA wrap; rewrap decrypt without symmetric key file |
+
+---
+
+## Data Model Changes
+
+No platform DB schema. Artifacts only (see Report artifact contract).
+
+---
+
+## Alternatives Considered
+
+### 1. Fold community into official `xtest.yml` matrix
+
+Rejected: multiplies cost; Swift macOS; community red fails official; upstream hostility.
+
+### 2. Per-SDK suites only (no shared xtest)
+
+Rejected as sole approach: no shared interop pane; diverging vocabularies. Keep SDK-local tests **and** central xtest.
+
+### 3. Replace cli.sh with gRPC/JSON-RPC test agent
+
+Deferred: large protocol; rewrites official SDKs.
+
+### 4. Rust/Swift offline forever as “conformance”
+
+Rejected for branding: offline self-tests OK as Stage-0 label only.
+
+### 5. In-process Python only
+
+Rejected for CI: hybrid with CLI default.
+
+### 6. Golden/fixture-based Stage-0 interop (no live platform)
+
+- **Pros:** Fast; no platform boot; community decrypt of checked-in go TDFs.  
+- **Cons:** Stale goldens; no encrypt→go path; weak auth coverage.  
+- **Decision:** Optional offline/fixture job for rust/swift before KAS; **not** a substitute for Stage-1 when claiming kas-partial.
+
+### 7. `workflow_call` into official xtest with community matrix input
+
+- **Pros:** Reuse platform boot steps.  
+- **Cons:** Still couples failure signaling and runner labels; macOS matrix muddies official workflow.  
+- **Decision:** Prefer separate `community-xtest.yml`; may extract shared composite later.
+
+### 8. otdf-local-first for all community CI
+
+- **Pros:** Fork-owned; better macOS story.  
+- **Cons:** Diverges from official composite path on ubuntu; two ways to boot platform.  
+- **Decision:** Ubuntu community jobs use **same composite as official xtest**; macOS uses Docker+composite if viable else **otdf-local** (see Swift ops). Revisit unifying on otdf-local later.
+
+---
+
+## Security & Privacy Considerations
+
+| Threat | Severity | Mitigation |
+|--------|----------|------------|
+| Community CLI ignores KAS allowlist | High | Local platform only; honesty on `kasallowlist` when claimed |
+| `CLIENTSECRET` on argv / in logs | Medium | PR4 env fallbacks; shim never passes `--client-secret`; redact echo |
+| Supply chain third-party clones | Medium | Pin SHAs in meta.json; configurable URLs; CODEOWNERS on workflows |
+| Offline PEM material in artifacts | Low | Do not upload private keys |
+| Pages public data | Low | No secrets in report JSON |
+
+---
+
+## Observability
+
+| Signal | Mechanism |
+|--------|-----------|
+| Pass/fail/skip | junit + html artifacts (PR + main) |
+| Feature claims | supports.json → capability.json |
+| Honesty | honesty.json; warn→error rollout |
+| Interop | interop.json on Pages (main) |
+| Trends | history by run_id / daily |
+| Duration | Stage-1 python target ≤ 30–45 min including platform |
+
+Community jobs use **pytest-xdist** (`-n auto --dist loadscope`) like official CI; honesty plugin must be xdist-safe (Issue 4/14).
+
+---
+
+## Rollout Plan
+
+### Feature flags
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `XT_PYTHON_MODE` | `cli` | Python backend |
+| `XT_ALLOW_OFFLINE` | unset | Offline rust/swift paths |
+| `XT_COMMUNITY_HONESTY` | `warn` initially → `error` after 4 weeks | Honesty severity |
+| `OTDF_*_GIT_URL` | arkavo-org / b-long | Repo overrides |
+
+### Phased implementation readiness
+
+1. **Harness + python green path** (PR1–PR5) — implementable now.  
+2. **Reporting export + Pages** (PR6–PR8) — python-only data OK.  
+3. **Honesty warn** then **error** (PR6 export; PR15 hard gate).  
+4. **Swift/Rust KAS SDK work** (PR10a, PR12a/b) — readiness gates before matrix enable.  
+5. **Stage-2** only if ≥2 community kas-ready (criterion-gated, not forced).
+
+### Rollback
+
+- Workflow `if: false` / disable schedule.  
+- `XT_COMMUNITY_HONESTY=off`.  
+- Pages: redeploy previous artifact.  
+- Matrix cell removal for a SDK without reverting `sdk_type`.
+
+### Ownership of red badges (Key Decision)
+
+- **Workflow / harness / report bugs** → `arkavo-org/opentdf-tests` maintainers.  
+- **SDK encrypt/decrypt/supports lies or crypto bugs** → respective SDK maintainers (`CODEOWNERS` notify on honesty `broken` for that sdk).  
+- PR comments @mention from `meta.json` sdk field mapping.
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Rust/Swift KAS larger than expected | High | Offline tier; python-only Stage-1 |
+| Honesty false positives thrash badges | High | Classification + warn soak + N≥2 |
+| Swift macOS platform ops flaky | Medium | otdf-local fallback; 60–75m timeout |
+| Python shim flag order bugs | Medium | Documented parent-first CLI; CI tests |
+| Pages history loss | Low | run_id immutability; tolerate reset |
+| Cross-repo merge order | Medium | PR plan gates; pin SHAs |
+
+---
+
+## Open Questions
+
+1. **NanoTDF in a later stage?** Official containers are ztdf-only; Swift nano+KAS may work earlier than ztdf—product choice for Stage-1.5.  
+2. **Should `SdkName` in otdf-sdk-mgr scenarios include community SDKs?** Not required for pytest Stage-1.  
+3. **Org policy for building b-long / arkavo-org in CI** — assume public OSS OK; confirm if private runners needed.  
+4. **When expanding stage1 markers beyond roundtrip** — after first month green.
+
+*(Former OQs on otdf-local vs composite, badge ownership, Pages hosting, cargo features, honesty timeline, sdk_type upstream are now Key Decisions.)*
+
+---
+
+## Key Decisions
+
+1. **Separate `community-xtest.yml`** — isolate cost/failures from official matrix.  
+2. **Additive community sdk dirs + small `sdk_type` Literal extension** — upstream-mergeable; expanding `sdk_type` in shared files is **acceptable** for a later upstream PR.  
+3. **Stage-1 = kas-ready community ↔ go@main, `ztdf` only, `-m stage1`** — not full `test_tdfs.py`.  
+4. **Rust offline-only until R1+R2; R0 must clear false `kas-rewrap` supports** before reporting.  
+5. **Swift ztdf is offline-only today** despite Config parsing CLIENTID; OpenTDFKitCLI preferred over stub, but **requires PR10a KAS/OAuth work before Stage-1**.  
+6. **Python is the only near-term Stage-1 community SDK.**  
+7. **Python hybrid: CLI default CI; in-process local; lazy cli.sh for inprocess.**  
+8. **`ALL_SDKS` stays official-only; `COMMUNITY_SDKS` is explicit.**  
+9. **Cargo pin:** `cargo build --release --example xtest_cli --features kas-client,cbor`.  
+10. **Ubuntu platform:** official `start-up-with-containers` composite. **macOS:** Docker+composite if viable else otdf-local; self-contained runner.  
+11. **Pages:** GitHub Actions Pages (`upload-pages-artifact` + `deploy-pages`); main only; PRs use workflow artifacts. Single-writer aggregate; no matrix commits to history.  
+12. **Honesty:** classify infra/peer/flaky/broken; actor-only broken; N≥2 main fails; **warn 4 weeks then error** for Stage-1 python.  
+13. **Badge ownership:** harness→tests fork; SDK crypto/supports→SDK maintainers.  
+14. **Allowlist env:** community shims accept `XT_WITH_KAS_ALLOWLIST` and `XT_WITH_KAS_ALLOW_LIST`.  
+15. **Feature catalog SSOT:** generate from `feature_type`, not hand-waved YAML.  
+16. **Stage-2 is criterion-gated** (≥2 community kas-ready), not a forced date.  
+17. **Cross-repo order:** SDK KAS PRs merge before tests-fork matrix enable PRs (same as Rust PR12→PR13).
+
+---
+
+## References
+
+| Path | Relevance |
+|------|-----------|
+| `opentdf-tests/xtest/tdfs.py` | SDK abstraction; allowlist env set |
+| `opentdf-tests/xtest/sdk/{go,java,js}/cli.sh` | Official contract; `XT_WITH_KAS_ALLOW_LIST` |
+| `opentdf-tests/otdf-sdk-mgr/.../config.py` | `ALL_SDKS` |
+| `opentdf-tests/otdf-sdk-mgr/.../cli_install.py` | `sdks or ALL_SDKS` |
+| `opentdf-tests/.github/workflows/xtest.yml` | xdist `-n auto`; no Pages |
+| `opentdf-tests/TESTING.md` | Scale, readability, data-driven reports |
+| `opentdf-rs/examples/xtest_cli.rs` | Offline CLI; false `kas-rewrap` supports |
+| `opentdf-rs/examples/create_tdf_platform.rs` | Connect PublicKey + RSA wrap |
+| `opentdf-rs/src/kas.rs` | KasClient oauth_token passthrough |
+| `opentdf-rs/tests/platform_integration.rs` | client_credentials helper |
+| `opentdf-rs/docs/INTEROPERABILITY.md` | Stale Swift snake_case claim |
+| `OpenTDFKit/OpenTDFKitCLI/main.swift` | `buildTDFConfiguration` PEM path |
+| `OpenTDFKit/OpenTDFKitTests/IntegrationTests.swift` | `getOAuthToken` |
+| `OpenTDFKit/OpenTDFKit/TDF/TDFManifest.swift` | camelCase |
+| `opentdf-python-sdk/.../cli.py` | Parent flags + encrypt/decrypt |
+
+---
+
+## PR Plan
+
+Ordered, independently reviewable. Cross-repo noted.
+
+### PR1 — Harness: extend `sdk_type` + stage1 marker
+
+- **Title:** `xtest: add community sdk_type values and stage1 marker`
+- **Files:** `xtest/tdfs.py`, `xtest/conftest.py`, `xtest/test_tdfs.py` (marker on roundtrip), `xtest/AGENTS.md`
+- **Dependencies:** None
+- **Description:** Extend `sdk_type`; register `stage1`; dual-set allowlist env from decrypt (optional small fix); behavior unchanged without community dist.
+
+### PR2 — otdf-sdk-mgr: COMMUNITY_SDKS without expanding ALL_SDKS
+
+- **Title:** `otdf-sdk-mgr: register community SDKs; keep ALL_SDKS official-only`
+- **Files:** `config.py`, `checkout.py`, tests; **not** default tip targets
+- **Dependencies:** None (∥ PR1)
+- **Description:** `COMMUNITY_SDKS`, URLs, `get_sdk_dirs`; install tip without args still go/js/java only; tests assert that.
+
+### PR3 — Community Makefile/cli.sh scaffolding
+
+- **Title:** `xtest/sdk: rust/swift/python Makefile and cli.sh scaffolds`
+- **Files:** `xtest/sdk/{rust,swift,python}/*`, `xtest/sdk/Makefile` (`community` target)
+- **Dependencies:** PR2
+- **Description:** Shims fail clearly if missing binary; allowlist dual env; python parent-first invocation sketch; rust Makefile features pin.
+
+### PR4 — Python SDK: supports + env credentials (b-long repo)
+
+- **Title:** `otdf-python: supports subcommand + CLIENTID/PLATFORMURL env fallbacks`
+- **Files:** `cli.py`, tests
+- **Dependencies:** None (∥)
+- **Description:** Honest `supports`; read env for creds/URLs so shims never pass `--client-secret` on argv; conservative feature set.
+
+### PR5 — Python Stage-1 community-xtest (green path)
+
+- **Title:** `community-xtest: python ↔ go@main stage1 on ubuntu`
+- **Files:** `.github/workflows/community-xtest.yml` (python only), python cli.sh complete
+- **Dependencies:** PR1, PR3, PR4
+- **Description:** Platform composite (same family as official); install **go@main** for otdfctl attribute fixtures; set `PLATFORM_DIR`, `PLATFORM_LOG_FILE` (or rely on `$PLATFORM_DIR/logs` auto-discovery), `PLATFORM_VERSION`, `SCHEMA_FILE=manifest.schema.json`; run stage1 **1a and 1b** with env parity to official “standard xtests” (not multi-KAS ABAC); upload `report-python-ubuntu-latest`; **no honesty error yet**.
+
+### PR6 — Reporting export only (no hard gate)
+
+- **Title:** `xtest/reporting: supports probe, junit export hooks, schema_version`
+- **Files:** `xtest/reporting/` package (`-m reporting.*` from suite cwd), catalog generator from `feature_type`, `--export-report`, honesty leg classifier
+- **Dependencies:** PR1
+- **Description:** Flat-package `reporting/` (not `xtest.reporting`); produce supports.json; honesty plugin with enc/dec leg detection + warn only; **no** session fail on broken yet.
+
+### PR7 — GitHub Pages aggregate + deploy
+
+- **Title:** `ci: community conformance Pages via actions/deploy-pages`
+- **Files:** `reporting/generate_site.py`, pages-aggregate job, permissions, bootstrap docs
+- **Dependencies:** PR5, PR6
+- **Description:** Single-writer aggregate via `uv run python -m reporting.generate_site`; python-only data OK; PR comments stay on artifacts.
+
+### PR8 — Bug metrics history rollup
+
+- **Title:** `reporting: fingerprint history and trend summary on Pages`
+- **Files:** `metrics.py`, site charts
+- **Dependencies:** PR7
+- **Description:** run_id + daily rollups inside Pages artifact chain.
+
+### PR9 — Python in-process mode (non-gating)
+
+- **Title:** `xtest: XT_PYTHON_MODE=inprocess adapter`
+- **Files:** `tdfs.py`, `conftest.py`, optional `pyproject` extra, docs
+- **Dependencies:** PR1, PR5
+- **Description:** Lazy cli.sh; per-call builder + token cache; CI remains cli.
+
+### PR10a — OpenTDFKit: ztdf OAuth + RSA KAS wrap/rewrap (SDK repo)
+
+- **Title:** `OpenTDFKitCLI: client-credentials, PublicKey fetch, RSA wrap, rewrap decrypt`
+- **Files:** `OpenTDFKitCLI/*` (esp. `Commands.decryptTDF`), `KASRewrapClient` if needed, helper from IntegrationTests, tests
+- **Dependencies:** None on tests fork; **blocks PR10b**
+- **Description:** S1 encrypt (PublicKey fetch + RSA wrap). S2 decrypt: client-credentials; **ephemeral session keypair + `unwrapKey` (or equivalent) using rewrap session material—no `TDF_SYMMETRIC_KEY` / no static `TDF_PRIVATE_KEY` RSA shortcut** for Stage-1 ztdf. Honest supports only after tests.
+
+### PR10b — Swift Stage-1 enablement (tests fork)
+
+- **Title:** `community-xtest: enable swift ↔ go@main stage1 on macos`
+- **Files:** workflow matrix, swift cli.sh, macOS ops docs
+- **Dependencies:** PR10a, PR3, PR5, PR6
+- **Description:** Self-contained macOS platform procedure; stage1 only.
+
+### PR11 — Rust offline tier probe (not Stage-1)
+
+- **Title:** `community-xtest: rust offline capability probe + R0 supports honesty`
+- **Files:** rust cli.sh/Makefile, optional offline job, **R0 supports flip** (may be in SDK if code change needed)
+- **Dependencies:** PR3; SDK R0 supports fix if in-tree
+- **Description:** All official feature_type → unsupported; optional XT_ALLOW_OFFLINE self-test; no go interop.
+
+### PR12a — Rust R1 encrypt KAS wrap (SDK repo)
+
+- **Title:** `opentdf-rs: xtest_cli RSA PublicKey wrap encrypt (Connect)`
+- **Files:** `xtest_cli.rs`, helpers from `create_tdf_platform.rs`
+- **Dependencies:** R0 done
+- **Description:** Async encrypt path; go decrypt manual verification.
+
+### PR12b — Rust R2 decrypt token + KasClient (SDK repo)
+
+- **Title:** `opentdf-rs: xtest_cli client-credentials + KasClient rewrap decrypt`
+- **Files:** oauth helper, `xtest_cli.rs` decrypt path
+- **Dependencies:** PR12a
+- **Description:** TOKENENDPOINT/KCFULLURL discovery; form POST; rewrap_standard_tdf.
+
+### PR13 — Rust Stage-1 enablement
+
+- **Title:** `community-xtest: enable rust ↔ go@main stage1`
+- **Files:** workflow, tier flip, cli.sh
+- **Dependencies:** PR12b, PR5, PR6
+- **Description:** Ubuntu Stage-1 cell.
+
+### PR14 — Stage-2 community×community (optional / criterion-gated)
+
+- **Title:** `community-xtest: Stage-2 when ≥2 community SDKs kas-ready`
+- **Files:** workflow_dispatch stage=2
+- **Dependencies:** ≥2 of {PR5 stable, PR10b, PR13}
+- **Description:** Skip entire PR if criterion unmet; no open-ended commitment.
+
+### PR15 — Honesty hard gate + docs + INTEROPERABILITY chore
+
+- **Title:** `community-xtest: honesty error severity + conformance guide`
+- **Files:** honesty plugin gate, README/TESTING, note to fix `opentdf-rs/docs/INTEROPERABILITY.md` after first green zip interop (python or swift)
+- **Dependencies:** PR6–PR8; ≥4 weeks warn soak on main **or** manual flip
+- **Description:** `XT_COMMUNITY_HONESTY=error` for stage1 python; document ownership; stale snake_case docs PR in rust when evidence exists.
+
+### Rollback / kill-switch (not a PR—ops)
+
+- Workflow env `XT_COMMUNITY_HONESTY=off` or disable `community-xtest.yml` schedule; document in README.
+
+---
+
+## Cross-repo coordination
+
+```mermaid
+flowchart LR
+  PR4[Python supports PR] --> PR5[tests: python Stage-1]
+  PR10a[OpenTDFKit KAS CLI] --> PR10b[tests: swift Stage-1]
+  PR12a[Rust R1] --> PR12b[Rust R2] --> PR13[tests: rust Stage-1]
+  PR1 --> PR5
+  PR3 --> PR5
+```
+
+Pin community SHAs in workflow resolve output; fail closed if SDK ref missing.
+
+---
+
+*End of design document (rev 2).*

--- a/index.html
+++ b/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>OpenTDF Community SDK Conformance</title>
+  <style>
+    :root {
+      --bg: #0b1220;
+      --card: #121a2b;
+      --text: #e8eef7;
+      --muted: #9fb0c7;
+      --accent: #3d9cf0;
+      --ok: #2ecc71;
+      --bad: #e74c3c;
+      --warn: #f1c40f;
+      --border: #243147;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      background: radial-gradient(1200px 600px at 10% -10%, #1a2a44 0%, var(--bg) 55%);
+      color: var(--text);
+      line-height: 1.5;
+    }
+    header {
+      padding: 2.5rem 1.5rem 1rem;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+    h1 { margin: 0 0 0.4rem; font-size: 1.85rem; letter-spacing: -0.02em; }
+    .sub { color: var(--muted); max-width: 70ch; }
+    main { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 3rem; }
+    .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); margin: 1.5rem 0; }
+    .card {
+      background: color-mix(in srgb, var(--card) 92%, white 8%);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.1rem;
+    }
+    .card h2 { margin: 0 0 0.35rem; font-size: 1rem; color: var(--muted); font-weight: 600; }
+    .card .value { font-size: 1.35rem; font-weight: 700; }
+    .ok { color: var(--ok); }
+    .bad { color: var(--bad); }
+    .warn { color: var(--warn); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      font-size: 0.92rem;
+    }
+    th, td { padding: 0.65rem 0.75rem; border-bottom: 1px solid var(--border); text-align: left; }
+    th { background: #182338; color: var(--muted); font-weight: 600; }
+    tr:last-child td { border-bottom: 0; }
+    .pill {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+    .pill.ok { background: rgba(46,204,113,0.15); color: var(--ok); }
+    .pill.fail { background: rgba(231,76,60,0.15); color: var(--bad); }
+    .pill.skip { background: rgba(241,196,15,0.12); color: var(--warn); }
+    .pill.na { background: rgba(159,176,199,0.12); color: var(--muted); }
+    a { color: var(--accent); }
+    footer { color: var(--muted); font-size: 0.85rem; margin-top: 2rem; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.88em; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>OpenTDF Community SDK Conformance</h1>
+    <p class="sub">
+      Cross-SDK Stage-1 confidence for adopters: community encrypt ↔ go decrypt and the reverse,
+      <strong>Base TDF (<code>tdf</code>) only</strong> — not NATO ZTDF, not NanoTDF. Source:
+      <a href="https://github.com/arkavo-org/opentdf-tests/tree/community-xtest-stage1">arkavo-org/opentdf-tests</a>
+      · workflow <code>Community X-Test</code>.
+    </p>
+  </header>
+  <main>
+    <div class="grid">
+      <div class="card">
+        <h2>Stage-1 format</h2>
+        <div class="value">Base TDF (tdf)</div>
+      </div>
+      <div class="card">
+        <h2>Peer SDK</h2>
+        <div class="value">go@main</div>
+      </div>
+      <div class="card">
+        <h2>Platform</h2>
+        <div class="value">opentdf/platform@main</div>
+      </div>
+      <div class="card">
+        <h2>Pages source</h2>
+        <div class="value">community-xtest-stage1</div>
+      </div>
+    </div>
+
+    <h2>SDK readiness</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>SDK</th>
+          <th>Repo</th>
+          <th>Stage-1 path</th>
+          <th>CI job</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>python</strong></td>
+          <td><a href="https://github.com/b-long/opentdf-python-sdk">b-long/opentdf-python-sdk</a></td>
+          <td>platform auth + TDF CLI</td>
+          <td><span class="pill ok">ubuntu</span></td>
+          <td>First green path</td>
+        </tr>
+        <tr>
+          <td><strong>rust</strong></td>
+          <td><a href="https://github.com/arkavo-org/opentdf-rs">arkavo-org/opentdf-rs</a></td>
+          <td>RSA wrap + KasClient rewrap</td>
+          <td><span class="pill ok">ubuntu</span></td>
+          <td>schema 4.3.0 + RSA session-optional rewrap</td>
+        </tr>
+        <tr>
+          <td><strong>swift</strong></td>
+          <td><a href="https://github.com/arkavo-org/OpenTDFKit">arkavo-org/OpenTDFKit</a></td>
+          <td>OAuth + RSA wrap + ephemeral rewrap</td>
+          <td><span class="pill ok">macos-latest</span></td>
+          <td>CryptoKit/Security require Apple; Docker via Colima for platform</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 style="margin-top:2rem">Capability matrix (advertised <code>supports</code>)</h2>
+    <p class="sub">Conservative honesty: only claim features Stage-1 exercises or that the CLI proves.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Feature</th>
+          <th>python</th>
+          <th>rust</th>
+          <th>swift</th>
+          <th>go (peer)</th>
+        </tr>
+      </thead>
+      <tbody id="cap-body">
+        <!-- filled by script from summary.json if present -->
+      </tbody>
+    </table>
+
+    <h2 style="margin-top:2rem">Interop (Stage-1 directions)</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Encrypt → Decrypt</th>
+          <th>Expected</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>python → go</td><td><span class="pill ok">pass</span></td></tr>
+        <tr><td>go → python</td><td><span class="pill ok">pass</span></td></tr>
+        <tr><td>rust → go</td><td><span class="pill ok">target</span></td></tr>
+        <tr><td>go → rust</td><td><span class="pill ok">target</span></td></tr>
+        <tr><td>swift → go</td><td><span class="pill skip">macos CI</span></td></tr>
+        <tr><td>go → swift</td><td><span class="pill skip">macos CI</span></td></tr>
+      </tbody>
+    </table>
+
+    <h2 style="margin-top:2rem">Bug metrics</h2>
+    <p class="sub">
+      Historical fingerprints will roll up from CI junit artifacts (<code>supports.json</code> +
+      <code>*.junit.xml</code>). Live run artifacts are on
+      <a href="https://github.com/arkavo-org/opentdf-tests/actions/workflows/community-xtest.yml">Actions → Community X-Test</a>.
+    </p>
+    <div class="card" id="metrics-card">
+      <h2>Latest summary</h2>
+      <div class="value" id="metrics-value">Load <code>summary.json</code> after next CI publish…</div>
+    </div>
+
+    <footer>
+      <p>
+        Design: <a href="docs/community-xtest-design.md">docs/community-xtest-design.md</a>
+        · Adopter guide: <a href="docs/community-conformance.md">docs/community-conformance.md</a>
+        · Stage-1 is Base TDF only (see docs/FORMATS.md).
+      </p>
+      <p id="generated">Generated statically on branch community-xtest-stage1. CI can overwrite summary.json.</p>
+    </footer>
+  </main>
+  <script>
+    const FEATURES = [
+      "autoconfigure","connectrpc","hexless","hexaflexible","ecwrap","kasallowlist",
+      "assertions","dpop","key_management","obligations"
+    ];
+    const DEFAULT = {
+      python: { autoconfigure:"supported", connectrpc:"supported", hexless:"supported", hexaflexible:"unsupported", ecwrap:"unsupported", kasallowlist:"supported", assertions:"unsupported", dpop:"unsupported", key_management:"unsupported", obligations:"unsupported" },
+      rust:   { autoconfigure:"unsupported", connectrpc:"supported", hexless:"supported", hexaflexible:"unsupported", ecwrap:"unsupported", kasallowlist:"unsupported", assertions:"unsupported", dpop:"unsupported", key_management:"unsupported", obligations:"unsupported" },
+      swift:  { autoconfigure:"unsupported", connectrpc:"supported", hexless:"supported", hexaflexible:"unsupported", ecwrap:"unsupported", kasallowlist:"unsupported", assertions:"unsupported", dpop:"unsupported", key_management:"unsupported", obligations:"unsupported" },
+      go:     { autoconfigure:"supported", connectrpc:"supported", hexless:"supported", hexaflexible:"supported", ecwrap:"supported", kasallowlist:"supported", assertions:"supported", dpop:"supported", key_management:"supported", obligations:"supported" },
+    };
+    function cell(v) {
+      if (v === "supported") return '<span class="pill ok">supported</span>';
+      if (v === "unsupported") return '<span class="pill fail">unsupported</span>';
+      return '<span class="pill na">' + (v || "—") + '</span>';
+    }
+    function render(matrix) {
+      const body = document.getElementById("cap-body");
+      body.innerHTML = FEATURES.map(f => {
+        return `<tr><td><code>${f}</code></td><td>${cell(matrix.python[f])}</td><td>${cell(matrix.rust[f])}</td><td>${cell(matrix.swift[f])}</td><td>${cell(matrix.go[f])}</td></tr>`;
+      }).join("");
+    }
+    render(DEFAULT);
+    fetch("summary.json").then(r => r.ok ? r.json() : null).then(data => {
+      if (!data) return;
+      document.getElementById("metrics-value").textContent =
+        `reports=${(data.reports||[]).length} generated_at=${data.generated_at || "n/a"}`;
+      document.getElementById("generated").textContent = "Last summary.json: " + (data.generated_at || "");
+    }).catch(() => {});
+  </script>
+</body>
+</html>

--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/config.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/config.py
@@ -38,21 +38,30 @@ def get_sdk_dir() -> Path:
 
 
 def get_sdk_dirs() -> dict[str, Path]:
-    """Return per-SDK directories keyed by SDK name."""
+    """Return per-SDK directories keyed by SDK name (official + community)."""
     sdk_dir = get_sdk_dir()
     return {
         "go": sdk_dir / "go",
         "js": sdk_dir / "js",
         "java": sdk_dir / "java",
+        "rust": sdk_dir / "rust",
+        "swift": sdk_dir / "swift",
+        "python": sdk_dir / "python",
     }
 
 
-# Git repository URLs
+# Git repository URLs (overridable via OTDF_*_GIT_URL env vars in CI)
 SDK_GIT_URLS: dict[str, str] = {
     "go": "https://github.com/opentdf/otdfctl.git",
     "java": "https://github.com/opentdf/java-sdk.git",
     "js": "https://github.com/opentdf/web-sdk.git",
     "platform": "https://github.com/opentdf/platform.git",
+    # Community SDKs (fork defaults; override with OTDF_RUST_GIT_URL etc.)
+    "rust": os.environ.get("OTDF_RUST_GIT_URL", "https://github.com/arkavo-org/opentdf-rs.git"),
+    "swift": os.environ.get("OTDF_SWIFT_GIT_URL", "https://github.com/arkavo-org/OpenTDFKit.git"),
+    "python": os.environ.get(
+        "OTDF_PYTHON_GIT_URL", "https://github.com/b-long/opentdf-python-sdk.git"
+    ),
 }
 
 SDK_NPM_PACKAGES: dict[str, str] = {
@@ -120,6 +129,9 @@ JAVA_PLATFORM_BRANCH_MAP: dict[str, str] = {
 SDK_BARE_REPOS: dict[str, str] = {
     "java": "java-sdk.git",
     "js": "web-sdk.git",
+    "rust": "opentdf-rs.git",
+    "swift": "OpenTDFKit.git",
+    "python": "opentdf-python-sdk.git",
 }
 
 # Tag infixes for monorepo tag resolution
@@ -129,4 +141,11 @@ SDK_TAG_INFIXES: dict[str, str] = {
 }
 
 
+# Official SDKs only — default install/checkout/clean must not pull community.
 ALL_SDKS = ["go", "js", "java"]
+
+# Community SDKs (fork). Explicit install/checkout only; never folded into ALL_SDKS.
+COMMUNITY_SDKS = ["rust", "swift", "python"]
+
+# All SDKs known to otdf-sdk-mgr (official + community).
+KNOWN_SDKS = ALL_SDKS + COMMUNITY_SDKS

--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/schema.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/schema.py
@@ -13,7 +13,14 @@ from datetime import date
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from ruamel.yaml import YAML, YAMLError
 
 API_VERSION = "opentdf.io/v1alpha1"
@@ -36,7 +43,18 @@ API_VERSION = "opentdf.io/v1alpha1"
 
 KasMode = Literal["standard", "key_management"]
 SdkName = Literal["go", "java", "js"]
-ContainerKind = Literal["ztdf", "ztdf-ecwrap"]
+# Canonical Base TDF profiles (docs/FORMATS.md). Legacy "ztdf" normalizes to tdf.
+ContainerKind = Literal["tdf", "tdf-ecwrap"]
+
+_CONTAINER_ALIASES: dict[str, ContainerKind] = {
+    "tdf": "tdf",
+    "base-tdf": "tdf",
+    "standard-tdf": "tdf",
+    "ztdf": "tdf",  # legacy OpenTDF tooling name for Base TDF ZIP
+    "tdf-ecwrap": "tdf-ecwrap",
+    "base-tdf-ecwrap": "tdf-ecwrap",
+    "ztdf-ecwrap": "tdf-ecwrap",
+}
 
 
 class _StrictModel(BaseModel):
@@ -199,10 +217,27 @@ class Suite(_StrictModel):
     kexpr: str | None = Field(default=None, description="Forwarded to pytest -k")
     containers: list[ContainerKind] = Field(
         default_factory=list,
-        description="Forwarded to --containers as a whitespace-separated list",
+        description=(
+            "Format profiles for --containers: tdf (Base TDF), tdf-ecwrap. "
+            "Legacy aliases ztdf / ztdf-ecwrap normalize to tdf / tdf-ecwrap."
+        ),
     )
     markers: str | None = Field(default=None, description="Forwarded to -m")
     extra_args: list[str] = Field(default_factory=list)
+
+    @field_validator("containers", mode="before")
+    @classmethod
+    def _normalize_containers(cls, value: object) -> object:
+        if not isinstance(value, list):
+            return value
+        out: list[str] = []
+        for item in value:
+            key = str(item).strip().lower()
+            if key in _CONTAINER_ALIASES:
+                out.append(_CONTAINER_ALIASES[key])
+            else:
+                out.append(str(item))
+        return out
 
 
 class Scenario(_StrictModel):

--- a/otdf-sdk-mgr/tests/test_community_config.py
+++ b/otdf-sdk-mgr/tests/test_community_config.py
@@ -1,0 +1,37 @@
+"""Community SDK registration must not pollute official ALL_SDKS defaults."""
+
+from otdf_sdk_mgr.config import (
+    ALL_SDKS,
+    COMMUNITY_SDKS,
+    KNOWN_SDKS,
+    SDK_BARE_REPOS,
+    SDK_GIT_URLS,
+    get_sdk_dirs,
+)
+
+
+def test_all_sdks_official_only():
+    assert ALL_SDKS == ["go", "js", "java"]
+    assert "python" not in ALL_SDKS
+    assert "rust" not in ALL_SDKS
+    assert "swift" not in ALL_SDKS
+
+
+def test_community_sdks_registered():
+    assert COMMUNITY_SDKS == ["rust", "swift", "python"]
+    assert set(KNOWN_SDKS) == set(ALL_SDKS + COMMUNITY_SDKS)
+
+
+def test_community_git_urls():
+    for sdk in COMMUNITY_SDKS:
+        assert sdk in SDK_GIT_URLS
+        assert SDK_GIT_URLS[sdk].startswith("https://")
+        assert sdk in SDK_BARE_REPOS
+
+
+def test_get_sdk_dirs_includes_community(monkeypatch, tmp_path):
+    monkeypatch.setenv("OTDF_SDK_DIR", str(tmp_path))
+    dirs = get_sdk_dirs()
+    for name in ALL_SDKS + COMMUNITY_SDKS:
+        assert name in dirs
+        assert dirs[name] == tmp_path / name

--- a/otdf-sdk-mgr/tests/test_schema.py
+++ b/otdf-sdk-mgr/tests/test_schema.py
@@ -47,7 +47,7 @@ suite:
   targets:
     - "xtest/test_tdfs.py::test_tdf_roundtrip"
   containers:
-    - ztdf
+    - tdf
 """
 
 
@@ -64,7 +64,7 @@ def test_scenario_roundtrip(tmp_path: Path) -> None:
     assert scenario.sdks.decrypt[0].sdk == "java"
     assert scenario.sdks.decrypt[0].version == "0.7.8"
     assert scenario.suite.targets == ["xtest/test_tdfs.py::test_tdf_roundtrip"]
-    assert scenario.suite.containers == ["ztdf"]
+    assert scenario.suite.containers == ["tdf"]
 
 
 def test_platform_pin_requires_exactly_one_source() -> None:

--- a/summary.json
+++ b/summary.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "generated_at": "bootstrap",
+  "stage": 1,
+  "container": "tdf",
+  "format_profile": "base-tdf",
+  "peer": "go@main",
+  "reports": [],
+  "note": "Populated by community-xtest / pages publish job"
+}

--- a/xtest/AGENTS.md
+++ b/xtest/AGENTS.md
@@ -1,7 +1,11 @@
 # xtest - Agent Guide
 
 The cross-client integration test suite. pytest with custom options that
-fan out tests across SDK CLIs (`go`, `java`, `js`) and TDF container types.
+fan out tests across SDK CLIs (`go`, `java`, `js`, plus community
+`python` / `rust` / `swift`) and TDF container types.
+
+Community Stage-1 uses `@pytest.mark.stage1` on basic **Base TDF** (`tdf`)
+roundtrip only — see `../docs/community-conformance.md` and `../docs/FORMATS.md`.
 
 For env-variable setup, audit-log details, and common-failure recipes,
 see the root `AGENTS.md`. This guide focuses on test authoring and the
@@ -15,7 +19,8 @@ fixture system.
 | `conftest.py` | `pytest_addoption` + the encrypt/decrypt SDK parametrization. Defines `--sdks`, `--sdks-encrypt`, `--sdks-decrypt`, `--containers`, `--no-audit-logs`. |
 | `fixtures/` | Module-scoped pytest fixtures: `attributes.py`, `keys.py`, `audit.py`, `assertions.py`, `kas.py`, `encryption.py`, `obligations.py`. |
 | `tdfs.py` | SDK abstraction layer — wraps the `cli.sh` shims under `sdk/<lang>/dist/<version>/`. |
-| `sdk/{go,java,js}/dist/<version>/` | SDK CLI builds. Installed by `otdf-sdk-mgr install` (see `../otdf-sdk-mgr/AGENTS.md`). |
+| `sdk/{go,java,js}/dist/<version>/` | Official SDK CLI builds. Installed by `otdf-sdk-mgr install`. |
+| `sdk/{python,rust,swift}/dist/<version>/` | Community SDK CLI builds (`make -C sdk/python`, etc.). |
 | `test.env` | Default endpoint and client-credential env vars. Source with `set -a && source test.env && set +a`. |
 
 ## Custom pytest Options (defined in `conftest.py`)
@@ -24,7 +29,7 @@ fixture system.
 |--------|---------|
 | `--sdks "go java js"` | Which SDKs to use for both encrypt and decrypt. |
 | `--sdks-encrypt`, `--sdks-decrypt` | Asymmetric encrypt/decrypt SDK selection (use when reproducing cross-SDK interop bugs). |
-| `--containers ztdf ztdf-ecwrap` | Which TDF container types to exercise. |
+| `--containers tdf tdf-ecwrap` | Which format profiles to exercise (Base TDF; aliases: `ztdf`→`tdf`). See `docs/FORMATS.md`. |
 | `--no-audit-logs` | Skip audit-log assertions for this run. CLI equivalent of `DISABLE_AUDIT_ASSERTIONS=1`. |
 
 ## Authoring a New Test

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -88,10 +88,22 @@ def pytest_addoption(parser: pytest.Parser):
         help="comma-separated list of docker compose services to monitor for audit logs",
         type=lambda s: [s.strip() for s in s.split(",")],
     )
+
+    def containers_opt(v: str) -> str:
+        """Validate whitespace-separated container profiles (canonical or aliases)."""
+        if not v.strip():
+            raise ValueError("At least one container profile is required")
+        for tok in v.split():
+            tdfs.normalize_container(tok)  # raises ValueError if unknown
+        return v
+
     parser.addoption(
         "--containers",
-        help=f"which container formats to test, one or more of {englist(typing.get_args(tdfs.container_type))}",
-        type=is_type_or_list_of_types(tdfs.container_type),
+        help=(
+            "which container profiles to test: tdf (Base TDF), tdf-ecwrap; "
+            "aliases: base-tdf, ztdf (legacy→tdf), ztdf-ecwrap. See docs/FORMATS.md"
+        ),
+        type=containers_opt,
     )
     parser.addoption(
         "--focus",
@@ -138,7 +150,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
     - encrypt_sdk: which SDK(s) to use for encryption
     - decrypt_sdk: which SDK(s) to use for decryption
     - in_focus: filter tests by SDK focus
-    - container: which container formats to test (ztdf, ztdf-ecwrap)
+    - container: which container profiles to test (tdf, tdf-ecwrap; aliases ok)
     """
     if "size" in metafunc.fixturenames:
         metafunc.parametrize(
@@ -160,13 +172,33 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
                 raise ValueError(f"Invalid value for {name}: {i}, must be one of {ttt}")
         return a
 
+    def containers_list_opt() -> list[tdfs.container_type]:
+        v = metafunc.config.getoption("--containers")
+        if not v:
+            return list(typing.get_args(tdfs.container_type))
+        if type(v) is not str:
+            raise ValueError(f"Invalid value for --containers: {v}")
+        # Preserve order, drop duplicate canonical names
+        seen: set[tdfs.container_type] = set()
+        out: list[tdfs.container_type] = []
+        for tok in v.split():
+            c = tdfs.normalize_container(tok)
+            if c not in seen:
+                seen.add(c)
+                out.append(c)
+        return out
+
     def sdk_specs_opt(names: list[str]) -> list[str]:
-        """Return SDK specifier tokens from the first matching option, or all sdk types."""
+        """Return SDK specifier tokens from the first matching option.
+
+        Default is official SDKs only (go/java/js) so community dists are
+        opt-in via --sdks / --sdks-encrypt / --sdks-decrypt.
+        """
         for name in names:
             v = metafunc.config.getoption(name)
             if v:
                 return v.split()
-        return list(typing.get_args(tdfs.sdk_type))
+        return list(tdfs.OFFICIAL_SDKS)
 
     subject_sdks: set[tdfs.SDK] = set()
 
@@ -206,13 +238,10 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
         metafunc.parametrize("in_focus", [focused_sdks])
 
     if "container" in metafunc.fixturenames:
-        containers: list[tdfs.container_type] = []
-        if metafunc.config.getoption("--containers"):
-            containers = cast(
-                list[tdfs.container_type], list_opt("--containers", tdfs.container_type)
-            )
-        else:
-            containers = list(typing.get_args(tdfs.container_type))
+        try:
+            containers = containers_list_opt()
+        except ValueError as e:
+            raise pytest.UsageError(str(e)) from e
         metafunc.parametrize("container", containers)
 
 

--- a/xtest/fixtures/encryption.py
+++ b/xtest/fixtures/encryption.py
@@ -35,7 +35,7 @@ class EncryptFactory:
         self,
         encrypt_sdk: tdfs.SDK,
         *,
-        container: tdfs.container_type = "ztdf",
+        container: tdfs.container_type = "tdf",
         attr_values: list[str] | None = None,
         target_mode: tdfs.container_version | None = None,
         az: str = "",

--- a/xtest/pyproject.toml
+++ b/xtest/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "construct>=2.10.70",
     "construct-typing>=0.7.0",
     "cryptography>=48.0.1",
+    "defusedxml>=0.7.1",
     "gitdb>=4.0.12",
     "GitPython>=3.1.50",
     "idna>=3.18",

--- a/xtest/pyproject.toml
+++ b/xtest/pyproject.toml
@@ -100,3 +100,7 @@ testpaths = ["."]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-ra -v"
+markers = [
+    "stage1: community Stage-1 basic Base TDF (tdf) roundtrip (community ↔ go)",
+    "integration: requires a running platform",
+]

--- a/xtest/reporting/__init__.py
+++ b/xtest/reporting/__init__.py
@@ -1,0 +1,5 @@
+"""Reporting helpers for community conformance (run as `uv run python -m reporting.*` from xtest/)."""
+
+__all__ = ["schema_version"]
+
+schema_version = 1

--- a/xtest/reporting/export_supports.py
+++ b/xtest/reporting/export_supports.py
@@ -1,0 +1,109 @@
+"""Export an SDK capability snapshot (supports.json) for the Pages report.
+
+Usage (from xtest/ cwd, after the SDK CLI dist is built):
+  uv run python -m reporting.export_supports --sdk python \\
+    --sdk-ref "$PYTHON_REF" --out test-results
+
+Probes ``sdk/<sdk>/dist/<version>/cli.sh supports <feature>`` for every
+known feature and writes supports.json + meta.json under
+``<out>/report-<sdk>-<os>/``, which reporting.generate_site consumes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+FEATURES = [
+    "assertions",
+    "assertion_verification",
+    "attribute_traversal",
+    "audit_logging",
+    "autoconfigure",
+    "better-messages-2024",
+    "bulk_rewrap",
+    "connectrpc",
+    "dpop",
+    "dpop_nonce_challenge",
+    "ecwrap",
+    "hexless",
+    "hexaflexible",
+    "kasallowlist",
+    "key_management",
+    "mechanism-rsa-4096",
+    "mechanism-ec-curves-384-521",
+    "mechanism-xwing",
+    "mechanism-secpmlkem",
+    "mechanism-mlkem",
+    "ns_grants",
+    "obligations",
+]
+
+
+def probe(cli: Path, feature: str) -> str:
+    try:
+        result = subprocess.run(
+            [str(cli), "supports", feature], capture_output=True, timeout=30
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return f"error:{e}"
+    if result.returncode == 0:
+        return "supported"
+    if result.returncode == 1:
+        return "unsupported"
+    return "unknown"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--sdk", required=True, help="SDK name, e.g. python")
+    p.add_argument(
+        "--version", default="main", help="dist channel under sdk/<sdk>/dist/"
+    )
+    p.add_argument("--sdk-ref", default=os.environ.get("SDK_REF", "latest"))
+    p.add_argument(
+        "--os",
+        dest="os_name",
+        default=os.environ.get("RUNNER_OS_LABEL", "ubuntu-latest"),
+    )
+    p.add_argument("--tier", default="kas-ready")
+    p.add_argument("--out", type=Path, default=Path("test-results"))
+    args = p.parse_args()
+
+    cli = Path("sdk") / args.sdk / "dist" / args.version / "cli.sh"
+    supports = {feature: probe(cli, feature) for feature in FEATURES}
+
+    snapshot = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "sdk": args.sdk,
+        "sdk_ref": args.sdk_ref,
+        "platform_ref": os.environ.get("PLATFORM_REF", "latest"),
+        "go_channel": os.environ.get("GO_CHANNEL", "latest"),
+        "tier": args.tier,
+        "supports": supports,
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "repo": os.environ.get("GITHUB_REPOSITORY"),
+    }
+    dest = args.out / f"report-{args.sdk}-{args.os_name}"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "supports.json").write_text(json.dumps(snapshot, indent=2))
+    (dest / "meta.json").write_text(
+        json.dumps(
+            {
+                "sdk": args.sdk,
+                "os": args.os_name,
+                "run_id": os.environ.get("GITHUB_RUN_ID"),
+            },
+            indent=2,
+        )
+    )
+    print(json.dumps(snapshot, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/xtest/reporting/generate_site.py
+++ b/xtest/reporting/generate_site.py
@@ -1,0 +1,162 @@
+"""Generate a static HTML capability/interop report for GitHub Pages.
+
+Usage (from xtest/ cwd):
+  uv run python -m reporting.generate_site \\
+    --input-dir test-results \\
+    --output-dir site
+
+Expects directories matching report-<sdk>-<os>/ containing supports.json
+and optional junit XML / meta.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def _load_supports(report_dir: Path) -> dict:
+    path = report_dir / "supports.json"
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _junit_counts(report_dir: Path) -> dict[str, int]:
+    total = passed = failed = skipped = 0
+    for junit in report_dir.glob("**/*.junit.xml"):
+        try:
+            root = ET.parse(junit).getroot()
+        except ET.ParseError:
+            continue
+        # pytest may use testsuites or testsuite root
+        suites = root.findall("testsuite")
+        if root.tag == "testsuite":
+            suites = [root]
+        for suite in suites:
+            total += int(suite.attrib.get("tests", 0))
+            failed += int(suite.attrib.get("failures", 0)) + int(
+                suite.attrib.get("errors", 0)
+            )
+            skipped += int(suite.attrib.get("skipped", 0))
+    passed = max(0, total - failed - skipped)
+    return {"total": total, "passed": passed, "failed": failed, "skipped": skipped}
+
+
+def generate(input_dir: Path, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    for report_dir in sorted(input_dir.glob("report-*")):
+        if not report_dir.is_dir():
+            continue
+        supports = _load_supports(report_dir)
+        counts = _junit_counts(report_dir.parent)  # junit often sibling of report dir
+        # also check inside report dir
+        inner = _junit_counts(report_dir)
+        if inner["total"] > counts["total"]:
+            counts = inner
+        rows.append(
+            {
+                "dir": report_dir.name,
+                "supports": supports,
+                "counts": counts,
+            }
+        )
+
+    generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    feature_names: set[str] = set()
+    for r in rows:
+        feature_names.update((r["supports"].get("supports") or {}).keys())
+    features = sorted(feature_names)
+
+    # Capability matrix table
+    matrix_rows = []
+    for r in rows:
+        sdk = r["supports"].get("sdk", r["dir"])
+        sup = r["supports"].get("supports") or {}
+        cells = "".join(
+            f'<td class="{sup.get(f, "missing")}">{sup.get(f, "—")}</td>'
+            for f in features
+        )
+        matrix_rows.append(f"<tr><th>{sdk}</th>{cells}</tr>")
+
+    feature_header = "".join(f"<th>{f}</th>" for f in features)
+    interop_rows = []
+    for r in rows:
+        sdk = r["supports"].get("sdk", r["dir"])
+        c = r["counts"]
+        interop_rows.append(
+            f"<tr><td>{sdk}</td><td>{c['passed']}</td><td>{c['failed']}</td>"
+            f"<td>{c['skipped']}</td><td>{c['total']}</td></tr>"
+        )
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>OpenTDF Community Conformance</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; color: #1a1a1a; }}
+    h1, h2 {{ color: #0b3d5c; }}
+    table {{ border-collapse: collapse; margin: 1rem 0; font-size: 0.85rem; }}
+    th, td {{ border: 1px solid #ccc; padding: 0.35rem 0.5rem; }}
+    th {{ background: #eef3f7; }}
+    td.supported {{ background: #d4edda; }}
+    td.unsupported {{ background: #f8d7da; }}
+    td.unknown, td.missing {{ background: #fff3cd; }}
+    .meta {{ color: #555; font-size: 0.9rem; }}
+  </style>
+</head>
+<body>
+  <h1>OpenTDF Community SDK Conformance</h1>
+  <p class="meta">Generated {generated}. Stage-1 = community ↔ go@main, Base TDF (<code>tdf</code>) only.</p>
+
+  <h2>Interop summary (junit)</h2>
+  <table>
+    <tr><th>SDK</th><th>Passed</th><th>Failed</th><th>Skipped</th><th>Total</th></tr>
+    {"".join(interop_rows) or "<tr><td colspan='5'>No junit data yet</td></tr>"}
+  </table>
+
+  <h2>Capability matrix (<code>cli.sh supports</code>)</h2>
+  <table>
+    <tr><th>SDK</th>{feature_header}</tr>
+    {"".join(matrix_rows) or "<tr><td colspan='2'>No supports.json found under report-*</td></tr>"}
+  </table>
+
+  <h2>Bug metrics</h2>
+  <p>Historical fingerprints roll up when Pages deploy (PR8) merges successive
+  <code>history.json</code> artifacts. This snapshot only shows the current run.</p>
+
+  <p class="meta">See docs/community-conformance.md in the tests fork for ownership and stages.</p>
+</body>
+</html>
+"""
+    (output_dir / "index.html").write_text(html)
+    summary = {
+        "generated_at": generated,
+        "reports": [
+            {
+                "dir": r["dir"],
+                "sdk": r["supports"].get("sdk"),
+                "counts": r["counts"],
+            }
+            for r in rows
+        ],
+    }
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(f"Wrote {output_dir / 'index.html'} ({len(rows)} report dirs)")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input-dir", type=Path, default=Path("test-results"))
+    p.add_argument("--output-dir", type=Path, default=Path("site"))
+    args = p.parse_args()
+    generate(args.input_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/xtest/reporting/generate_site.py
+++ b/xtest/reporting/generate_site.py
@@ -1,153 +1,467 @@
-"""Generate a static HTML capability/interop report for GitHub Pages.
+"""Generate the community SDK conformance homepage for GitHub Pages.
 
 Usage (from xtest/ cwd):
   uv run python -m reporting.generate_site \\
     --input-dir test-results \\
     --output-dir site
 
-Expects directories matching report-<sdk>-<os>/ containing supports.json
-and optional junit XML / meta.json.
+Expects one subdirectory per Community X-Test artifact under --input-dir,
+each containing pytest junit XML files (any depth) and optionally a
+capability snapshot (supports.json, written by reporting.export_supports).
+Every junit testcase id encodes the encrypt/decrypt pair
+(``test_tdf_roundtrip[small-python@main-go@v0.35.0-...]``), which is what
+the interop matrix is built from.
+
+Outputs index.html (self-contained, no external assets) and summary.json.
 """
 
 from __future__ import annotations
 
 import argparse
+import html
 import json
+import os
+import re
 import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
+from defusedxml.ElementTree import parse as _safe_xml_parse
 
-def _load_supports(report_dir: Path) -> dict:
-    path = report_dir / "supports.json"
-    if not path.exists():
-        return {}
-    return json.loads(path.read_text())
+OFFICIAL_SDKS = ("go", "java", "js")
+COMMUNITY_SDKS = ("python", "rust", "swift")
+
+SDK_REPOS = {
+    "python": "https://github.com/b-long/opentdf-python-sdk",
+    "rust": "https://github.com/arkavo-org/opentdf-rs",
+    "swift": "https://github.com/arkavo-org/OpenTDFKit",
+    "go": "https://github.com/opentdf/otdfctl",
+}
+
+# encrypt/decrypt peers inside a pytest param id, e.g. "python@main" or
+# "go@v0.35.0". Versions are dist channels (main/lts/vX.Y.Z, optional
+# -rcN/-betaN suffix); parametrize order guarantees encrypt before decrypt.
+_PEER_RE = re.compile(
+    r"\b(go|java|js|python|rust|swift)@([\w.+]+(?:-(?:rc|beta|alpha)\.?\d+)?)"
+)
 
 
-def _junit_counts(report_dir: Path) -> dict[str, int]:
-    total = passed = failed = skipped = 0
-    for junit in report_dir.glob("**/*.junit.xml"):
+@dataclass
+class Counts:
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.passed + self.failed + self.skipped
+
+    @property
+    def run(self) -> int:
+        return self.passed + self.failed
+
+    def add(self, outcome: str) -> None:
+        setattr(self, outcome, getattr(self, outcome) + 1)
+
+    def merge(self, other: Counts) -> None:
+        self.passed += other.passed
+        self.failed += other.failed
+        self.skipped += other.skipped
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "passed": self.passed,
+            "failed": self.failed,
+            "skipped": self.skipped,
+            "total": self.total,
+        }
+
+
+@dataclass
+class Report:
+    """Aggregated results across every artifact directory."""
+
+    pair_counts: dict[tuple[str, str], Counts] = field(
+        default_factory=lambda: defaultdict(Counts)
+    )
+    sdk_counts: dict[str, Counts] = field(default_factory=lambda: defaultdict(Counts))
+    snapshots: dict[str, dict] = field(default_factory=dict)
+    junit_files: int = 0
+
+
+def _testcase_outcome(case: ET.Element) -> str:
+    for child in case:
+        if child.tag in ("failure", "error"):
+            return "failed"
+        if child.tag == "skipped":
+            return "skipped"
+    return "passed"
+
+
+def collect(input_dir: Path) -> Report:
+    report = Report()
+    for junit in sorted(input_dir.rglob("*.junit.xml")):
         try:
-            root = ET.parse(junit).getroot()
+            tree = _safe_xml_parse(junit)
         except ET.ParseError:
             continue
-        # pytest may use testsuites or testsuite root
-        suites = root.findall("testsuite")
-        if root.tag == "testsuite":
-            suites = [root]
-        for suite in suites:
-            total += int(suite.attrib.get("tests", 0))
-            failed += int(suite.attrib.get("failures", 0)) + int(
-                suite.attrib.get("errors", 0)
-            )
-            skipped += int(suite.attrib.get("skipped", 0))
-    passed = max(0, total - failed - skipped)
-    return {"total": total, "passed": passed, "failed": failed, "skipped": skipped}
-
-
-def generate(input_dir: Path, output_dir: Path) -> None:
-    output_dir.mkdir(parents=True, exist_ok=True)
-    rows: list[dict] = []
-    for report_dir in sorted(input_dir.glob("report-*")):
-        if not report_dir.is_dir():
+        root = tree.getroot() if tree is not None else None
+        if root is None:
             continue
-        supports = _load_supports(report_dir)
-        counts = _junit_counts(report_dir.parent)  # junit often sibling of report dir
-        # also check inside report dir
-        inner = _junit_counts(report_dir)
-        if inner["total"] > counts["total"]:
-            counts = inner
-        rows.append(
-            {
-                "dir": report_dir.name,
-                "supports": supports,
-                "counts": counts,
-            }
+        report.junit_files += 1
+        for case in root.iter("testcase"):
+            outcome = _testcase_outcome(case)
+            peers = _PEER_RE.findall(case.attrib.get("name", ""))
+            if len(peers) >= 2:
+                enc = f"{peers[0][0]}@{peers[0][1]}"
+                dec = f"{peers[1][0]}@{peers[1][1]}"
+                report.pair_counts[(enc, dec)].add(outcome)
+                for sdk in {peers[0][0], peers[1][0]}:
+                    report.sdk_counts[sdk].add(outcome)
+
+    for supports in sorted(input_dir.rglob("supports.json")):
+        try:
+            snap = json.loads(supports.read_text())
+        except json.JSONDecodeError, OSError:
+            continue
+        sdk = snap.get("sdk")
+        if isinstance(sdk, str) and sdk:
+            report.snapshots[sdk] = snap
+    return report
+
+
+def _sdk_sort_key(peer: str) -> tuple[int, str]:
+    name = peer.split("@", 1)[0]
+    return (0 if name in COMMUNITY_SDKS else 1, peer)
+
+
+def _esc(value: object) -> str:
+    return html.escape(str(value))
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+_CSS = """
+:root {
+  --surface: #fcfcfb; --panel: #f4f4f1; --ink: #0b0b0b; --ink-2: #52514e;
+  --line: #e3e2dd; --accent: #2a78d6;
+  --good: #0ca30c; --bad: #d03b3b; --warn: #b97f00;
+  --good-bg: rgba(12, 163, 12, 0.11); --bad-bg: rgba(208, 59, 59, 0.11);
+  --warn-bg: rgba(250, 178, 25, 0.16); --skip-bg: rgba(82, 81, 78, 0.08);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: #1a1a19; --panel: #222220; --ink: #ffffff; --ink-2: #c3c2b7;
+    --line: #373633; --accent: #3987e5; --warn: #fab219;
+    --good-bg: rgba(12, 163, 12, 0.22); --bad-bg: rgba(208, 59, 59, 0.24);
+    --warn-bg: rgba(250, 178, 25, 0.18); --skip-bg: rgba(195, 194, 183, 0.10);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--surface); color: var(--ink);
+  font: 400 0.9375rem/1.6 ui-monospace, "SF Mono", "Cascadia Code", Menlo,
+    Consolas, "Liberation Mono", monospace;
+}
+main { max-width: 66rem; margin: 0 auto; padding: 3.5rem 1.5rem 4rem; }
+a { color: var(--accent); text-underline-offset: 3px; }
+h1, h2 { line-height: 1.15; letter-spacing: -0.03em; }
+h1 { font-size: clamp(2rem, 5vw, 3.1rem); margin: 0.4rem 0 1rem; font-weight: 700; }
+h2 { font-size: 1.25rem; margin: 3rem 0 0.25rem; }
+.eyebrow {
+  color: var(--accent); font-size: 0.72rem; letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+.lede { color: var(--ink-2); max-width: 46rem; margin: 0 0 1.5rem; }
+.section-note { color: var(--ink-2); font-size: 0.82rem; margin: 0 0 1rem; }
+.provenance {
+  display: flex; flex-wrap: wrap; gap: 0.4rem 1.6rem; padding: 0.9rem 1.1rem;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+  font-size: 0.82rem;
+}
+.provenance b { font-weight: 400; color: var(--ink-2); }
+.cards {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1rem; margin-top: 1.25rem;
+}
+.card {
+  border: 1px solid var(--line); border-radius: 10px; padding: 1.1rem 1.2rem;
+  background: var(--panel); display: flex; flex-direction: column; gap: 0.45rem;
+}
+.card h3 { margin: 0; font-size: 1.2rem; letter-spacing: -0.02em; }
+.card .ref { color: var(--ink-2); font-size: 0.8rem; overflow-wrap: anywhere; }
+.card .nums { font-size: 0.85rem; }
+.pill {
+  align-self: flex-start; border-radius: 999px; padding: 0.15rem 0.7rem;
+  font-size: 0.78rem; border: 1px solid transparent;
+}
+.pill.good { background: var(--good-bg); color: var(--good); border-color: var(--good); }
+.pill.bad { background: var(--bad-bg); color: var(--bad); border-color: var(--bad); }
+.pill.none { background: var(--skip-bg); color: var(--ink-2); border-color: var(--line); }
+.scroll { overflow-x: auto; }
+table { border-collapse: collapse; font-size: 0.85rem; margin: 0.75rem 0 0.5rem; }
+th, td { border: 1px solid var(--line); padding: 0.45rem 0.7rem; text-align: left; }
+th { background: var(--panel); font-weight: 400; color: var(--ink-2); }
+th.peer, td.feature { color: var(--ink); white-space: nowrap; }
+tbody tr:hover td { filter: brightness(0.96); }
+@media (prefers-color-scheme: dark) { tbody tr:hover td { filter: brightness(1.18); } }
+td.ok { background: var(--good-bg); }
+td.fail { background: var(--bad-bg); }
+td.warn { background: var(--warn-bg); }
+td.skip, td.none { background: var(--skip-bg); color: var(--ink-2); }
+td.blank { color: var(--ink-2); text-align: center; }
+.legend { color: var(--ink-2); font-size: 0.78rem; display: flex; flex-wrap: wrap; gap: 1.2rem; }
+.legend span::before { content: ""; }
+footer {
+  margin-top: 3.5rem; padding-top: 1.25rem; border-top: 1px solid var(--line);
+  color: var(--ink-2); font-size: 0.82rem;
+}
+footer p { max-width: 46rem; }
+.empty {
+  border: 1px dashed var(--line); border-radius: 10px; padding: 2rem;
+  color: var(--ink-2); margin-top: 1.5rem;
+}
+"""
+
+
+def _verdict(counts: Counts) -> tuple[str, str, str]:
+    """(css class, glyph, label) for an SDK scorecard."""
+    if counts.run == 0:
+        return "none", "—", "no results"
+    if counts.failed:
+        return "bad", "✕", "failing"
+    return "good", "✓", "conformant"
+
+
+def _render_cards(report: Report) -> str:
+    # Scorecards are for the community SDKs under test; the go reference
+    # peer appears in the matrices instead.
+    sdks = sorted(
+        (set(report.snapshots) | set(report.sdk_counts)) & set(COMMUNITY_SDKS)
+    )
+    cards = []
+    for sdk in sdks:
+        counts = report.sdk_counts.get(sdk, Counts())
+        snap = report.snapshots.get(sdk, {})
+        cls, glyph, label = _verdict(counts)
+        ref = snap.get("sdk_ref", "")
+        repo = SDK_REPOS.get(sdk)
+        title = f'<a href="{_esc(repo)}">{_esc(sdk)}</a>' if repo else _esc(sdk)
+        tier = _esc(snap["tier"]) if snap.get("tier") else ""
+        cards.append(
+            f'<div class="card">'
+            f"<h3>{title}</h3>"
+            f'<span class="pill {cls}">{glyph} {label}</span>'
+            f'<span class="ref">{_esc(ref) if ref else "release not recorded"}</span>'
+            f'<span class="nums">{counts.passed} passed · {counts.failed} failed'
+            f" · {counts.skipped} skipped</span>"
+            f'<span class="ref">{tier}</span>'
+            f"</div>"
         )
+    return "".join(cards)
 
-    generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
-    feature_names: set[str] = set()
-    for r in rows:
-        feature_names.update((r["supports"].get("supports") or {}).keys())
-    features = sorted(feature_names)
 
-    # Capability matrix table
-    matrix_rows = []
-    for r in rows:
-        sdk = r["supports"].get("sdk", r["dir"])
-        sup = r["supports"].get("supports") or {}
+def _pair_cell(counts: Counts | None) -> str:
+    if counts is None:
+        return '<td class="blank" title="pair not exercised">·</td>'
+    if counts.run == 0:
+        return f'<td class="skip" title="all skipped">— {counts.skipped} skipped</td>'
+    if counts.failed:
+        return (
+            f'<td class="fail" title="{counts.failed} of {counts.run} failed">'
+            f"✕ {counts.passed}/{counts.run}</td>"
+        )
+    return f'<td class="ok" title="all passed">✓ {counts.passed}/{counts.run}</td>'
+
+
+def _render_matrix(report: Report) -> str:
+    if not report.pair_counts:
+        return ""
+    encrypters = sorted({e for e, _ in report.pair_counts}, key=_sdk_sort_key)
+    decrypters = sorted({d for _, d in report.pair_counts}, key=_sdk_sort_key)
+    head = "".join(f'<th class="peer">{_esc(d)}</th>' for d in decrypters)
+    body = []
+    for enc in encrypters:
         cells = "".join(
-            f'<td class="{sup.get(f, "missing")}">{sup.get(f, "—")}</td>'
-            for f in features
+            _pair_cell(report.pair_counts.get((enc, dec))) for dec in decrypters
         )
-        matrix_rows.append(f"<tr><th>{sdk}</th>{cells}</tr>")
+        body.append(f'<tr><th class="peer">{_esc(enc)}</th>{cells}</tr>')
+    return f"""
+  <h2 id="interop">Interop matrix</h2>
+  <p class="section-note">Rows encrypt, columns decrypt. Each cell counts Base
+  TDF round-trips against a live platform and KAS in the source run.</p>
+  <div class="scroll"><table>
+    <thead><tr><th>encrypt ↓ / decrypt →</th>{head}</tr></thead>
+    <tbody>{"".join(body)}</tbody>
+  </table></div>
+  <p class="legend"><span>✓ all round-trips passed</span>
+  <span>✕ at least one failure (passed/run)</span>
+  <span>— skipped</span><span>· pair not exercised</span></p>
+"""
 
-    feature_header = "".join(f"<th>{f}</th>" for f in features)
-    interop_rows = []
-    for r in rows:
-        sdk = r["supports"].get("sdk", r["dir"])
-        c = r["counts"]
-        interop_rows.append(
-            f"<tr><td>{sdk}</td><td>{c['passed']}</td><td>{c['failed']}</td>"
-            f"<td>{c['skipped']}</td><td>{c['total']}</td></tr>"
+
+_FEATURE_GLYPHS = {
+    "supported": ("ok", "✓ yes"),
+    "unsupported": ("none", "–"),
+}
+
+
+def _render_capabilities(report: Report) -> str:
+    # Every SDK in the conformance runs gets a column, snapshot or not —
+    # community SDKs always, plus any peer seen in junit results (e.g. go).
+    sdks = sorted(
+        set(report.snapshots) | set(COMMUNITY_SDKS) | set(report.sdk_counts),
+        key=lambda s: (0 if s in COMMUNITY_SDKS else 1, s),
+    )
+    features: set[str] = set()
+    for snap in report.snapshots.values():
+        features.update((snap.get("supports") or {}).keys())
+    if not features:
+        return ""
+    head = "".join(f'<th class="peer">{_esc(s)}</th>' for s in sdks)
+    rows = []
+    for feature in sorted(features):
+        cells = []
+        for sdk in sdks:
+            snap = report.snapshots.get(sdk)
+            value = ((snap or {}).get("supports") or {}).get(feature)
+            if snap is None:
+                cells.append('<td class="blank" title="no snapshot yet">·</td>')
+            elif value is None:
+                cells.append('<td class="blank" title="not probed">·</td>')
+            else:
+                cls, text = _FEATURE_GLYPHS.get(
+                    str(value), ("warn", f"? {_esc(value)}")
+                )
+                cells.append(f'<td class="{cls}">{text}</td>')
+        rows.append(
+            f'<tr><td class="feature">{_esc(feature)}</td>{"".join(cells)}</tr>'
         )
+    return f"""
+  <h2 id="capabilities">Capability matrix</h2>
+  <p class="section-note">What each SDK's CLI reports via <code>cli.sh
+  supports &lt;feature&gt;</code>. “–” means the SDK does not implement the
+  feature; “?” means the probe errored; “·” means no capability snapshot
+  for that SDK yet.</p>
+  <div class="scroll"><table>
+    <thead><tr><th>feature</th>{head}</tr></thead>
+    <tbody>{"".join(rows)}</tbody>
+  </table></div>
+"""
 
-    html = f"""<!DOCTYPE html>
+
+def _render_provenance(report: Report, generated: str) -> str:
+    any_snap = next(iter(report.snapshots.values()), {})
+    run_id = os.environ.get("SOURCE_RUN_ID") or any_snap.get("run_id")
+    repo = os.environ.get("GITHUB_REPOSITORY") or any_snap.get("repo")
+    run_url = os.environ.get("SOURCE_RUN_URL")
+    if not run_url and run_id and repo:
+        run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+    items = []
+    if run_url and run_id:
+        items.append(
+            f'<span><b>source run</b> <a href="{_esc(run_url)}">#{_esc(run_id)}</a></span>'
+        )
+    if any_snap.get("platform_ref"):
+        items.append(f"<span><b>platform</b> {_esc(any_snap['platform_ref'])}</span>")
+    if any_snap.get("go_channel"):
+        items.append(f"<span><b>go peer</b> {_esc(any_snap['go_channel'])}</span>")
+    items.append(f"<span><b>generated</b> {_esc(generated)}</span>")
+    return f'<div class="provenance">{"".join(items)}</div>'
+
+
+def _render_empty() -> str:
+    return """
+  <div class="empty">No conformance data yet. This page publishes
+  automatically after the next <a
+  href="https://github.com/arkavo-org/opentdf-tests/actions/workflows/community-xtest.yml">Community
+  X-Test</a> run completes on <code>main</code>.</div>
+"""
+
+
+def render_html(report: Report, generated: str) -> str:
+    sdk_total = len(
+        (set(report.snapshots) | set(report.sdk_counts)) & set(COMMUNITY_SDKS)
+    )
+    if sdk_total:
+        body = (
+            f'<div class="cards">{_render_cards(report)}</div>'
+            + _render_matrix(report)
+            + _render_capabilities(report)
+        )
+    else:
+        body = _render_empty()
+    return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
-  <title>OpenTDF Community Conformance</title>
-  <style>
-    body {{ font-family: system-ui, sans-serif; margin: 2rem; color: #1a1a1a; }}
-    h1, h2 {{ color: #0b3d5c; }}
-    table {{ border-collapse: collapse; margin: 1rem 0; font-size: 0.85rem; }}
-    th, td {{ border: 1px solid #ccc; padding: 0.35rem 0.5rem; }}
-    th {{ background: #eef3f7; }}
-    td.supported {{ background: #d4edda; }}
-    td.unsupported {{ background: #f8d7da; }}
-    td.unknown, td.missing {{ background: #fff3cd; }}
-    .meta {{ color: #555; font-size: 0.9rem; }}
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="color-scheme" content="light dark"/>
+  <title>OpenTDF Community SDK Conformance</title>
+  <style>{_CSS}</style>
 </head>
 <body>
-  <h1>OpenTDF Community SDK Conformance</h1>
-  <p class="meta">Generated {generated}. Stage-1 = community ↔ go@main, Base TDF (<code>tdf</code>) only.</p>
-
-  <h2>Interop summary (junit)</h2>
-  <table>
-    <tr><th>SDK</th><th>Passed</th><th>Failed</th><th>Skipped</th><th>Total</th></tr>
-    {"".join(interop_rows) or "<tr><td colspan='5'>No junit data yet</td></tr>"}
-  </table>
-
-  <h2>Capability matrix (<code>cli.sh supports</code>)</h2>
-  <table>
-    <tr><th>SDK</th>{feature_header}</tr>
-    {"".join(matrix_rows) or "<tr><td colspan='2'>No supports.json found under report-*</td></tr>"}
-  </table>
-
-  <h2>Bug metrics</h2>
-  <p>Historical fingerprints roll up when Pages deploy (PR8) merges successive
-  <code>history.json</code> artifacts. This snapshot only shows the current run.</p>
-
-  <p class="meta">See docs/community-conformance.md in the tests fork for ownership and stages.</p>
+<main>
+  <p class="eyebrow">OpenTDF · Community Conformance</p>
+  <h1>SDK Conformance Report</h1>
+  <p class="lede">Continuous interoperability results for community OpenTDF
+  SDKs. Every run encrypts with one SDK, decrypts with another, and verifies
+  the round-trip against a live platform and KAS — so a green cell means two
+  independent implementations really exchanged a Base TDF.</p>
+  {_render_provenance(report, generated)}
+  {body}
+  <footer>
+    <p><strong>Add your SDK.</strong> Implement the <code>cli.sh</code>
+    contract and open a PR against
+    <a href="https://github.com/arkavo-org/opentdf-tests">arkavo-org/opentdf-tests</a>
+    — see <a
+    href="https://github.com/arkavo-org/opentdf-tests/blob/main/docs/community-conformance.md">docs/community-conformance.md</a>
+    for the conformance contract and ownership.</p>
+    <p>Community fork of <a href="https://github.com/opentdf/tests">opentdf/tests</a>;
+    not an official OpenTDF certification. Machine-readable data:
+    <a href="summary.json">summary.json</a>.</p>
+  </footer>
+</main>
 </body>
 </html>
 """
-    (output_dir / "index.html").write_text(html)
+
+
+def generate(input_dir: Path, output_dir: Path) -> None:
+    report = collect(input_dir)
+    generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "index.html").write_text(render_html(report, generated))
+
     summary = {
         "generated_at": generated,
-        "reports": [
+        "source_run_id": os.environ.get("SOURCE_RUN_ID"),
+        "junit_files": report.junit_files,
+        "sdks": [
             {
-                "dir": r["dir"],
-                "sdk": r["supports"].get("sdk"),
-                "counts": r["counts"],
+                "sdk": sdk,
+                "sdk_ref": report.snapshots.get(sdk, {}).get("sdk_ref"),
+                "tier": report.snapshots.get(sdk, {}).get("tier"),
+                "counts": report.sdk_counts.get(sdk, Counts()).as_dict(),
+                "supports": report.snapshots.get(sdk, {}).get("supports"),
             }
-            for r in rows
+            for sdk in sorted(set(report.snapshots) | set(report.sdk_counts))
+        ],
+        "pairs": [
+            {"encrypt": enc, "decrypt": dec, **counts.as_dict()}
+            for (enc, dec), counts in sorted(report.pair_counts.items())
         ],
     }
     (output_dir / "summary.json").write_text(json.dumps(summary, indent=2))
-    print(f"Wrote {output_dir / 'index.html'} ({len(rows)} report dirs)")
+    print(
+        f"Wrote {output_dir / 'index.html'} "
+        f"({report.junit_files} junit files, {len(report.snapshots)} snapshots, "
+        f"{len(report.pair_counts)} interop pairs)"
+    )
 
 
 def main() -> None:

--- a/xtest/sdk/Makefile
+++ b/xtest/sdk/Makefile
@@ -1,10 +1,13 @@
 # Makefile
 
 # Targets
-.PHONY: all js go java
+.PHONY: all js go java community rust swift python
 
 all: js go java
-	@echo "Setup all sdk clis"
+	@echo "Setup all official sdk clis"
+
+community: rust swift python
+	@echo "Setup all community sdk clis"
 
 js:
 	@echo "Building JavaScript SDK..."
@@ -20,3 +23,18 @@ java:
 	@echo "Building Java SDK..."
 	@cd java && make all
 	@echo "Java SDK built successfully"
+
+rust:
+	@echo "Building Rust community SDK..."
+	@cd rust && make all
+	@echo "Rust SDK built successfully"
+
+swift:
+	@echo "Building Swift community SDK..."
+	@cd swift && make all
+	@echo "Swift SDK built successfully"
+
+python:
+	@echo "Building Python community SDK..."
+	@cd python && make all
+	@echo "Python SDK built successfully"

--- a/xtest/sdk/python/Makefile
+++ b/xtest/sdk/python/Makefile
@@ -1,0 +1,59 @@
+# Makefile for building the community Python SDK CLI for xtest
+
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Dynamically set VERSIONS from sdk/python/src/* worktrees if not provided
+VERSIONS ?= $(shell find "$(MAKEFILE_DIR)/src" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -not -name "*.git" -exec basename {} \; 2>/dev/null)
+
+.PHONY: all build clean help
+
+all: build
+	@echo "Setup python sdk clis for versions: $(VERSIONS)"
+
+build:
+	@if [ -z "$(strip $(VERSIONS))" ]; then \
+		echo "No versions found in sdk/python/src — checkout with otdf-sdk-mgr first, or link a local tree."; \
+		exit 1; \
+	fi
+	@for version in $(VERSIONS); do \
+		echo "Installing otdf-python for $$version"; \
+		SRC="$(MAKEFILE_DIR)/src/$$version"; \
+		DIST="$(MAKEFILE_DIR)/dist/$$version"; \
+		mkdir -p "$$DIST"; \
+		cp "$(MAKEFILE_DIR)/cli.sh" "$$DIST/cli.sh"; \
+		chmod +x "$$DIST/cli.sh"; \
+		if [ -f "$$SRC/packages/otdf-python/pyproject.toml" ]; then \
+			echo "  editable install from monorepo packages/"; \
+			python3 -m venv "$$DIST/.venv"; \
+			"$$DIST/.venv/bin/pip" install -U pip wheel; \
+			if [ -f "$$SRC/packages/otdf-python-proto/pyproject.toml" ]; then \
+				"$$DIST/.venv/bin/pip" install -e "$$SRC/packages/otdf-python-proto" || true; \
+			fi; \
+			"$$DIST/.venv/bin/pip" install -e "$$SRC/packages/otdf-python"; \
+		elif [ -f "$$SRC/pyproject.toml" ]; then \
+			python3 -m venv "$$DIST/.venv"; \
+			"$$DIST/.venv/bin/pip" install -U pip wheel; \
+			"$$DIST/.venv/bin/pip" install -e "$$SRC"; \
+		else \
+			echo "Error: no pyproject.toml under $$SRC" >&2; \
+			exit 1; \
+		fi; \
+		ln -sfn .venv/bin/python "$$DIST/otdf-python-python" 2>/dev/null || true; \
+		printf '%s\n' '#!/usr/bin/env bash' \
+			'exec "$$(cd "$$(dirname "$$0")" && pwd)/.venv/bin/python" -m otdf_python "$$@"' \
+			> "$$DIST/otdf-python"; \
+		chmod +x "$$DIST/otdf-python"; \
+		echo "Installed: $$DIST"; \
+	done
+	@echo "All python SDK clis built successfully"
+
+clean:
+	@for version in $(VERSIONS); do \
+		rm -rf "$(MAKEFILE_DIR)/dist/$$version"; \
+	done
+	@echo "Cleanup complete"
+
+help:
+	@echo "python SDK Makefile"
+	@echo "  all/build  - install otdf-python into dist/<version>"
+	@echo "  clean      - remove dist trees"

--- a/xtest/sdk/python/cli.sh
+++ b/xtest/sdk/python/cli.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# xtest CLI wrapper for the community Python SDK (otdf-python).
+#
+# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <fmt>
+#        ./cli.sh supports <feature>
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# Prefer a venv/binary laid down by the Makefile; fall back to python -m.
+if [[ -x "$SCRIPT_DIR/otdf-python" ]]; then
+  PY_CMD=("$SCRIPT_DIR/otdf-python")
+elif [[ -n "${OTDF_PYTHON_BIN:-}" ]]; then
+  PY_CMD=("$OTDF_PYTHON_BIN")
+elif [[ -x "$SCRIPT_DIR/.venv/bin/python" ]]; then
+  PY_CMD=("$SCRIPT_DIR/.venv/bin/python" -m otdf_python)
+else
+  PY_CMD=(python3 -m otdf_python)
+fi
+
+# ---------------------------------------------------------------------------
+# supports <feature>
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "supports" ]]; then
+  feature="${2:-}"
+  if [[ -z "$feature" ]]; then
+    echo "Usage: $0 supports <feature>" >&2
+    exit 2
+  fi
+  # Prefer the SDK's own supports subcommand when present (otdf-python ≥ community xtest).
+  if "${PY_CMD[@]}" supports --help &>/dev/null || "${PY_CMD[@]}" supports help &>/dev/null; then
+    "${PY_CMD[@]}" supports "$feature"
+    exit $?
+  fi
+  # Fallback static map for older packages without `supports`.
+  case "$feature" in
+    autoconfigure | connectrpc | hexless | kasallowlist)
+      exit 0
+      ;;
+    assertions | assertion_verification | attribute_traversal | audit_logging | \
+      better-messages-2024 | bulk_rewrap | dpop | dpop_nonce_challenge | ecwrap | \
+      hexaflexible | key_management | mechanism-rsa-4096 | mechanism-ec-curves-384-521 | \
+      mechanism-xwing | mechanism-secpmlkem | mechanism-mlkem | ns_grants | obligations)
+      exit 1
+      ;;
+    *)
+      echo "Unknown feature: $feature" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# Locate xtest root + load test.env
+# ---------------------------------------------------------------------------
+XTEST_DIR="$SCRIPT_DIR"
+while [[ "$XTEST_DIR" != "/" ]]; do
+  if [[ -f "$XTEST_DIR/pyproject.toml" ]] && grep -q 'name = "xtest"' "$XTEST_DIR/pyproject.toml"; then
+    break
+  fi
+  XTEST_DIR=$(dirname "$XTEST_DIR")
+done
+
+if [[ "$XTEST_DIR" == "/" ]]; then
+  echo "xtest root (pyproject.toml with name = \"xtest\") not found." >&2
+  exit 1
+fi
+
+if [[ -f "$XTEST_DIR/test.env" ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  # shellcheck disable=SC1091
+  source "$XTEST_DIR/test.env"
+  set +a
+else
+  echo "test.env not found in xtest root: $XTEST_DIR" >&2
+  exit 1
+fi
+
+cmd="${1:-}"
+src="${2:-}"
+dst="${3:-}"
+fmt="${4:-}"
+
+if [[ -z "$cmd" || -z "$src" || -z "$dst" ]]; then
+  echo "Usage: $0 <encrypt|decrypt> <src> <dst> <fmt>" >&2
+  exit 1
+fi
+
+# Parent-level flags (must appear before the subcommand for argparse).
+# Prefer a temp credentials file over --client-secret on argv (ps(1) leakage).
+# Newer otdf-python also reads CLIENTID/CLIENTSECRET from the environment.
+parent_args=()
+if [[ -n "${PLATFORMURL:-}" ]]; then
+  parent_args+=(--platform-url "$PLATFORMURL")
+fi
+if [[ -n "${KASURL:-}" ]]; then
+  parent_args+=(--kas-endpoint "$KASURL")
+fi
+if [[ -n "${KCFULLURL:-}" ]]; then
+  parent_args+=(--oidc-endpoint "$KCFULLURL")
+fi
+# Local platform is typically HTTP.
+if [[ "${PLATFORMURL:-}" == http://* ]]; then
+  parent_args+=(--plaintext)
+fi
+parent_args+=(--insecure)
+
+if [[ -n "${CLIENTID:-}" && -n "${CLIENTSECRET:-}" ]]; then
+  _creds_file=$(mktemp)
+  # shellcheck disable=SC2064
+  trap 'rm -f "${_creds_file:-}"' EXIT
+  printf '{"clientId":"%s","clientSecret":"%s"}\n' "$CLIENTID" "$CLIENTSECRET" >"$_creds_file"
+  parent_args+=(--with-client-creds-file "$_creds_file")
+fi
+
+# Allowlist (both spellings accepted from harness)
+allowlist="${XT_WITH_KAS_ALLOWLIST:-${XT_WITH_KAS_ALLOW_LIST:-}}"
+if [[ -n "$allowlist" ]]; then
+  parent_args+=(--kas-allowlist "$allowlist")
+fi
+if [[ "${XT_WITH_IGNORE_KAS_ALLOWLIST:-}" == "true" ]]; then
+  parent_args+=(--ignore-kas-allowlist)
+fi
+
+# Base TDF only for Stage-1 (wire token may still be legacy "ztdf" from harness).
+case "$fmt" in
+  tdf | base-tdf | ztdf)
+    container_type=tdf
+    ;;
+  tdf-ecwrap | ztdf-ecwrap)
+    echo "ecwrap not supported by python community shim" >&2
+    exit 1
+    ;;
+  *)
+    echo "Unsupported container format for python: $fmt" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$cmd" == "encrypt" ]]; then
+  enc_args=(encrypt "$src" --output "$dst" --container-type "$container_type")
+  if [[ -n "${XT_WITH_MIME_TYPE:-}" ]]; then
+    enc_args+=(--mime-type "$XT_WITH_MIME_TYPE")
+  fi
+  if [[ -n "${XT_WITH_ATTRIBUTES:-}" ]]; then
+    enc_args+=(--attributes "$XT_WITH_ATTRIBUTES" --autoconfigure)
+  fi
+  echo "${PY_CMD[@]}" "${parent_args[@]}" "${enc_args[@]}"
+  "${PY_CMD[@]}" "${parent_args[@]}" "${enc_args[@]}"
+elif [[ "$cmd" == "decrypt" ]]; then
+  dec_args=(decrypt "$src" --output "$dst")
+  echo "${PY_CMD[@]}" "${parent_args[@]}" "${dec_args[@]}"
+  "${PY_CMD[@]}" "${parent_args[@]}" "${dec_args[@]}"
+else
+  echo "Incorrect argument provided: $cmd" >&2
+  exit 1
+fi

--- a/xtest/sdk/rust/Makefile
+++ b/xtest/sdk/rust/Makefile
@@ -1,0 +1,35 @@
+# Makefile for building the community Rust SDK xtest_cli
+
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+VERSIONS ?= $(shell find "$(MAKEFILE_DIR)/src" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -not -name "*.git" -exec basename {} \; 2>/dev/null)
+CARGO_FEATURES ?= kas-client,cbor
+
+.PHONY: all build clean help
+
+all: build
+
+build:
+	@if [ -z "$(strip $(VERSIONS))" ]; then \
+		echo "No versions in sdk/rust/src — checkout with otdf-sdk-mgr first."; \
+		exit 1; \
+	fi
+	@for version in $(VERSIONS); do \
+		echo "Building xtest_cli for $$version"; \
+		SRC="$(MAKEFILE_DIR)/src/$$version"; \
+		DIST="$(MAKEFILE_DIR)/dist/$$version"; \
+		mkdir -p "$$DIST"; \
+		cp "$(MAKEFILE_DIR)/cli.sh" "$$DIST/cli.sh"; \
+		chmod +x "$$DIST/cli.sh"; \
+		( cd "$$SRC" && cargo build --release --example xtest_cli --features "$(CARGO_FEATURES)" ) || { \
+			echo "cargo build failed for $$version"; exit 1; \
+		}; \
+		cp "$$SRC/target/release/examples/xtest_cli" "$$DIST/xtest_cli"; \
+		chmod +x "$$DIST/xtest_cli"; \
+		echo "Installed: $$DIST/xtest_cli"; \
+	done
+
+clean:
+	@for version in $(VERSIONS); do rm -rf "$(MAKEFILE_DIR)/dist/$$version"; done
+
+help:
+	@echo "rust SDK Makefile — builds examples/xtest_cli with features: $(CARGO_FEATURES)"

--- a/xtest/sdk/rust/cli.sh
+++ b/xtest/sdk/rust/cli.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# xtest CLI wrapper for the community Rust SDK (opentdf-rs).
+#
+# Stage-1 (KAS interop) is gated until xtest_cli speaks CLIENTID/PLATFORMURL
+# and emits RSA-wrapped key access objects. Until then this shim either:
+#   - reports honest supports (mostly unsupported for official feature_type)
+#   - runs offline self-tests only when XT_ALLOW_OFFLINE=1
+#
+# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <fmt>
+#        ./cli.sh supports <feature>
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+BIN=""
+for candidate in "$SCRIPT_DIR/xtest_cli" "$SCRIPT_DIR/opentdf-xtest-cli"; do
+  if [[ -x "$candidate" ]]; then
+    BIN="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$BIN" ]]; then
+  echo "rust xtest CLI binary not found in $SCRIPT_DIR (run make in sdk/rust)" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "supports" ]]; then
+  # Delegate to binary (honest Stage-1 feature map).
+  exec "$BIN" supports "${2:-}"
+fi
+
+XTEST_DIR="$SCRIPT_DIR"
+while [[ "$XTEST_DIR" != "/" ]]; do
+  if [[ -f "$XTEST_DIR/pyproject.toml" ]] && grep -q 'name = "xtest"' "$XTEST_DIR/pyproject.toml"; then
+    break
+  fi
+  XTEST_DIR=$(dirname "$XTEST_DIR")
+done
+if [[ -f "$XTEST_DIR/test.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$XTEST_DIR/test.env"
+  set +a
+fi
+
+# Map official env into rust vars when present.
+export TDF_KAS_URL="${TDF_KAS_URL:-${KASURL:-http://localhost:8080/kas}}"
+export KASURL="${KASURL:-$TDF_KAS_URL}"
+
+# Stage-1 KAS path is live (RSA wrap + client_credentials rewrap).
+# Offline-only mode still available via TDF_SYMMETRIC_KEY_PATH / TDF_KAS_PUBLIC_KEY_PATH.
+exec "$BIN" "$@"

--- a/xtest/sdk/swift/Makefile
+++ b/xtest/sdk/swift/Makefile
@@ -1,0 +1,35 @@
+# Makefile for building OpenTDFKitCLI for xtest (macOS / Swift toolchain required)
+
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+VERSIONS ?= $(shell find "$(MAKEFILE_DIR)/src" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -not -name "*.git" -exec basename {} \; 2>/dev/null)
+
+.PHONY: all build clean help
+
+all: build
+
+build:
+	@if [ -z "$(strip $(VERSIONS))" ]; then \
+		echo "No versions in sdk/swift/src — checkout with otdf-sdk-mgr first."; \
+		exit 1; \
+	fi
+	@for version in $(VERSIONS); do \
+		echo "Building OpenTDFKitCLI for $$version"; \
+		SRC="$(MAKEFILE_DIR)/src/$$version"; \
+		DIST="$(MAKEFILE_DIR)/dist/$$version"; \
+		mkdir -p "$$DIST"; \
+		cp "$(MAKEFILE_DIR)/cli.sh" "$$DIST/cli.sh"; \
+		chmod +x "$$DIST/cli.sh"; \
+		( cd "$$SRC" && swift build -c release --product OpenTDFKitCLI ) || { \
+			echo "swift build failed for $$version"; exit 1; \
+		}; \
+		BIN=$$(cd "$$SRC" && swift build -c release --product OpenTDFKitCLI --show-bin-path)/OpenTDFKitCLI; \
+		cp "$$BIN" "$$DIST/OpenTDFKitCLI"; \
+		chmod +x "$$DIST/OpenTDFKitCLI"; \
+		echo "Installed: $$DIST/OpenTDFKitCLI"; \
+	done
+
+clean:
+	@for version in $(VERSIONS); do rm -rf "$(MAKEFILE_DIR)/dist/$$version"; done
+
+help:
+	@echo "swift SDK Makefile — builds OpenTDFKitCLI (requires Swift on macOS)"

--- a/xtest/sdk/swift/cli.sh
+++ b/xtest/sdk/swift/cli.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# xtest CLI wrapper for the community Swift SDK (OpenTDFKit).
+#
+# Prefers OpenTDFKitCLI over the stub xtest/cli.swift.
+# Stage-1 (KAS interop) is gated until OpenTDFKitCLI does client-credentials
+# PublicKey fetch + RSA wrap encrypt and ephemeral rewrap decrypt.
+#
+# Usage: ./cli.sh <encrypt | decrypt> <src-file> <dst-file> <fmt>
+#        ./cli.sh supports <feature>
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+BIN=""
+for candidate in "$SCRIPT_DIR/OpenTDFKitCLI" "$SCRIPT_DIR/opentdfkit-cli"; do
+  if [[ -x "$candidate" ]]; then
+    BIN="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$BIN" ]]; then
+  echo "OpenTDFKitCLI binary not found in $SCRIPT_DIR (run make in sdk/swift)" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "supports" ]]; then
+  # Delegate to OpenTDFKitCLI (Stage-1 KAS path is live).
+  exec "$BIN" supports "${2:-}"
+fi
+
+XTEST_DIR="$SCRIPT_DIR"
+while [[ "$XTEST_DIR" != "/" ]]; do
+  if [[ -f "$XTEST_DIR/pyproject.toml" ]] && grep -q 'name = "xtest"' "$XTEST_DIR/pyproject.toml"; then
+    break
+  fi
+  XTEST_DIR=$(dirname "$XTEST_DIR")
+done
+if [[ -f "$XTEST_DIR/test.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$XTEST_DIR/test.env"
+  set +a
+fi
+
+# Dual allowlist env spellings
+if [[ -z "${XT_WITH_KAS_ALLOW_LIST:-}" && -n "${XT_WITH_KAS_ALLOWLIST:-}" ]]; then
+  export XT_WITH_KAS_ALLOW_LIST="$XT_WITH_KAS_ALLOWLIST"
+fi
+
+# Stage-1 KAS path: CLIENTID/CLIENTSECRET/PLATFORMURL/KASURL used by OpenTDFKitCLI.
+exec "$BIN" "$@"

--- a/xtest/tdfs.py
+++ b/xtest/tdfs.py
@@ -98,19 +98,76 @@ def _kas_supports_algorithm(algorithm: str) -> bool:
         return False
 
 
-sdk_type = Literal["go", "java", "js"]
+# Official first-party SDKs (upstream-compatible).
+official_sdk_type = Literal["go", "java", "js"]
+# Community SDKs integrated in the arkavo-org/opentdf-tests fork.
+community_sdk_type = Literal["rust", "swift", "python"]
+# Flat union so get_args(sdk_type) returns all six names.
+sdk_type = Literal["go", "java", "js", "rust", "swift", "python"]
+
+OFFICIAL_SDKS: tuple[str, ...] = ("go", "java", "js")
+COMMUNITY_SDKS: tuple[str, ...] = ("rust", "swift", "python")
 
 
 def is_sdk_type(val: str) -> TypeIs[sdk_type]:
     return val in get_args(sdk_type)
 
 
+def is_community_sdk(val: str) -> bool:
+    return val in COMMUNITY_SDKS
+
+
 focus_type = Literal[sdk_type, "all"]
 
+# Canonical container *profile* slugs (OpenTDF / Virtru terminology).
+# See docs/FORMATS.md.
+#
+# - tdf:          Base TDF / Standard TDF (ZIP + JSON manifest + encrypted payload)
+# - tdf-ecwrap:   Base TDF with EC key wrapping
+# - ztdf:         Reserved for the NATO STANAG Zero Trust Data Format profile
+#                 (not the same as Base TDF; not yet a Stage-1 matrix cell)
+# - nanotdf:      NanoTDF (binary; not Stage-1)
 container_type = Literal[
-    "ztdf",
-    "ztdf-ecwrap",
+    "tdf",
+    "tdf-ecwrap",
 ]
+
+# Aliases accepted on CLI / configs; normalized to container_type.
+# "ztdf" was historically misused in OpenTDF tooling for Base TDF ZIP format.
+CONTAINER_ALIASES: dict[str, container_type] = {
+    "tdf": "tdf",
+    "base-tdf": "tdf",
+    "standard-tdf": "tdf",
+    "ztdf": "tdf",  # legacy alias → Base TDF (not NATO ZTDF profile)
+    "tdf-ecwrap": "tdf-ecwrap",
+    "base-tdf-ecwrap": "tdf-ecwrap",
+    "ztdf-ecwrap": "tdf-ecwrap",  # legacy alias
+}
+
+
+def normalize_container(name: str) -> container_type:
+    """Map alias or canonical name to a container_type; raise ValueError if unknown."""
+    key = name.strip().lower()
+    if key in CONTAINER_ALIASES:
+        return CONTAINER_ALIASES[key]
+    raise ValueError(
+        f"Unknown container profile {name!r}. "
+        f"Use one of: {', '.join(sorted(set(CONTAINER_ALIASES.values())))} "
+        f"(aliases: {', '.join(sorted(CONTAINER_ALIASES))}). "
+        f"Note: 'ztdf' is a legacy alias for Base TDF; true NATO ZTDF is not yet tested."
+    )
+
+
+def wire_cli_format(container: container_type) -> str:
+    """Format token passed as the 4th argument to official sdk/*/cli.sh.
+
+    Historical go/java/js shims expect the string ``ztdf`` for Base TDF ZIP
+    containers. Community shims accept ``tdf`` and ``ztdf`` as synonyms.
+    """
+    if container in ("tdf", "tdf-ecwrap"):
+        return "ztdf"
+    return container
+
 
 feature_type = Literal[
     "assertions",
@@ -463,10 +520,9 @@ def fmt_env(env: dict[str, str]) -> str:
     return " ".join(a)
 
 
-def simple_container(container: container_type) -> container_type:
-    if container == "ztdf-ecwrap":
-        return "ztdf"
-    return container
+def simple_container(container: container_type) -> str:
+    """Reduce profile to the wire format for cli.sh (Base TDF → legacy 'ztdf')."""
+    return wire_cli_format(container)
 
 
 class SDK:
@@ -508,13 +564,13 @@ class SDK:
         pt_file: Path,
         ct_file: Path,
         mime_type: str = "application/octet-stream",
-        container: container_type = "ztdf",
+        container: container_type = "tdf",
         attr_values: list[str] | None = None,
         assert_value: str = "",
         policy_mode: str = "encrypted",
         target_mode: container_version | None = None,
     ):
-        use_ecwrap = container == "ztdf-ecwrap"
+        use_ecwrap = container == "tdf-ecwrap"
         fmt = simple_container(container)
         c = [
             self.path,
@@ -534,7 +590,7 @@ class SDK:
         if assert_value:
             local_env |= {"XT_WITH_ASSERTIONS": assert_value}
 
-        if fmt == "ztdf" and target_mode:
+        if container in ("tdf", "tdf-ecwrap") and target_mode:
             local_env |= {"XT_WITH_TARGET_MODE": target_mode}
 
         if use_ecwrap:
@@ -556,7 +612,7 @@ class SDK:
         self,
         ct_file: Path,
         rt_file: Path,
-        container: container_type = "ztdf",
+        container: container_type = "tdf",
         assert_keys: str = "",
         verify_assertions: bool = True,
         ecwrap: bool = False,
@@ -582,7 +638,12 @@ class SDK:
         if not verify_assertions:
             local_env |= {"XT_WITH_VERIFY_ASSERTIONS": "false"}
         if kasallowlist:
-            local_env |= {"XT_WITH_KAS_ALLOWLIST": kasallowlist}
+            # Official go/java cli.sh read XT_WITH_KAS_ALLOW_LIST;
+            # community shims accept both spellings.
+            local_env |= {
+                "XT_WITH_KAS_ALLOWLIST": kasallowlist,
+                "XT_WITH_KAS_ALLOW_LIST": kasallowlist,
+            }
         if ignore_kas_allowlist:
             local_env |= {"XT_WITH_IGNORE_KAS_ALLOWLIST": "true"}
         logger.info(f"dec [{' '.join([fmt_env(local_env)] + c)}]")

--- a/xtest/test_abac.py
+++ b/xtest/test_abac.py
@@ -102,7 +102,7 @@ def test_key_mapping_multiple_mechanisms(
 
     tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -170,7 +170,7 @@ def test_key_mapping_extended_mechanisms(
 
     # Decrypt and verify
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -231,7 +231,7 @@ def test_key_mapping_extended_ec_mechanisms(
 
     # Decrypt and verify
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -291,7 +291,7 @@ def test_key_mapping_extended_rsa_mechanisms(
 
     # Decrypt and verify
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -330,7 +330,7 @@ def test_autoconfigure_one_attribute_standard(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
     # Verify rewrap was logged with expected attribute FQNs
@@ -386,7 +386,7 @@ def test_autoconfigure_two_kas_or_standard(
     mark = audit_logs.mark("before_decrypt")
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
     # Verify rewrap was logged - for OR policy, SDK only needs one KAS to succeed
@@ -440,7 +440,7 @@ def test_autoconfigure_double_kas_and(
     mark = audit_logs.mark("before_decrypt")
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
     # Verify rewrap was logged - for AND policy, SDK must contact both KASes
@@ -481,7 +481,7 @@ def test_autoconfigure_one_attribute_attr_grant(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -526,7 +526,7 @@ def test_autoconfigure_two_kas_or_attr_and_value_grant(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -571,7 +571,7 @@ def test_autoconfigure_two_kas_and_attr_and_value_grant(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -608,7 +608,7 @@ def test_autoconfigure_one_attribute_ns_grant(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -653,7 +653,7 @@ def test_autoconfigure_two_kas_or_ns_and_value_grant(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -698,7 +698,7 @@ def test_autoconfigure_two_kas_and_ns_and_value_grant(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -726,7 +726,7 @@ def test_obligations_not_entitled(
     attr, _ = obligation_setup_no_scs_unscoped_trigger
 
     # Encrypt the file with the attribute
-    ct_file = tmp_dir / "test-obligations.ztdf"
+    ct_file = tmp_dir / "test-obligations.tdf"
     assert attr.values, "Attribute has no values"
     attr_val = attr.values[0]
     assert attr_val is not None and attr_val.fqn, "Attribute value is invalid"
@@ -779,7 +779,7 @@ def test_obligations_not_fulfillable(
     assert attr_val is not None and attr_val.fqn, "Attribute value is invalid"
 
     # Encrypt the file with the attribute
-    ct_file = tmp_dir / "test-obligations-fulfillable.ztdf"
+    ct_file = tmp_dir / "test-obligations-fulfillable.tdf"
     encrypt_sdk.encrypt(
         pt_file,
         ct_file,
@@ -827,7 +827,7 @@ def test_obligations_client_not_scoped(
     assert attr_val is not None and attr_val.fqn, "Attribute value is invalid"
 
     # Encrypt the file with the attribute
-    ct_file = tmp_dir / "test-obligations-fulfillable.ztdf"
+    ct_file = tmp_dir / "test-obligations-fulfillable.tdf"
     encrypt_sdk.encrypt(
         pt_file,
         ct_file,
@@ -870,7 +870,7 @@ def test_obligations_client_scoped(
     assert attr_val is not None and attr_val.fqn, "Attribute value is invalid"
 
     # Encrypt the file with the attribute
-    ct_file = tmp_dir / "test-obligations-fulfillable.ztdf"
+    ct_file = tmp_dir / "test-obligations-fulfillable.tdf"
     encrypt_sdk.encrypt(
         pt_file,
         ct_file,
@@ -946,7 +946,7 @@ def test_autoconfigure_key_management_two_kas_two_keys(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -1000,7 +1000,7 @@ def test_import_legacy_golden_r1_key_and_decrypt_no_split(
     golden_file_name = "key-management-no-split-golden"
     ct_file = get_golden_file(f"{golden_file_name}.tdf")
     rt_file = tmp_dir / f"{golden_file_name}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf")
     with rt_file.open("r", encoding="utf-8") as f:
         assert f.read().strip() == "hello"
 

--- a/xtest/test_audit_logs_integration.py
+++ b/xtest/test_audit_logs_integration.py
@@ -68,13 +68,13 @@ class TestRewrapAudit:
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
-            container="ztdf",
+            container="tdf",
             attr_values=attribute_default_rsa.value_fqns,
         )
 
         mark = audit_logs.mark("before_decrypt")
         rt_file = tmp_dir / f"rewrap-success-{encrypt_sdk}-{decrypt_sdk}.untdf"
-        decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+        decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
         assert filecmp.cmp(pt_file, rt_file)
 
         # Verify rewrap success was logged with structured assertion
@@ -118,7 +118,7 @@ class TestRewrapAudit:
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
-            container="ztdf",
+            container="tdf",
             attr_values=attribute_single_kas_grant.value_fqns,
         )
 
@@ -126,7 +126,7 @@ class TestRewrapAudit:
         rt_file = tmp_dir / f"rewrap-access-{encrypt_sdk}-{decrypt_sdk}.untdf"
 
         # This should succeed if the client has access
-        decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+        decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
         assert filecmp.cmp(pt_file, rt_file)
 
         # Verify rewrap success with attribute FQNs
@@ -163,7 +163,7 @@ class TestRewrapAudit:
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
-            container="ztdf",
+            container="tdf",
             attr_values=[
                 attribute_two_kas_grant_and.value_fqns[0],
                 attribute_two_kas_grant_and.value_fqns[1],
@@ -180,7 +180,7 @@ class TestRewrapAudit:
         ):
             tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
 
-        decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+        decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
         assert filecmp.cmp(pt_file, rt_file)
 
         # For AND policy, should have 2 rewrap success events (one per KAS)
@@ -317,13 +317,13 @@ class TestDecisionAudit:
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
-            container="ztdf",
+            container="tdf",
             attr_values=attribute_single_kas_grant.value_fqns,
         )
 
         mark = audit_logs.mark("before_decision_decrypt")
         rt_file = tmp_dir / f"decision-success-{encrypt_sdk}-{decrypt_sdk}.untdf"
-        decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+        decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
         assert filecmp.cmp(pt_file, rt_file)
 
         # Verify both rewrap and decision were logged
@@ -379,7 +379,7 @@ class TestEdgeCases:
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
-            container="ztdf",
+            container="tdf",
             attr_values=attribute_default_rsa.value_fqns,
         )
 
@@ -403,7 +403,7 @@ class TestEdgeCases:
         rt_file = tmp_dir / f"tamper-audit-{encrypt_sdk}-{decrypt_sdk}.untdf"
 
         try:
-            decrypt_sdk.decrypt(tampered_file, rt_file, "ztdf", expect_error=True)
+            decrypt_sdk.decrypt(tampered_file, rt_file, "tdf", expect_error=True)
             pytest.fail("Expected decrypt to fail")
         except subprocess.CalledProcessError:
             pass  # Expected
@@ -440,7 +440,7 @@ class TestEdgeCases:
         encrypt_sdk.encrypt(
             pt_file,
             ct_file,
-            container="ztdf",
+            container="tdf",
             attr_values=attribute_default_rsa.value_fqns,
         )
 
@@ -449,7 +449,7 @@ class TestEdgeCases:
         # Perform multiple decrypts
         for i in range(num_decrypts):
             rt_file = tmp_dir / f"load-test-{encrypt_sdk}-{decrypt_sdk}-{i}.untdf"
-            decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+            decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
             assert filecmp.cmp(pt_file, rt_file)
 
         # Verify we got audit events for all decrypts

--- a/xtest/test_dpop.py
+++ b/xtest/test_dpop.py
@@ -358,7 +358,7 @@ def test_dpop_happy_path_roundtrip(
         target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
     )
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file, shallow=False)
 
 
@@ -395,7 +395,7 @@ def test_dpop_server_issued_nonce_retry(
         target_mode=tdfs.select_target_version(encrypt_sdk, decrypt_sdk),
     )
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file, shallow=False)
 
 

--- a/xtest/test_legacy.py
+++ b/xtest/test_legacy.py
@@ -25,7 +25,7 @@ def test_decrypt_small(
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("small-java-4.3.0-e0f8caf.tdf")
     rt_file = tmp_dir / f"small-java-{decrypt_sdk}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
@@ -45,7 +45,7 @@ def test_decrypt_big(
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("big-java-4.3.0-e0f8caf.tdf")
     rt_file = tmp_dir / f"big-java-{decrypt_sdk}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 10 * 2**20
     expected_bytes = bytes([0] * 1024)
@@ -66,7 +66,7 @@ def test_decrypt_SDKv0_7_5(
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("xstext-java-v0.7.5-94b161d53-DSP2.0.2_and_2.0.3.tdf")
     rt_file = tmp_dir / f"0.7.5-java-{decrypt_sdk}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 102
 
@@ -83,7 +83,7 @@ def test_decrypt_SDKv0_7_8(
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("xstext-java-v0.7.8-7f487c2-DSP2.0.4.tdf")
     rt_file = tmp_dir / f"0.7.8-java-{decrypt_sdk}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 92
 
@@ -100,7 +100,7 @@ def test_decrypt_SDKv0_9_0(
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("xstext-java-v0.9.0-2de6a49-DSP2.0.5.1_and_2.0.6.tdf")
     rt_file = tmp_dir / f"0.9.0-java-{decrypt_sdk}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 92
 
@@ -116,7 +116,7 @@ def test_decrypt_no_splitid(
         pytest.skip("Decrypting hexless files is not supported")
     ct_file = get_golden_file("no-splitids-java.tdf")
     rt_file = tmp_dir / f"no-splitids-java-{decrypt_sdk}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf")
     file_stats = os.stat(rt_file)
     assert file_stats.st_size == 5 * 2**10
     expected_bytes = bytes([0] * 1024)
@@ -136,6 +136,6 @@ def test_decrypt_object_statement_value_json(
         pytest.skip("assertion_verification is not supported")
     ct_file = get_golden_file("with-json-object-assertions-java.tdf")
     rt_file = tmp_dir / f"with-json-object-assertions-java-{decrypt_sdk}.untdf"
-    decrypt_sdk.decrypt(ct_file, rt_file, container="ztdf", verify_assertions=False)
+    decrypt_sdk.decrypt(ct_file, rt_file, container="tdf", verify_assertions=False)
     with rt_file.open("rb") as f:
         assert f.read().decode("utf-8") == "text"

--- a/xtest/test_policytypes.py
+++ b/xtest/test_policytypes.py
@@ -22,7 +22,7 @@ def skip_rts_as_needed(
     pfs = tdfs.get_platform_features()
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
-    if container == "ztdf-ecwrap":
+    if container == "tdf-ecwrap":
         if not encrypt_sdk.supports("ecwrap"):
             pytest.skip(f"{encrypt_sdk} sdk doesn't yet support ecwrap bindings")
         if "ecwrap" not in pfs.features:

--- a/xtest/test_pqc.py
+++ b/xtest/test_pqc.py
@@ -110,7 +110,7 @@ def test_xwing_roundtrip(
     assert_xwing_public_key_size(key_xwing)
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -175,7 +175,7 @@ def test_xwing_with_ec_roundtrip(
     ):
         tdfs.skip_if_unsupported(decrypt_sdk, "ecwrap")
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -233,7 +233,7 @@ def test_secpmlkem_3_roundtrip(
     )
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -311,7 +311,7 @@ def test_secpmlkem_5_roundtrip(
     )
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -363,7 +363,7 @@ def test_mlkem_768_roundtrip(
     )
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -413,5 +413,5 @@ def test_mlkem_1024_roundtrip(
     )
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)

--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -25,6 +25,7 @@ except FileNotFoundError:
 #### BASIC ROUNDTRIP TESTS
 
 
+@pytest.mark.stage1
 def test_tdf_roundtrip(
     encrypt_sdk: tdfs.SDK,
     decrypt_sdk: tdfs.SDK,
@@ -35,14 +36,14 @@ def test_tdf_roundtrip(
     attribute_default_rsa: Attribute,
     encrypted_tdf: EncryptFactory,
 ):
-    if container == "ztdf" and decrypt_sdk in dspx1153Fails:
+    if container == "tdf" and decrypt_sdk in dspx1153Fails:
         pytest.skip(f"DSPX-1153 SDK [{decrypt_sdk}] has a bug with payload tampering")
     pfs = tdfs.get_platform_features()
     if not in_focus & {encrypt_sdk, decrypt_sdk}:
         pytest.skip("Not in focus")
     tdfs.skip_hexless_skew(encrypt_sdk, decrypt_sdk)
     tdfs.skip_connectrpc_skew(encrypt_sdk, decrypt_sdk, pfs)
-    if container == "ztdf-ecwrap":
+    if container == "tdf-ecwrap":
         if not encrypt_sdk.supports("ecwrap"):
             pytest.skip(f"{encrypt_sdk} sdk doesn't yet support ecwrap bindings")
         if "ecwrap" not in pfs.features:
@@ -58,7 +59,7 @@ def test_tdf_roundtrip(
     target_mode = tdfs.select_target_version(encrypt_sdk, decrypt_sdk)
     # Use explicit RSA attribute when not using EC wrapping to avoid base_key interference
     attr_values = (
-        None if container == "ztdf-ecwrap" else attribute_default_rsa.value_fqns
+        None if container == "tdf-ecwrap" else attribute_default_rsa.value_fqns
     )
     ct_file = encrypted_tdf(
         encrypt_sdk,
@@ -71,7 +72,7 @@ def test_tdf_roundtrip(
     assert manifest.payload.isEncrypted
     assert len(manifest.encryptionInformation.keyAccess) == 1
     kao = manifest.encryptionInformation.keyAccess[0]
-    if container == "ztdf-ecwrap":
+    if container == "tdf-ecwrap":
         assert kao.type == "ec-wrapped"
         assert kao.ephemeralPublicKey is not None
     else:
@@ -96,7 +97,7 @@ def test_tdf_roundtrip(
     audit_logs.assert_rewrap_success(min_count=1, since_mark=mark)
 
     if (
-        container.startswith("ztdf")
+        container.startswith("tdf")
         and decrypt_sdk.supports("ecwrap")
         and "ecwrap" in pfs.features
     ):
@@ -134,7 +135,7 @@ def test_tdf_spec_target_422(
     )
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -164,7 +165,7 @@ def test_tdf_spec_target_430(
     )
 
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -303,7 +304,7 @@ def test_tdf_assertions_unkeyed(
         attr_values=attribute_default_rsa.value_fqns,
     )
     rt_file = encrypted_tdf.rt_file(ct_file, decrypt_sdk)
-    decrypt_sdk.decrypt(ct_file, rt_file, "ztdf")
+    decrypt_sdk.decrypt(ct_file, rt_file, "tdf")
     assert filecmp.cmp(pt_file, rt_file)
 
 
@@ -337,7 +338,7 @@ def test_tdf_assertions_with_keys(
     decrypt_sdk.decrypt(
         ct_file,
         rt_file,
-        "ztdf",
+        "tdf",
         assertion_verification_file_rs_and_hs_keys,
     )
     assert filecmp.cmp(pt_file, rt_file)
@@ -378,7 +379,7 @@ def test_tdf_assertions_422_format(
     decrypt_sdk.decrypt(
         ct_file,
         rt_file,
-        "ztdf",
+        "tdf",
         assertion_verification_file_rs_and_hs_keys,
     )
     assert filecmp.cmp(pt_file, rt_file)
@@ -559,7 +560,7 @@ def test_tdf_with_unbound_policy(
     rt_file = encrypted_tdf.rt_file(b_file, decrypt_sdk)
 
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "tdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_kas_request_error(exc, decrypt_sdk)
@@ -587,7 +588,7 @@ def test_tdf_with_altered_policy_binding(
     rt_file = encrypted_tdf.rt_file(b_file, decrypt_sdk)
 
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "tdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_kas_request_error(exc, decrypt_sdk)
@@ -616,7 +617,7 @@ def test_tdf_with_altered_root_sig(
     b_file = tdfs.update_manifest("broken_root_sig", ct_file, change_root_signature)
     rt_file = encrypted_tdf.rt_file(b_file, decrypt_sdk)
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "tdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_tamper_error(exc, "root", decrypt_sdk)
@@ -643,7 +644,7 @@ def test_tdf_with_altered_seg_sig_wrong(
     rt_file = encrypted_tdf.rt_file(b_file, decrypt_sdk)
     try:
         decrypt_sdk.decrypt(
-            b_file, rt_file, "ztdf", expect_error=True, verify_assertions=False
+            b_file, rt_file, "tdf", expect_error=True, verify_assertions=False
         )
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
@@ -675,7 +676,7 @@ def test_tdf_with_altered_enc_seg_size(
     )
     rt_file = encrypted_tdf.rt_file(b_file, decrypt_sdk)
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "tdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_tamper_error(exc, "", decrypt_sdk)
@@ -712,7 +713,7 @@ def test_tdf_with_altered_assertion_statement(
     )
     rt_file = encrypted_tdf.rt_file(b_file, decrypt_sdk)
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "tdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_tamper_error(exc, "assertion", decrypt_sdk)
@@ -750,7 +751,7 @@ def test_tdf_with_altered_assertion_with_keys(
         decrypt_sdk.decrypt(
             b_file,
             rt_file,
-            "ztdf",
+            "tdf",
             assertion_verification_file_rs_and_hs_keys,
             expect_error=True,
         )
@@ -784,7 +785,7 @@ def test_tdf_altered_payload_end(
     b_file = tdfs.update_payload("altered_payload_end", ct_file, change_payload_end)
     rt_file = encrypted_tdf.rt_file(b_file, decrypt_sdk)
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "tdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert_tamper_error(exc, "segment", decrypt_sdk)
@@ -820,7 +821,7 @@ def test_tdf_with_malicious_kao(
     _mark = audit_logs.mark("before_malicious_kao_decrypt")
 
     try:
-        decrypt_sdk.decrypt(b_file, rt_file, "ztdf", expect_error=True)
+        decrypt_sdk.decrypt(b_file, rt_file, "tdf", expect_error=True)
         assert False, "decrypt succeeded unexpectedly"
     except subprocess.CalledProcessError as exc:
         assert re.search(

--- a/xtest/uv.lock
+++ b/xtest/uv.lock
@@ -188,6 +188,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -647,6 +656,7 @@ dependencies = [
     { name = "construct" },
     { name = "construct-typing" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "gitdb" },
     { name = "gitpython" },
     { name = "idna" },
@@ -689,6 +699,7 @@ requires-dist = [
     { name = "construct", specifier = ">=2.10.70" },
     { name = "construct-typing", specifier = ">=0.7.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "gitdb", specifier = ">=4.0.12" },
     { name = "gitpython", specifier = ">=3.1.50" },
     { name = "idna", specifier = ">=3.18" },


### PR DESCRIPTION
## Summary

Rebuilds the GitHub Pages community conformance report as a homepage covering **all** community SDKs (python, rust, swift) plus the go reference peer — previously only the python artifact was consumed and rendered as a bare two-table page.

- **Site generator** (`xtest/reporting/generate_site.py`): per-SDK scorecards, an encrypt×decrypt **interop matrix** built from junit test ids (stage-2 community×community pairs appear automatically), a **capability matrix** listing every SDK, provenance strip (source run, platform ref, go peer, timestamp), and an enriched machine-readable `summary.json`. Self-contained HTML, light/dark, status glyphs never rely on color alone.
- **Capability snapshots** (`xtest/reporting/export_supports.py`): extracted from the workflow heredoc, parameterized, and now exported for python, rust, swift, and go (tagged `reference`).
- **`community-pages.yml`**: downloads all `community-*stage*` artifacts from the source run (via `download-artifact` with `run-id`), passes run provenance to the generator, pins the Pages actions by SHA, adds job timeouts, and still deploys on failed runs so the page shows red instead of going stale.
- **`community-xtest.yml`**: adds `set -o pipefail` to the three piped pytest steps. `pytest | tee` was swallowing pytest's exit code — run 29210974140 reported green while python stage-1 recorded **3 failed, 0 passed**. Note: with the current python failures, the gate will legitimately go red until those are addressed.

## Verification

- Generator run against the real artifacts of run 29210974140; page inspected in light and dark modes.
- `ruff check`, `ruff format --check`, `pyright`: clean.
- `actionlint` on both workflows: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvm7uKaNssz7ztu3nAmf7u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conformance testing for community Python, Rust, and Swift SDKs, including cross-SDK interoperability checks.
  * Added generated GitHub Pages dashboards showing SDK capabilities, interoperability results, and test metrics.
  * Added native macOS platform startup support without Docker or Colima.
* **Bug Fixes**
  * Improved compatibility for container format names while preserving legacy aliases.
  * Improved dependency review behavior for forked contributions.
* **Documentation**
  * Added community conformance guidance, format terminology, setup instructions, and workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->