### PR TITLE
fix(xtest): move malicious-KAO test URL off a live km1 port

### DIFF
--- a/xtest/test_tdfs.py
+++ b/xtest/test_tdfs.py
@@ -465,11 +465,14 @@ def change_payload_end(payload_bytes: bytes) -> bytes:
     return change_last_three(payload_bytes)
 
 
+# URL that must be blocked by the SDK 'allowlist' functionality.
+# Uses an unbound port so it should fail at the network layer.
+MALICIOUS_KAS_URL = "http://localhost:9999/malicious/kas"
+
+
 def malicious_kao(manifest: tdfs.Manifest) -> tdfs.Manifest:
     assert manifest.encryptionInformation.keyAccess
-    manifest.encryptionInformation.keyAccess[
-        0
-    ].url = "http://localhost:8585/malicious/kas"  # nothing running at 8585
+    manifest.encryptionInformation.keyAccess[0].url = MALICIOUS_KAS_URL
     return manifest
 
 


### PR DESCRIPTION
## Problem

`test_tdf_with_malicious_kao` rewrites a KAO's `url` to an unreachable KAS and expects the decrypt to fail. It hardcoded `http://localhost:8585`, with the comment `# nothing running at 8585` — true when it was written, but `otdf-local` later assigned that port to **km1** ([`otdf-local/src/otdf_local/config/ports.py:23`](../blob/main/otdf-local/src/otdf_local/config/ports.py#L23)).

That matters because the test tolerates two different failure modes:

- **go** screens the URL against its KAS allowlist and never connects, so its error says `allowlist`. It passes either way.
- **js** (v0.20.0) doesn't, and falls through to a real request. This is why `AggregateError` — what Node's `fetch` raises for a refused connection — is one of the accepted alternatives in the assertion.

With km1 listening on 8585, that request gets an *answer* instead of a refusal:

```
POST http://localhost:8585/malicious/kas/v2/rewrap => 404 Not Found NetworkError
```

which matches none of `allowlist|not allowed|disallowed KASes|AggregateError`, so both js-decrypt parametrizations fail:

```
FAILED test_tdfs.py::test_tdf_with_malicious_kao[small-go@v0.36.0-js@v0.20.0-in_focus0]
FAILED test_tdfs.py::test_tdf_with_malicious_kao[small-js@v0.20.0-js@v0.20.0-in_focus0]
```

The failure is environmental — it reproduces against any `otdf-local` stack, and not in CI, where nothing binds 8585.

## Fix

Move the URL to port 9999, lift it into a `MALICIOUS_KAS_URL` constant, and replace the stale comment with the actual constraint plus a pointer to the port map, so a future port assignment doesn't silently reclaim it.

## Testing

Against a local `otdf-local` platform:

```
uv run pytest test_tdfs.py::test_tdf_with_malicious_kao --sdks "go js" -v
```

`4 passed in 11.28s` — including the two js-decrypt combinations that previously failed.

Found while verifying #571; split out because it's unrelated to that change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to use the revised local endpoint for malicious service scenarios.
  * Improved consistency by centralizing the endpoint value used during testing.

* **User Impact**
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->