### PR TITLE
chore(ci): Support key_management stable change.

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -506,10 +506,11 @@ jobs:
         run: |-
           OT_CONFIG_FILE="$(pwd)/opentdf.yaml"
           echo "OT_CONFIG_FILE=$OT_CONFIG_FILE" >> "$GITHUB_ENV"
-          # Determine if the config declares the key_management field
-          km_value=$(yq e '.services.kas.preview.key_management' "$OT_CONFIG_FILE" 2>/dev/null || echo "null")
-          case "$km_value" in
-            true|false)
+          # Determine if the config declares either key_management field
+          key_management=$(yq e '.services.kas.key_management' "$OT_CONFIG_FILE" 2>/dev/null || echo "null")
+          preview_key_management=$(yq e '.services.kas.preview.key_management' "$OT_CONFIG_FILE" 2>/dev/null || echo "null")
+          case "$key_management:$preview_key_management" in
+            true:*|false:*|*:true|*:false)
               echo "KEY_MANAGEMENT_SUPPORTED=true" >> "$GITHUB_ENV"
               echo "supported=true" >> "$GITHUB_OUTPUT"
               ;;


### PR DESCRIPTION
1.) Support new and old key_management flags


Tested with a manual run:
- https://github.com/opentdf/tests/actions/runs/32278408353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key-management support detection by checking both standard and preview service configurations.
  * Support is now correctly recognized when either configuration explicitly enables or disables key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->