### PR TITLE
fix(xtest): pull Keycloak 26.4 bootstrap on the main platform lane

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -306,9 +306,17 @@ jobs:
       ######## SPIN UP PLATFORM BACKEND #############
       - name: Check out and start up platform with deps/containers
         id: run-platform
-        uses: opentdf/platform/test/start-up-with-containers@6dd5f649347fb2314c6090ea6d090a5c673d58a6  # ci-startup-yaml-fix (opentdf/platform#3750)
+        uses: opentdf/platform/test/start-up-with-containers@18b8070f7ae1e3547234342f42d0d686dc77788f  # keycloak-26.4 (opentdf/platform#3792)
         with:
           platform-ref: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-to-sha)[matrix.platform-tag] }}
+          # The action overlays docker-compose.yaml from bootstrap-ref, independent
+          # of platform-ref. The default `pqc-enabled` tag is still Keycloak 25.0,
+          # which cannot issue DPoP-bound access tokens, so test_dpop.py roundtrips
+          # fail with a plain Bearer token. main's compose is Keycloak 26.4 with
+          # KC_FEATURES: dpop. Only the main lane gets it -- released platform tags
+          # predate the switch to standard Keycloak token exchange and still need
+          # the 25.0 bootstrap.
+          bootstrap-ref: ${{ matrix.platform-tag == 'main' && 'main' || 'pqc-enabled' }}
           ec-tdf-enabled: true
           extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
           log-type: json


### PR DESCRIPTION
## What

Bump the `start-up-with-containers` pin to `18b8070f` (opentdf/platform#3792) and pass `bootstrap-ref: main` on the `main` platform lane only.

## Why

The action overlays `docker-compose.yaml` from `bootstrap-ref`, **independent of `platform-ref`**. That input defaults to the `pqc-enabled` tag, which is still pinned to `keycloak/keycloak:25.0` — a Keycloak that cannot issue DPoP-bound access tokens. So every lane ran KC 25 even though platform `main`'s own compose has been `ghcr.io/opentdf/keycloak-standard:26.4.0` with `KC_FEATURES: dpop` since #3792, and `service/cmd/keycloak_data.yaml` provisions `opentdf-dpop` with `dpop.bound.access.tokens: "true"`.

The visible symptom: `test_dpop.py::test_dpop_happy_path_roundtrip` fails for any SDK that checks token binding. The token comes back `typ=Bearer` with no `cnf.jkt`, and the js CLI rejects it:

```
[CRITICAL] DPoP requested but the access token is not bound (missing cnf.jkt)
```

go and java pass only because they don't assert `cnf.jkt`. The other `test_dpop.py` cases already self-skip on `token_type != DPoP`; the SDK-level roundtrips gate on the platform well-known and SDK features, not on IdP capability, so they run and fail. This is what keeps opentdf/web-sdk#939 red.

Released platform tags keep the 25.0 bootstrap — they predate the move to standard Keycloak token exchange (opentdf/platform#3754).

## Testing

Dispatched against this branch with `platform-ref=main`, `js-ref=refs/pull/939/merge`, `focus-sdk=js` — https://github.com/opentdf/tests/actions/runs/31016132383 — all three lanes green (`go@main`, `java@main`, `js@pull-939`).

Confirmed Keycloak 26.4 came up, and these ran rather than skipped:

```
PASSED test_dpop.py::test_dpop_happy_path_roundtrip[small-js@pull-939-js@pull-939-in_focus0]
PASSED test_dpop.py::test_dpop_happy_path_roundtrip[small-js@pull-939-java@main-in_focus0]
PASSED test_dpop.py::test_dpop_rejects_replayed_jti[small-js@pull-939-in_focus0]
PASSED test_dpop.py::test_dpop_rejects_tampered_proof_htu[small-js@pull-939-in_focus0]
PASSED test_dpop.py::test_dpop_bearer_scheme_warns_but_accepted_for_dpop_token[small-js@pull-939-in_focus0]
```

The nonce-dependent cases still skip, correctly — `dpop-challenge` is off by default, so `require_nonce` is unset.

## Notes

- The new action's input set is a strict superset of the old pin's; no call-site changes beyond `bootstrap-ref`.
- `start-additional-kas` is left at `6dd5f649` — it downloads no compose.
- Overlaps opentdf/tests#568 (DSPX-4190), which took the broader approach of moving every lane to 26.4 via a platform PR branch. This is the narrow slice needed now; #568's remaining checklist (re-point the `pqc-enabled` tag, align `vulnerability.yml`) still stands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform startup workflows to use the Keycloak 26.4 revision.
  * Adjusted bootstrap selection so the main platform lane uses the main configuration while released tags retain the PQC-enabled configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->