### PR TITLE
fix(xtest): pin start-up-with-containers to opentdf/platform#3750

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -306,7 +306,7 @@ jobs:
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers
         id: run-platform
-        uses: opentdf/platform/test/start-up-with-containers@0612ea897264e3c621ce076029a5e1e3f2d3971e  # main
+        uses: opentdf/platform/test/start-up-with-containers@c4038bdd72b8777654aa36266ad721710d220f4d  # fix/ci-startup-yaml-pqc-guard (opentdf/platform#3750) — DO NOT MERGE until that PR lands, then re-pin to main
         with:
           platform-ref: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-to-sha)[matrix.platform-tag] }}
           ec-tdf-enabled: true


### PR DESCRIPTION
Ppins the `start-up-with-containers` action to the fix branch for testing.

## Why

opentdf/platform#3594 introduced a regression: a misplaced `exit 0` in the `Map the config to the keys` step of `test/start-up-with-containers/action.yaml` skips creation of `opentdf.yaml` whenever the platform under test lacks PQC keys (e.g. released tags like v0.9.0 that predate `service/cmd/keygen`). Every later step then fails with `stat opentdf.yaml: no such file or directory`.

Fix: opentdf/platform#3750 (branch `fix/ci-startup-yaml-pqc-guard`, `c4038bdd72b8777654aa36266ad721710d220f4d`).

## Change

- `.github/workflows/xtest.yml`: pin `start-up-with-containers` from `0612ea89 # main` → `c4038bd` (the fix branch) so CI exercises the fix.
- `.github/workflows/vulnerability.yml` is intentionally **left** at `11af44a5 # pqc-enabled` — it's on a different lineage and isn't affected by this bug.

## Follow-up

- Merge opentdf/platform#3750, then re-pin this back to the resulting `main` SHA.
- A more principled replacement for the version/file heuristics (capability probe via keygen) is planned separately.