### PR TITLE
chore(xtest): validate e2e against Keycloak 26.4 (DSPX-4190)

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -306,8 +306,13 @@ jobs:
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers
         id: run-platform
-        uses: opentdf/platform/test/start-up-with-containers@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix (opentdf/platform#3750)
+        uses: opentdf/platform/test/start-up-with-containers@d1081e925e320d620a07f481d108cc7d9f76ec52  # DSPX-4190: bootstrap-ref support (Keycloak 26.4 validation) — roll back to pqc-enabled/main SHA after
         with:
+          # DSPX-4190 validation: source docker-compose.yaml (Keycloak 26.4.0),
+          # init-temp-keys.sh, and watch.sh from the DSPX-4190 branch instead of
+          # the frozen pqc-enabled tag (Keycloak 25.0). Drop once pqc-enabled is
+          # re-pointed to carry the 26.4 bootstrap files.
+          bootstrap-ref: DSPX-4190
           platform-ref: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-to-sha)[matrix.platform-tag] }}
           ec-tdf-enabled: true
           extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}

--- a/spec/DSPX-4190.md
+++ b/spec/DSPX-4190.md
@@ -17,23 +17,70 @@ jira_priority: Medium
 # Update opentdf e2e tests to use keycloak 26.x
 
 ## Summary
-This is now the CVE free version, and it has a few breaking changes (DPoP strictness, token exchange improvements)
+Move all OpenTDF e2e test environments and targets onto Keycloak **26.4** (the
+current CVE-free line). 26.x carries two breaking changes we must validate:
+tightened **DPoP** enforcement and the move to **standard token exchange**.
 
 ## Problem / Motivation
-_Why does this work need to happen? What is the user/business pain?_
+The e2e suite previously ran against an older Keycloak that now carries known
+CVEs. Staying on it leaves the test fleet — and the behavior it certifies — on
+an unsupported, vulnerable identity provider. 26.4 is the CVE-free target, but
+its DPoP-strictness and token-exchange changes must be exercised by the e2e
+tests to prove the platform + SDKs still interoperate under the new rules.
 
 ## Proposed Solution
-_What will you build, at a functional level? Sketch the approach._
+The Keycloak image, realm provisioning, DPoP-bound client, and token-exchange
+config live in `opentdf/platform` (branch `opentdf/platform:DSPX-4190`, already
+pinned to `ghcr.io/opentdf/keycloak-standard:26.4.0`). This `tests` repo
+*consumes* that build; it pins no Keycloak version of its own. Work here:
+
+1. **CI e2e targets** — advance the pinned `opentdf/platform/test/*` composite
+   action SHAs in `.github/workflows/xtest.yml` (`start-up-with-containers` +
+   six `start-additional-kas`) and `.github/workflows/vulnerability.yml`
+   (currently an older, divergent SHA) to the single merged-`main` platform
+   commit that carries the 26.4 bump, aligning both workflows to that SHA.
+2. **DPoP coverage** — the `xtest/test_dpop.py` lanes are capability-gated
+   (`xtest/tdfs.py` reads the platform `.well-known`), so the happy-path lanes
+   auto-activate on 26.4. Enable `dpop-challenge: true` on a nightly cron so the
+   nonce-challenge/strictness lanes run regularly.
+3. **Docs** — this spec; no source docstring changes needed
+   (`xtest/test_dpop.py` already references Keycloak 26).
 
 ## Inputs / Outputs / Contracts
-_Function signatures, data shapes, API contracts, CLI flags._
+- Keycloak endpoints unchanged on 26.4 and require no edits: host `:8888`,
+  relative path `/auth`, realm `opentdf`, token endpoint
+  `/auth/realms/opentdf/protocol/openid-connect/token` (`xtest/test.env`,
+  `vulnerability/.env`).
+- CI input contract: `dpop-challenge` (boolean) on `xtest.yml` gates
+  `dpop-challenge-enabled` passthrough to every KAS start step.
+- Platform capability contract: `.well-known/opentdf-configuration` must expose
+  `dpop_signing_alg_values_supported` (and `dpop_nonce_required` when challenge
+  mode is on) for the DPoP lanes to activate.
 
 ## Edge Cases & Constraints
