### PR TITLE
fix(xtest): detect java dpop support via supports subcommand

### DIFF
--- a/xtest/sdk/java/cli.sh
+++ b/xtest/sdk/java/cli.sh
@@ -137,8 +137,7 @@ if [ "$1" == "supports" ]; then
       exit $?
       ;;
     dpop)
-      set -o pipefail
-      java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep -iE -- '--dpop'
+      java -jar "$SCRIPT_DIR"/cmdline.jar supports dpop
       exit $?
       ;;
     dpop_nonce_challenge)


### PR DESCRIPTION
## Problem

The java-sdk removed the user-facing `--dpop` / `--dpop-key` CLI flags in opentdf/java-sdk#374. DPoP is now always-on by default, and capability is exposed through the `supports` subcommand instead.

The Java wrapper's `supports dpop` case still detects DPoP by grepping `help encrypt` for the `--dpop` flag:

```bash
dpop)
  set -o pipefail
  java -jar "$SCRIPT_DIR"/cmdline.jar help encrypt | grep -iE -- '--dpop'
  exit $?
  ;;
```

With the flags gone this grep finds nothing, exits 1, and xtest skips java DPoP tests:

```
SKIPPED [2] tdfs.py:619: java@... sdk doesn't yet support [dpop]
```

The sibling `dpop_nonce_challenge` case already delegates to the `supports` subcommand and is unaffected.

## Fix

Detect `dpop` the same way `dpop_nonce_challenge` already does — via the `supports` subcommand, whose exit code is the capability contract (0 = supported, 1 = not):

```bash
dpop)
  java -jar "$SCRIPT_DIR"/cmdline.jar supports dpop
  exit $?
  ;;
```

`set -o pipefail` is dropped since there's no longer a pipe.

## Verification

With a current java `cmdline.jar` installed: `./cli.sh supports dpop; echo $?` prints `0`, and `dpop_nonce_challenge` still returns `0`. Only `xtest/sdk/java/cli.sh` changes; other SDK wrappers are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of DPoP support in the Java CLI feature probe.
  * Prevents incorrect results caused by relying on help output and flag matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->