### PR TITLE
chore(xtest): re-pin opentdf/platform test actions to main

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -306,7 +306,7 @@ jobs:
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers
         id: run-platform
-        uses: opentdf/platform/test/start-up-with-containers@c4038bdd72b8777654aa36266ad721710d220f4d  # fix/ci-startup-yaml-pqc-guard (opentdf/platform#3750) — DO NOT MERGE until that PR lands, then re-pin to main
+        uses: opentdf/platform/test/start-up-with-containers@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix (opentdf/platform#3750)
         with:
           platform-ref: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-to-sha)[matrix.platform-tag] }}
           ec-tdf-enabled: true
@@ -601,7 +601,7 @@ jobs:
       - name: Start additional kas
         id: kas-alpha
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@0612ea897264e3c621ce076029a5e1e3f2d3971e  # main: require_nonce on additional KAS
+        uses: opentdf/platform/test/start-additional-kas@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix: require_nonce on additional KAS
         with:
           ec-tdf-enabled: true
           kas-name: alpha
@@ -614,7 +614,7 @@ jobs:
       - name: Start additional kas
         id: kas-beta
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@0612ea897264e3c621ce076029a5e1e3f2d3971e  # main: require_nonce on additional KAS
+        uses: opentdf/platform/test/start-additional-kas@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix: require_nonce on additional KAS
         with:
           ec-tdf-enabled: true
           kas-name: beta
@@ -627,7 +627,7 @@ jobs:
       - name: Start additional kas
         id: kas-gamma
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@0612ea897264e3c621ce076029a5e1e3f2d3971e  # main: require_nonce on additional KAS
+        uses: opentdf/platform/test/start-additional-kas@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix: require_nonce on additional KAS
         with:
           ec-tdf-enabled: true
           kas-name: gamma
@@ -640,7 +640,7 @@ jobs:
       - name: Start additional kas
         id: kas-delta
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@0612ea897264e3c621ce076029a5e1e3f2d3971e  # main: require_nonce on additional KAS
+        uses: opentdf/platform/test/start-additional-kas@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix: require_nonce on additional KAS
         with:
           ec-tdf-enabled: true
           kas-port: 8484
@@ -653,7 +653,7 @@ jobs:
       - name: Start additional KM kas (km1)
         id: kas-km1
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@0612ea897264e3c621ce076029a5e1e3f2d3971e  # main: require_nonce on additional KAS
+        uses: opentdf/platform/test/start-additional-kas@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix: require_nonce on additional KAS
         with:
           ec-tdf-enabled: true
           key-management: ${{ steps.km-check.outputs.supported }}
@@ -667,7 +667,7 @@ jobs:
       - name: Start additional KM kas (km2)
         id: kas-km2
         if: ${{ steps.multikas.outputs.supported == 'true' }}
-        uses: opentdf/platform/test/start-additional-kas@0612ea897264e3c621ce076029a5e1e3f2d3971e  # main: require_nonce on additional KAS
+        uses: opentdf/platform/test/start-additional-kas@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix: require_nonce on additional KAS
         with:
           ec-tdf-enabled: true
           kas-name: km2


### PR DESCRIPTION
Follow-up to #559. Now that [opentdf/platform#3750](https://github.com/opentdf/platform/pull/3750) has merged, re-pin the `opentdf/platform` test actions from the temporary fix branch / stale main SHA to a **stable, named snapshot** of current platform main.

To avoid the pins reading as "floating `main`", the target SHA is tagged in opentdf/platform as **`ci-startup-yaml-fix`** (annotated tag → `6dd5f649347fb2314c6090ea6d090a5c673d58a6`). Pins stay SHA-locked (supply-chain best practice); the tag is the human-readable comment.

## Changes (`.github/workflows/xtest.yml`)

| Action | Before | After (SHA `6dd5f649`, tag `ci-startup-yaml-fix`) |
|---|---|---|
| `start-up-with-containers` (L309) | `c4038bd` (fix branch) | ✅ |
| `start-additional-kas` ×6 (L604–670) | `0612ea89` (stale main) | ✅ |

## Notes

- `6dd5f649` is the squash-merge of #3750 ("always generate opentdf.yaml") and was current platform `main` HEAD; the `ci-startup-yaml-fix` tag makes it a durable pointer.
- `start-additional-kas/action.yaml` is **unchanged** between `0612ea89` and `6dd5f649` (verified via `compare`) — a SHA-only sync.
- `vulnerability.yml` intentionally left on its `# pqc-enabled` pin (separate lineage).