-_Boundary conditions, error states, performance limits, security considerations._
+- DPoP strictness: DPoP-bound tokens presented under `Authorization: Bearer`
+  are currently accepted-with-WARN (see `test_dpop.py`,
+  `test_dpop_bearer_scheme_warns_but_accepted_for_dpop_token`); flipping to a
+  hard 401 is tracked separately (DSPX-3573), not by this ticket.
+- Nonce challenge only activates when KAS is started with
+  `dpop-challenge-enabled: true`; PR runs may stay off for speed.
+- Keycloak readiness/health gates assume `/auth/realms/master` → 200 and mgmt
+  `:9001/auth/health/live` — both hold on 26.x.
 
 ## Out of Scope
-_What this work item explicitly does not cover._
+- Platform-repo edits (docker-compose image tag, `keycloak_data.yaml`,
+  `lib/fixtures/keycloak.go`) — tracked under `opentdf/platform:DSPX-4190`.
+- Reviewing the stale-looking `legacykeycloak: true` ERS flag (platform side).
+- Reviving the otherwise-dormant `vulnerability.yml` suite (Node 16, disabled
+  triggers) beyond aligning its action SHA.
 
 ## Acceptance Criteria
-- [ ] _Clear, testable condition_
-- [ ] _…_
+- [ ] `xtest.yml` and `vulnerability.yml` pin all `opentdf/platform/test/*`
+      actions to the same merged-`main` SHA carrying Keycloak 26.4.0.
+- [ ] The running Keycloak container in CI/local is `keycloak-standard:26.4.0`
+      (or later 26.x).
+- [ ] `xtest/test_dpop.py` DPoP lanes **run (not skip)** against the 26.4
+      platform, and pass across the SDK matrix.
+- [ ] At least one nightly cron runs with `dpop-challenge: true` so the
+      nonce-challenge lanes are exercised.
+- [ ] The core suite (`test_tdfs.py`, `test_abac.py`) stays green against 26.4.

--- a/spec/DSPX-4190.md
+++ b/spec/DSPX-4190.md
@@ -1,0 +1,39 @@
+---
+ticket: DSPX-4190
+title: Update opentdf e2e tests to use keycloak 26.x
+status: draft
+authors:
+    - dmihalcik@virtru.com
+branches:
+    - opentdf/tests:DSPX-4190
+    - opentdf/platform:DSPX-4190
+prs: []
+created: 2026-07-27T00:00:00Z
+updated: 2026-07-27T00:00:00Z
+jira_priority: Medium
+---
+
+
+# Update opentdf e2e tests to use keycloak 26.x
+
+## Summary
+This is now the CVE free version, and it has a few breaking changes (DPoP strictness, token exchange improvements)
+
+## Problem / Motivation
+_Why does this work need to happen? What is the user/business pain?_
+
+## Proposed Solution
+_What will you build, at a functional level? Sketch the approach._
+
+## Inputs / Outputs / Contracts
+_Function signatures, data shapes, API contracts, CLI flags._
+
+## Edge Cases & Constraints
+_Boundary conditions, error states, performance limits, security considerations._
+
+## Out of Scope
+_What this work item explicitly does not cover._
+
+## Acceptance Criteria
+- [ ] _Clear, testable condition_
+- [ ] _…_


### PR DESCRIPTION
## What
DSPX-4190 — move the e2e fleet onto **Keycloak 26.4** (CVE-free; DPoP strictness + standard token-exchange changes). **Draft/interim**, opened to validate the suite against 26.4.

## Why it's not a one-line image bump
`start-up-with-containers` overwrites the checked-out `docker-compose.yaml` with one fetched from a frozen ref — previously hardcoded to the `pqc-enabled` tag (`keycloak/keycloak:25.0`). So every lane, including `main`, ran 25.0 despite main's compose already being 26.4.0. The companion platform change (`opentdf/platform:DSPX-4190`) adds a `bootstrap-ref` input to select that ref.

## Changes
- Pin `start-up-with-containers` to `d1081e9` (adds `bootstrap-ref`) and set `bootstrap-ref: DSPX-4190`, so CI pulls the 26.4.0 compose from the branch. (`start-additional-kas` unchanged — it downloads no compose.)
- Flesh out `spec/DSPX-4190.md`.

## Before merge (do not merge as-is)
- [ ] Re-point `pqc-enabled` (or cut a new tag) to a 26.4 bootstrap commit, then drop `bootstrap-ref` and re-pin the action to a stable `main` SHA.
- [ ] `test_dpop.py` lanes skip unless the `opentdf-dpop` provisioning (DSPX-3397) is in the `platform-ref` checkout.
- [ ] Align `vulnerability.yml` (still on the 25.0 action SHA).