### PR TITLE
feat(xtest): benchmark two named refs via workflow_dispatch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
         run: >-
           uv run --frozen --no-build pytest --no-header -q
           test_bench_stats.py test_bench_measure.py test_bench_runner.py
-          test_bench_arms.py test_sdk_commands.py
+          test_bench_arms.py test_bench_report.py test_sdk_commands.py
         working-directory: xtest
       - name: Lint and test otdf-local
         run: |

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -1212,6 +1212,15 @@ jobs:
           BENCH_VERSION_INFO: >-
             ${{ steps.bench-arms.outputs.version-info
                 || needs.resolve-versions.outputs[matrix.sdk] }}
+          # Keep the names the caller asked for even when the resolver folds
+          # aliases at one SHA into a single install. That is how reporting can
+          # distinguish "main == latest" from a benchmark that broke before it
+          # found its second arm.
+          BENCH_REQUESTED_REFS: >-
+            ${{ needs.resolve-versions.outputs.bench-refs
+                || (matrix.sdk == 'go' && (inputs.otdfctl-ref || 'main latest'))
+                || (matrix.sdk == 'java' && (inputs.java-ref || 'main latest'))
+                || (inputs.js-ref || 'main latest') }}
           # pytest writes a summary template beside the JSON. Publish it only
           # after upload-artifact gives us the direct evidence URL.
           BENCH_DEFER_SUMMARY: "1"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -854,7 +854,14 @@ jobs:
   # Never runs on pull requests: 30 minutes of serial measurement is too slow
   # for a PR gate, and a PR runner is the noisiest place to measure.
   bench:
-    timeout-minutes: 45
+    # Has to cover setup plus the whole of bench-budget-seconds, and setup is
+    # not a small constant: a warm Go module cache builds both arms in ~3
+    # minutes, a cold one took 19. At 45 this job could not even finish its
+    # own default 1500s budget after a cold start -- it would be killed
+    # mid-measurement, which loses the report entirely rather than reporting
+    # fewer rounds. The budget is the knob that bounds the run; this is only
+    # the backstop for a hung one.
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     needs: resolve-versions
     # Nightly cron only, not the Mon/Wed or weekly ones: three runs a week of

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -1206,6 +1206,15 @@ jobs:
           # Already defaulted (and scaled by arm count) in resolve-versions.
           BENCH_BUDGET_SECONDS: ${{ needs.resolve-versions.outputs.bench-budget-seconds }}
           BENCH_MAX_ROUNDS: ${{ inputs.bench-max-rounds || '60' }}
+          # Structured resolver output: original alias, immutable SHA, PR,
+          # release tag, and source/head classification. The report turns it
+          # into links instead of guessing provenance from a dist directory.
+          BENCH_VERSION_INFO: >-
+            ${{ steps.bench-arms.outputs.version-info
+                || needs.resolve-versions.outputs[matrix.sdk] }}
+          # pytest writes a summary template beside the JSON. Publish it only
+          # after upload-artifact gives us the direct evidence URL.
+          BENCH_DEFER_SUMMARY: "1"
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           SCHEMA_FILE: "manifest.schema.json"
           PLATFORM_TAG: main
@@ -1223,14 +1232,42 @@ jobs:
       # surprising result offline beats re-running a 30-minute job to look at
       # the same numbers again.
       - name: Upload benchmark results
+        id: benchmark-results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
-          name: ${{ job.status == 'success' && '✅' || '❌' }} bench-${{ matrix.sdk }}
+          name: bench-result-${{ matrix.sdk }}
           path: |
             otdftests/xtest/test-results/benchmarks/*.json
+            otdftests/xtest/test-results/benchmarks/*.summary.md
             otdftests/xtest/test-results/*.html
           if-no-files-found: warn
+
+      - name: Publish benchmark summary
+        if: always()
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.benchmark-results.outputs.artifact-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SUMMARY_DIR: otdftests/xtest/test-results/benchmarks
+        run: |-
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          summaries = sorted(Path(os.environ["SUMMARY_DIR"]).glob("*.summary.md"))
+          target = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          if not summaries:
+              target.write_text(
+                  "## SDK performance benchmark — NO SUMMARY\n\n"
+                  "> The benchmark stopped before session-final reporting. "
+                  f"[Inspect the workflow run]({os.environ['RUN_URL']}).\n"
+              )
+          else:
+              evidence = os.environ.get("ARTIFACT_URL") or f"{os.environ['RUN_URL']}#artifacts"
+              text = summaries[0].read_text().replace("@@BENCH_ARTIFACT_URL@@", evidence)
+              target.write_text(text)
+          PY
 
       - name: Upload server logs on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1239,6 +1276,61 @@ jobs:
           name: bench-server-logs-${{ matrix.sdk }}
           path: ${{ steps.run-platform.outputs.platform-log-file }}
           if-no-files-found: ignore
+
+  benchmark-summary:
+    name: Performance benchmark roll-up
+    runs-on: ubuntu-latest
+    needs: [resolve-versions, bench]
+    if: >-
+      always() && (
+        github.event.schedule == '30 6 * * *' ||
+        ((github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')
+         && inputs.run-benchmarks)
+      )
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: opentdf/tests
+          path: otdftests
+          persist-credentials: false
+
+      - name: Download SDK benchmark results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          pattern: bench-result-*
+          path: benchmark-results
+          merge-multiple: true
+
+      - name: Resolve benchmark artifact links
+        id: benchmark-artifacts
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner, repo, run_id: context.runId, per_page: 100 },
+            );
+            const urls = {};
+            for (const artifact of artifacts) {
+              const match = artifact.name.match(/^bench-result-(.+)$/);
+              if (match) {
+                urls[match[1]] = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}/artifacts/${artifact.id}`;
+              }
+            }
+            core.setOutput('urls', JSON.stringify(urls));
+
+      - name: Publish combined benchmark summary
+        env:
+          BENCH_ARTIFACT_URLS: ${{ steps.benchmark-artifacts.outputs.urls }}
+          BENCH_EXPECTED_SDKS: ${{ needs.resolve-versions.outputs.bench-sdks }}
+          BENCH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |-
+          python3 otdftests/xtest/perf/aggregate.py benchmark-results >> "$GITHUB_STEP_SUMMARY"
 
   publish-results:
     runs-on: ubuntu-latest

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -48,6 +48,21 @@ on:
         type: string
         default: ""
         description: "The build under suspicion, measured against bench-baseline-ref. e.g. 'feat/DSPX-2604-createtdf-chunked'."
+      bench-payloads:
+        required: false
+        type: string
+        default: ""
+        description: "Payload sizes to benchmark, comma-separated, e.g. '1KiB,1MiB,32MiB,1GiB'. Default is 1KiB,1MiB,32MiB, at which ~86% of a go encrypt is fixed startup cost -- so the 1.15x gate is wider than the whole payload-dependent part and no throughput change can fail a cell. Add 1GiB to actually gate throughput; it needs a bench-budget-seconds to match and ~5 GiB of runner disk."
+      bench-budget-seconds:
+        required: false
+        type: string
+        default: ""
+        description: "Wall-clock allowance shared by every benchmark cell (default 1500). Manual runs are not on the nightly's schedule, so this is the knob to raise when adding payload sizes -- each one adds an encrypt and a decrypt cell, and the budget is divided evenly as cells start."
+      bench-max-rounds:
+        required: false
+        type: string
+        default: ""
+        description: "Hard cap on paired rounds per cell (default 60). Raise it together with the budget: at the default, cells routinely stop on max_rounds with budget left over, and every unspent round is interval width that could have been bought."
   workflow_call:
     inputs:
       platform-ref:
@@ -83,6 +98,18 @@ on:
         type: string
         default: ""
       bench-candidate-ref:
+        required: false
+        type: string
+        default: ""
+      bench-payloads:
+        required: false
+        type: string
+        default: ""
+      bench-budget-seconds:
+        required: false
+        type: string
+        default: ""
+      bench-max-rounds:
         required: false
         type: string
         default: ""
@@ -135,7 +162,21 @@ jobs:
           FOCUS_SDK: ${{ inputs.focus-sdk || 'all' }}
           BASELINE_REF: ${{ inputs.bench-baseline-ref }}
           CANDIDATE_REF: ${{ inputs.bench-candidate-ref }}
+          BUDGET_SECONDS: ${{ inputs.bench-budget-seconds }}
+          MAX_ROUNDS: ${{ inputs.bench-max-rounds }}
         run: |-
+          # Only the numeric inputs are checked here. bench-payloads has a
+          # grammar, and a second copy of it in bash would drift from the one
+          # pytest enforces and start rejecting runs that would have worked;
+          # the bench job validates it with the real parser instead.
+          for pair in "bench-budget-seconds:$BUDGET_SECONDS" "bench-max-rounds:$MAX_ROUNDS"; do
+            name=${pair%%:*}
+            value=${pair#*:}
+            if [[ -n "$value" && ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::${name} must be a positive whole number, got '${value}'."
+              exit 1
+            fi
+          done
           if [[ -n "$BASELINE_REF" && -z "$CANDIDATE_REF" ]] \
              || [[ -z "$BASELINE_REF" && -n "$CANDIDATE_REF" ]]; then
             echo "::error::bench-baseline-ref and bench-candidate-ref must be set together; a comparison needs both arms named."
@@ -839,6 +880,30 @@ jobs:
           path: otdftests
           persist-credentials: false
 
+      # Before the platform, which takes ~15 minutes to come up: a typo'd size
+      # is worth catching in the first thirty seconds. This calls the harness's
+      # own parser rather than reimplementing the grammar in bash -- perf.cells
+      # imports nothing outside the standard library, so a bare python3 can
+      # read it, and a bash copy that drifted would start refusing specs the
+      # run itself would have accepted.
+      - name: Validate benchmark payload sizes
+        if: inputs.bench-payloads != ''
+        working-directory: otdftests/xtest
+        env:
+          BENCH_PAYLOADS: ${{ inputs.bench-payloads }}
+        run: |-
+          python3 - "$BENCH_PAYLOADS" <<'PY'
+          import sys
+
+          from perf.cells import parse_payloads
+
+          try:
+              sizes = parse_payloads(sys.argv[1])
+          except ValueError as e:
+              raise SystemExit(f"::error::invalid bench-payloads: {e}")
+          print("payload sizes:", ", ".join(p.label for p in sizes))
+          PY
+
       - name: load extra keys from file
         id: load-extra-keys
         run: |-
@@ -1061,7 +1126,9 @@ jobs:
             --bench \
             --sdks "$BENCH_SDK" \
             "${arms[@]}" \
-            --bench-budget-seconds 1500 \
+            --bench-payloads "$BENCH_PAYLOADS" \
+            --bench-budget-seconds "$BENCH_BUDGET_SECONDS" \
+            --bench-max-rounds "$BENCH_MAX_ROUNDS" \
             --bench-out test-results/benchmarks \
             --html "test-results/bench-${BENCH_SDK}.html" \
             --self-contained-html \
@@ -1071,6 +1138,12 @@ jobs:
           BENCH_SDK: ${{ matrix.sdk }}
           BENCH_BASELINE_SPEC: ${{ steps.bench-arms.outputs.baseline-spec }}
           BENCH_CANDIDATE_SPEC: ${{ steps.bench-arms.outputs.candidate-spec }}
+          # Fallbacks rather than input defaults: the scheduled nightly
+          # supplies no inputs at all, so `inputs.*` is empty there and these
+          # are what keeps its matrix and budget where they have always been.
+          BENCH_PAYLOADS: ${{ inputs.bench-payloads || '1KiB,1MiB,32MiB' }}
+          BENCH_BUDGET_SECONDS: ${{ inputs.bench-budget-seconds || '1500' }}
+          BENCH_MAX_ROUNDS: ${{ inputs.bench-max-rounds || '60' }}
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           SCHEMA_FILE: "manifest.schema.json"
           PLATFORM_TAG: main

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -38,6 +38,16 @@ on:
         type: boolean
         default: false
         description: "Run the SDK performance regression benchmarks (adds ~45m per SDK). Needs two builds per SDK: set the *-ref inputs to 'main latest', since a bare 'main' installs no release to use as a baseline and every cell will skip."
+      bench-baseline-ref:
+        required: false
+        type: string
+        default: ""
+        description: "Benchmark the ref named here against bench-candidate-ref, instead of the default newest-release-vs-branch-head comparison. Any ref otdf-sdk-mgr resolves: 'main', a branch, a tag, a SHA, 'refs/pull/N/head'. Requires bench-candidate-ref and a focus-sdk naming one SDK; ignores the *-ref inputs, which drive the functional matrix rather than this."
+      bench-candidate-ref:
+        required: false
+        type: string
+        default: ""
+        description: "The build under suspicion, measured against bench-baseline-ref. e.g. 'feat/DSPX-2604-createtdf-chunked'."
   workflow_call:
     inputs:
       platform-ref:
@@ -68,6 +78,14 @@ on:
         required: false
         type: boolean
         default: false
+      bench-baseline-ref:
+        required: false
+        type: string
+        default: ""
+      bench-candidate-ref:
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "30 6 * * *" # 0630 UTC
     - cron: "0 5 * * 1,3" # 500 UTC (Monday, Wednesday)
@@ -88,6 +106,7 @@ jobs:
       platform-tag-list: ${{ steps.version-info.outputs.platform-tag-list }}
       heads: ${{ steps.version-info.outputs.platform-heads }}
       default-tags: ${{ steps.version-info.outputs.default-tags }}
+      bench-sdks: ${{ steps.bench-inputs.outputs.sdks }}
       go: ${{ steps.version-info.outputs.go-version-info }}
       java: ${{ steps.version-info.outputs.java-version-info }}
       js: ${{ steps.version-info.outputs.js-version-info }}
@@ -107,6 +126,31 @@ jobs:
             echo "Invalid focus-sdk input: ${FOCUS_SDK_INPUT}. Must be one of: all, go, java, js." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
+      # Decided here rather than in the bench job because a matrix cannot be
+      # narrowed from inside the job it belongs to: a bad combination would
+      # already have spun up three runners for 45 minutes each.
+      - name: Validate benchmark inputs and pick the bench matrix
+        id: bench-inputs
+        env:
+          FOCUS_SDK: ${{ inputs.focus-sdk || 'all' }}
+          BASELINE_REF: ${{ inputs.bench-baseline-ref }}
+          CANDIDATE_REF: ${{ inputs.bench-candidate-ref }}
+        run: |-
+          if [[ -n "$BASELINE_REF" && -z "$CANDIDATE_REF" ]] \
+             || [[ -z "$BASELINE_REF" && -n "$CANDIDATE_REF" ]]; then
+            echo "::error::bench-baseline-ref and bench-candidate-ref must be set together; a comparison needs both arms named."
+            exit 1
+          fi
+          if [[ -n "$CANDIDATE_REF" && "$FOCUS_SDK" == "all" ]]; then
+            echo "::error::bench-baseline-ref/bench-candidate-ref name refs of one SDK, so focus-sdk must be go, java, or js -- not 'all'."
+            exit 1
+          fi
+          if [[ "$FOCUS_SDK" == "all" ]]; then
+            echo 'sdks=["go","java","js"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "sdks=[\"${FOCUS_SDK}\"]" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Default Versions depend on context
         id: default-tags
         run: |-
@@ -783,10 +827,11 @@ jobs:
       packages: read
     strategy:
       # One runner per SDK. Two SDKs on one runner would contend for the very
-      # CPU being measured.
+      # CPU being measured. Narrowed by focus-sdk, so investigating one SDK
+      # does not spend 45 minutes measuring the two nobody asked about.
       fail-fast: false
       matrix:
-        sdk: [go, java, js]
+        sdk: ${{ fromJSON(needs.resolve-versions.outputs.bench-sdks) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -859,16 +904,57 @@ jobs:
           PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
 
       ######## INSTALL BOTH ARMS OF THE COMPARISON #############
+      # Two named refs instead of the default release-vs-branch pair. Resolved
+      # here rather than in resolve-versions because the *-ref inputs there
+      # drive the functional matrix, and a benchmark wants to name its two
+      # arms without also changing what the rest of the workflow tests.
+      #
+      # Baseline first: the tag order becomes configure-sdk's `heads` output,
+      # and conftest.py takes heads[0] as the otdfctl that provisions
+      # attributes and the KAS registry. That provisioning is not measured,
+      # and it should be the same build for both arms.
+      - name: Resolve the two benchmark arms
+        id: bench-arms
+        if: inputs.bench-candidate-ref != ''
+        working-directory: otdftests/otdf-sdk-mgr
+        env:
+          SDK: ${{ matrix.sdk }}
+          BASELINE_REF: ${{ inputs.bench-baseline-ref }}
+          CANDIDATE_REF: ${{ inputs.bench-candidate-ref }}
+        run: |-
+          info=$(uv run --project . otdf-sdk-mgr versions resolve \
+                   "$SDK" "$BASELINE_REF" "$CANDIDATE_REF")
+          jq . <<<"$info"
+          err=$(jq -r '[.[] | select(.err != null) | .err] | join("; ")' <<<"$info")
+          if [[ -n "$err" ]]; then
+            echo "::error::Could not resolve benchmark arms: $err"
+            exit 1
+          fi
+          # `versions resolve` drops a ref whose SHA it has already seen, so
+          # two names for one commit come back as a single entry. Left alone
+          # that installs one build, fails arm selection in every cell, and
+          # spends the runner's 45 minutes arriving at NOTHING MEASURED.
+          if [[ "$(jq 'length' <<<"$info")" -ne 2 ]]; then
+            echo "::error::${BASELINE_REF} and ${CANDIDATE_REF} resolve to the same commit -- nothing to compare."
+            exit 1
+          fi
+          {
+            echo "version-info=$(jq -c . <<<"$info")"
+            echo "baseline-spec=${SDK}@$(jq -r '.[0].tag' <<<"$info")"
+            echo "candidate-spec=${SDK}@$(jq -r '.[1].tag' <<<"$info")"
+          } >> "$GITHUB_OUTPUT"
+
       # The whole design rests on this step laying down two builds side by
-      # side under sdk/<sdk>/dist/: the branch head (candidate) and the
-      # newest release (baseline). Arm selection picks them up from there.
+      # side under sdk/<sdk>/dist/: by default the branch head (candidate) and
+      # the newest release (baseline), or the two refs resolved above. Arm
+      # selection picks them up from there.
       - name: Configure ${{ matrix.sdk }} sdk
         id: configure-sdk
         uses: ./otdftests/xtest/setup-cli-tool
         with:
           path: otdftests/xtest/sdk
           sdk: ${{ matrix.sdk }}
-          version-info: "${{ needs.resolve-versions.outputs[matrix.sdk] }}"
+          version-info: "${{ steps.bench-arms.outputs.version-info || needs.resolve-versions.outputs[matrix.sdk] }}"
           platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
           platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
 
@@ -929,7 +1015,7 @@ jobs:
             fi
           done
         env:
-          java_version_info: ${{ needs.resolve-versions.outputs.java }}
+          java_version_info: ${{ steps.bench-arms.outputs.version-info || needs.resolve-versions.outputs.java }}
           platform_ref: ${{ fromJSON(needs.resolve-versions.outputs.platform-tag-to-sha)['main'] }}
 
       - name: Build the ${{ matrix.sdk }} cli
@@ -962,9 +1048,19 @@ jobs:
       - name: Run performance benchmarks
         id: bench
         run: |-
+          # Empty unless the two arms were named explicitly, in which case
+          # arm selection must not fall back to "newest release vs branch
+          # head": neither named ref need be a release, and with two branch
+          # builds installed the default would pick the wrong pair or none.
+          arms=()
+          if [[ -n "$BENCH_BASELINE_SPEC" ]]; then
+            arms=(--bench-baseline "$BENCH_BASELINE_SPEC"
+                  --bench-candidate "$BENCH_CANDIDATE_SPEC")
+          fi
           uv run --frozen --no-build pytest -ra -v \
             --bench \
             --sdks "$BENCH_SDK" \
+            "${arms[@]}" \
             --bench-budget-seconds 1500 \
             --bench-out test-results/benchmarks \
             --html "test-results/bench-${BENCH_SDK}.html" \
@@ -973,6 +1069,8 @@ jobs:
         working-directory: otdftests/xtest
         env:
           BENCH_SDK: ${{ matrix.sdk }}
+          BENCH_BASELINE_SPEC: ${{ steps.bench-arms.outputs.baseline-spec }}
+          BENCH_CANDIDATE_SPEC: ${{ steps.bench-arms.outputs.candidate-spec }}
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           SCHEMA_FILE: "manifest.schema.json"
           PLATFORM_TAG: main

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -38,16 +38,21 @@ on:
         type: boolean
         default: false
         description: "Run the SDK performance regression benchmarks (adds ~45m per SDK). Needs two builds per SDK: set the *-ref inputs to 'main latest', since a bare 'main' installs no release to use as a baseline and every cell will skip."
+      bench-refs:
+        required: false
+        type: string
+        default: ""
+        description: "Benchmark these refs against each other instead of the default newest-release-vs-branch-head pair. Comma-separated, 2 to 4 entries, first is the reference every other arm is gated against: 'main,fix/streaming-writer,DSPX-4499-streaming-codec'. Any ref otdf-sdk-mgr resolves works: a branch, a tag, a SHA, 'refs/pull/N/head'. The 4-arm ceiling is setup-cli-tool's -- it installs at most four builds side by side. All arms are measured in the same rounds on this one runner, so every pair is comparable, including two candidates against each other. For a bake-off between two implementations of the same feature, make the reference their shared parent rather than 'main' if they are stacked: 'main' then measures each candidate's whole stack, though the head-to-head that decides the bake-off is unaffected either way. Requires a focus-sdk naming one SDK; ignores the *-ref inputs, which drive the functional matrix rather than this."
       bench-baseline-ref:
         required: false
         type: string
         default: ""
-        description: "Benchmark the ref named here against bench-candidate-ref, instead of the default newest-release-vs-branch-head comparison. Any ref otdf-sdk-mgr resolves: 'main', a branch, a tag, a SHA, 'refs/pull/N/head'. Requires bench-candidate-ref and a focus-sdk naming one SDK; ignores the *-ref inputs, which drive the functional matrix rather than this."
+        description: "Deprecated two-arm spelling of bench-refs; 'X' here and 'Y' in bench-candidate-ref means bench-refs='X,Y'. Setting both forms is an error."
       bench-candidate-ref:
         required: false
         type: string
         default: ""
-        description: "The build under suspicion, measured against bench-baseline-ref. e.g. 'feat/DSPX-2604-createtdf-chunked'."
+        description: "Deprecated: the second arm of the bench-baseline-ref pair. e.g. 'feat/DSPX-2604-createtdf-chunked'."
       bench-payloads:
         required: false
         type: string
@@ -57,7 +62,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "Wall-clock allowance shared by every benchmark cell (default 1500). Manual runs are not on the nightly's schedule, so this is the knob to raise when adding payload sizes -- each one adds an encrypt and a decrypt cell, and the budget is divided evenly as cells start."
+        description: "Wall-clock allowance shared by every benchmark cell (default 1500 for two arms, scaled by K/2 for K arms). Manual runs are not on the nightly's schedule, so this is the knob to raise when adding payload sizes -- each one adds an encrypt and a decrypt cell, and the budget is divided evenly as cells start. A K-arm round costs K invocations rather than 2, so at a fixed budget every interval widens by ~sqrt(K/2); the scaled default buys that back."
       bench-max-rounds:
         required: false
         type: string
@@ -93,6 +98,10 @@ on:
         required: false
         type: boolean
         default: false
+      bench-refs:
+        required: false
+        type: string
+        default: ""
       bench-baseline-ref:
         required: false
         type: string
@@ -134,6 +143,10 @@ jobs:
       heads: ${{ steps.version-info.outputs.platform-heads }}
       default-tags: ${{ steps.version-info.outputs.default-tags }}
       bench-sdks: ${{ steps.bench-inputs.outputs.sdks }}
+      # Normalized here so the bench job never sees the deprecated pair, and
+      # so the arm count that scales the budget is counted once.
+      bench-refs: ${{ steps.bench-inputs.outputs.refs }}
+      bench-budget-seconds: ${{ steps.bench-inputs.outputs.budget-seconds }}
       go: ${{ steps.version-info.outputs.go-version-info }}
       java: ${{ steps.version-info.outputs.java-version-info }}
       js: ${{ steps.version-info.outputs.js-version-info }}
@@ -160,6 +173,7 @@ jobs:
         id: bench-inputs
         env:
           FOCUS_SDK: ${{ inputs.focus-sdk || 'all' }}
+          BENCH_REFS: ${{ inputs.bench-refs }}
           BASELINE_REF: ${{ inputs.bench-baseline-ref }}
           CANDIDATE_REF: ${{ inputs.bench-candidate-ref }}
           BUDGET_SECONDS: ${{ inputs.bench-budget-seconds }}
@@ -177,15 +191,51 @@ jobs:
               exit 1
             fi
           done
-          if [[ -n "$BASELINE_REF" && -z "$CANDIDATE_REF" ]] \
-             || [[ -z "$BASELINE_REF" && -n "$CANDIDATE_REF" ]]; then
-            echo "::error::bench-baseline-ref and bench-candidate-ref must be set together; a comparison needs both arms named."
-            exit 1
+          # Fold the deprecated pair into bench-refs, so everything downstream
+          # of this step deals with one list and one arm count.
+          refs=$BENCH_REFS
+          if [[ -n "$BASELINE_REF" || -n "$CANDIDATE_REF" ]]; then
+            if [[ -n "$refs" ]]; then
+              echo "::error::bench-refs replaces bench-baseline-ref/bench-candidate-ref -- give one form or the other, not both."
+              exit 1
+            fi
+            if [[ -z "$BASELINE_REF" || -z "$CANDIDATE_REF" ]]; then
+              echo "::error::bench-baseline-ref and bench-candidate-ref must be set together; a comparison needs both arms named."
+              exit 1
+            fi
+            refs="${BASELINE_REF},${CANDIDATE_REF}"
           fi
-          if [[ -n "$CANDIDATE_REF" && "$FOCUS_SDK" == "all" ]]; then
-            echo "::error::bench-baseline-ref/bench-candidate-ref name refs of one SDK, so focus-sdk must be go, java, or js -- not 'all'."
-            exit 1
+          # Two arms unless told otherwise: with no refs at all the bench job
+          # falls back to newest-release-vs-branch-head, which is a pair.
+          n_arms=2
+          if [[ -n "$refs" ]]; then
+            read -r -a arms <<<"${refs//,/ }"
+            n_arms=${#arms[@]}
+            # 4 is setup-cli-tool's ceiling (slots a/b/c/d); a 5th arm would
+            # be silently dropped there and then missing from every round.
+            if ((n_arms < 2 || n_arms > 4)); then
+              echo "::error::bench-refs needs 2 to 4 refs, got ${n_arms}: '${refs}'. The 4-arm cap is setup-cli-tool's, which installs at most four builds side by side."
+              exit 1
+            fi
+            if [[ "$(printf '%s\n' "${arms[@]}" | sort -u | wc -l)" -ne "$n_arms" ]]; then
+              echo "::error::bench-refs names the same ref twice: '${refs}'. Every arm has to be a distinct build."
+              exit 1
+            fi
+            if [[ "$FOCUS_SDK" == "all" ]]; then
+              echo "::error::bench-refs names refs of one SDK, so focus-sdk must be go, java, or js -- not 'all'."
+              exit 1
+            fi
+            printf -v refs '%s,' "${arms[@]}"
+            refs=${refs%,}
           fi
+          # A K-arm round costs K invocations, so a fixed budget buys K/2 as
+          # many rounds and every interval widens by ~sqrt(K/2). Scaling the
+          # default keeps a 3-arm run as precise as the 2-arm one it replaces.
+          budget=${BUDGET_SECONDS:-$((1500 * n_arms / 2))}
+          {
+            echo "refs=${refs}"
+            echo "budget-seconds=${budget}"
+          } >> "$GITHUB_OUTPUT"
           if [[ "$FOCUS_SDK" == "all" ]]; then
             echo 'sdks=["go","java","js"]' >> "$GITHUB_OUTPUT"
           else
@@ -842,14 +892,19 @@ jobs:
             ${{ steps.kas-km2.outputs.log-file }}
           if-no-files-found: ignore
 
-  # Paired A/B performance regression benchmark.
+  # Paired performance regression benchmark: two arms by default, up to four
+  # with bench-refs.
   #
   # Absolute timings from a GitHub-hosted runner are not comparable to
   # timings from any other runner -- CPU model, tenancy, and steal time all
   # vary more than any regression worth catching. So nothing is compared to
-  # history. Instead both builds under comparison run on *this* runner, in
-  # the same interleaved round, and only their ratio is reported. Runner
+  # history. Instead every build under comparison runs on *this* runner, in
+  # the same interleaved round, and only their ratios are reported. Runner
   # speed divides out.
+  #
+  # That is also why a bake-off has to be one job rather than two dispatches:
+  # two runs put the candidates on different runners, so their ratios share
+  # no denominator and the comparison is invalid by the premise above.
   #
   # Never runs on pull requests: 30 minutes of serial measurement is too slow
   # for a PR gate, and a PR runner is the noisiest place to measure.
@@ -860,8 +915,10 @@ jobs:
     # own default 1500s budget after a cold start -- it would be killed
     # mid-measurement, which loses the report entirely rather than reporting
     # fewer rounds. The budget is the knob that bounds the run; this is only
-    # the backstop for a hung one.
-    timeout-minutes: 90
+    # the backstop for a hung one. 240 rather than 90 because a K-arm run
+    # scales its budget by K/2 and adds a build per arm: three arms at 1 GiB
+    # want 8100s = 135 minutes of measurement before any setup at all.
+    timeout-minutes: 240
     runs-on: ubuntu-latest
     needs: resolve-versions
     # Nightly cron only, not the Mon/Wed or weekly ones: three runs a week of
@@ -975,27 +1032,27 @@ jobs:
         env:
           PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
 
-      ######## INSTALL BOTH ARMS OF THE COMPARISON #############
-      # Two named refs instead of the default release-vs-branch pair. Resolved
+      ######## INSTALL EVERY ARM OF THE COMPARISON #############
+      # Named refs instead of the default release-vs-branch pair. Resolved
       # here rather than in resolve-versions because the *-ref inputs there
-      # drive the functional matrix, and a benchmark wants to name its two
+      # drive the functional matrix, and a benchmark wants to name its own
       # arms without also changing what the rest of the workflow tests.
       #
-      # Baseline first: the tag order becomes configure-sdk's `heads` output,
-      # and conftest.py takes heads[0] as the otdfctl that provisions
-      # attributes and the KAS registry. That provisioning is not measured,
-      # and it should be the same build for both arms.
-      - name: Resolve the two benchmark arms
+      # Reference first, and input order preserved throughout: the tag order
+      # becomes configure-sdk's `heads` output, and conftest.py takes heads[0]
+      # as the otdfctl that provisions attributes and the KAS registry. That
+      # provisioning is not measured, and it should be the same build for
+      # every arm.
+      - name: Resolve the benchmark arms
         id: bench-arms
-        if: inputs.bench-candidate-ref != ''
+        if: needs.resolve-versions.outputs.bench-refs != ''
         working-directory: otdftests/otdf-sdk-mgr
         env:
           SDK: ${{ matrix.sdk }}
-          BASELINE_REF: ${{ inputs.bench-baseline-ref }}
-          CANDIDATE_REF: ${{ inputs.bench-candidate-ref }}
+          BENCH_REFS: ${{ needs.resolve-versions.outputs.bench-refs }}
         run: |-
-          info=$(uv run --project . otdf-sdk-mgr versions resolve \
-                   "$SDK" "$BASELINE_REF" "$CANDIDATE_REF")
+          read -r -a refs <<<"${BENCH_REFS//,/ }"
+          info=$(uv run --project . otdf-sdk-mgr versions resolve "$SDK" "${refs[@]}")
           jq . <<<"$info"
           err=$(jq -r '[.[] | select(.err != null) | .err] | join("; ")' <<<"$info")
           if [[ -n "$err" ]]; then
@@ -1003,23 +1060,22 @@ jobs:
             exit 1
           fi
           # `versions resolve` drops a ref whose SHA it has already seen, so
-          # two names for one commit come back as a single entry. Left alone
-          # that installs one build, fails arm selection in every cell, and
-          # spends the runner's 45 minutes arriving at NOTHING MEASURED.
-          if [[ "$(jq 'length' <<<"$info")" -ne 2 ]]; then
-            echo "::error::${BASELINE_REF} and ${CANDIDATE_REF} resolve to the same commit -- nothing to compare."
+          # two names for one commit come back as one entry. Left alone that
+          # installs fewer builds than there are arms, fails arm selection in
+          # every cell, and spends the runner arriving at NOTHING MEASURED.
+          if [[ "$(jq 'length' <<<"$info")" -ne "${#refs[@]}" ]]; then
+            echo "::error::${BENCH_REFS} does not name ${#refs[@]} distinct commits -- two of these refs are the same build, so there is nothing to compare between them."
             exit 1
           fi
           {
             echo "version-info=$(jq -c . <<<"$info")"
-            echo "baseline-spec=${SDK}@$(jq -r '.[0].tag' <<<"$info")"
-            echo "candidate-spec=${SDK}@$(jq -r '.[1].tag' <<<"$info")"
+            echo "refs-spec=$(jq -r --arg sdk "$SDK" '[.[] | "\($sdk)@\(.tag)"] | join(",")' <<<"$info")"
           } >> "$GITHUB_OUTPUT"
 
-      # The whole design rests on this step laying down two builds side by
-      # side under sdk/<sdk>/dist/: by default the branch head (candidate) and
-      # the newest release (baseline), or the two refs resolved above. Arm
-      # selection picks them up from there.
+      # The whole design rests on this step laying down every arm side by side
+      # under sdk/<sdk>/dist/: by default the branch head (candidate) and the
+      # newest release (baseline), or the refs resolved above. Arm selection
+      # picks them up from there.
       - name: Configure ${{ matrix.sdk }} sdk
         id: configure-sdk
         uses: ./otdftests/xtest/setup-cli-tool
@@ -1120,14 +1176,13 @@ jobs:
       - name: Run performance benchmarks
         id: bench
         run: |-
-          # Empty unless the two arms were named explicitly, in which case
-          # arm selection must not fall back to "newest release vs branch
-          # head": neither named ref need be a release, and with two branch
-          # builds installed the default would pick the wrong pair or none.
+          # Empty unless the arms were named explicitly, in which case arm
+          # selection must not fall back to "newest release vs branch head":
+          # no named ref need be a release, and with several branch builds
+          # installed the default would pick the wrong pair or none.
           arms=()
-          if [[ -n "$BENCH_BASELINE_SPEC" ]]; then
-            arms=(--bench-baseline "$BENCH_BASELINE_SPEC"
-                  --bench-candidate "$BENCH_CANDIDATE_SPEC")
+          if [[ -n "$BENCH_REFS_SPEC" ]]; then
+            arms=(--bench-refs "$BENCH_REFS_SPEC")
           fi
           uv run --frozen --no-build pytest -ra -v \
             --bench \
@@ -1143,13 +1198,13 @@ jobs:
         working-directory: otdftests/xtest
         env:
           BENCH_SDK: ${{ matrix.sdk }}
-          BENCH_BASELINE_SPEC: ${{ steps.bench-arms.outputs.baseline-spec }}
-          BENCH_CANDIDATE_SPEC: ${{ steps.bench-arms.outputs.candidate-spec }}
+          BENCH_REFS_SPEC: ${{ steps.bench-arms.outputs.refs-spec }}
           # Fallbacks rather than input defaults: the scheduled nightly
           # supplies no inputs at all, so `inputs.*` is empty there and these
           # are what keeps its matrix and budget where they have always been.
           BENCH_PAYLOADS: ${{ inputs.bench-payloads || '1KiB,1MiB,32MiB' }}
-          BENCH_BUDGET_SECONDS: ${{ inputs.bench-budget-seconds || '1500' }}
+          # Already defaulted (and scaled by arm count) in resolve-versions.
+          BENCH_BUDGET_SECONDS: ${{ needs.resolve-versions.outputs.bench-budget-seconds }}
           BENCH_MAX_ROUNDS: ${{ inputs.bench-max-rounds || '60' }}
           PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
           SCHEMA_FILE: "manifest.schema.json"

--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -1297,6 +1297,16 @@ jobs:
           path: otdftests
           persist-credentials: false
 
+      # aggregate.py follows xtest's Python target. The hosted runner's system
+      # Python can lag it (Ubuntu 24.04 currently supplies 3.12), so run through
+      # the same pinned uv/Python toolchain as the benchmark rather than hoping
+      # stdlib-only also means syntax-compatible.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.14"
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
       - name: Download SDK benchmark results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
@@ -1330,7 +1340,9 @@ jobs:
           BENCH_EXPECTED_SDKS: ${{ needs.resolve-versions.outputs.bench-sdks }}
           BENCH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |-
-          python3 otdftests/xtest/perf/aggregate.py benchmark-results >> "$GITHUB_STEP_SUMMARY"
+          uv run --project otdftests/xtest --frozen --no-sync \
+            python otdftests/xtest/perf/aggregate.py benchmark-results \
+            >> "$GITHUB_STEP_SUMMARY"
 
   publish-results:
     runs-on: ubuntu-latest

--- a/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
+++ b/otdf-sdk-mgr/src/otdf_sdk_mgr/resolve.py
@@ -300,7 +300,14 @@ def _resolve_against(
                 "alias": version,
                 "head": True,
                 "sha": sha,
-                "tag": version,
+                # Flattened the same way _classify_sha_match flattens a branch
+                # it reached by SHA: the tag becomes a single dist/<tag>/ and
+                # src/<tag>/ path component. A slash here nests those
+                # directories, and every consumer walks them one level deep --
+                # xtest's all_versions_of() lists dist/*/ and the go Makefile
+                # finds src/*/, so "feat/x" is discovered as a "feat" build
+                # with no cli.sh in it.
+                "tag": version.replace("/", "--"),
             }
 
         if infix and version.startswith(f"{infix}/"):

--- a/otdf-sdk-mgr/tests/test_resolve.py
+++ b/otdf-sdk-mgr/tests/test_resolve.py
@@ -76,7 +76,24 @@ class TestResolveMain:
             result = resolve("js", "refs/heads/release/sdk-v0.17", None)
         assert is_resolve_success(result)
         assert "head" in result and result["head"] is True
-        assert result["tag"] == "release/sdk-v0.17"
+        assert result["tag"] == "release--sdk-v0.17"
+        assert result["sha"] == SHA40
+
+    def test_branch_by_name_flattens_slashes(self):
+        # Same flattening the SHA path applies, and for the same reason: the
+        # tag is one path component under dist/ and src/. Reached by name
+        # rather than by SHA, which is the shape a workflow_dispatch input
+        # arrives in.
+        ls = make_ls_remote(
+            (SHA40, "refs/heads/feat/DSPX-2604-createtdf-chunked"),
+            ("d" * 40, "refs/heads/main"),
+        )
+        with patch_git(ls):
+            result = resolve("go", "feat/DSPX-2604-createtdf-chunked", None)
+        assert is_resolve_success(result)
+        assert result.get("head") is True
+        assert result["tag"] == "feat--DSPX-2604-createtdf-chunked"
+        assert result["alias"] == "feat/DSPX-2604-createtdf-chunked"
         assert result["sha"] == SHA40
 
 

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -455,7 +455,11 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     reporter = config.pluginmanager.get_plugin("terminalreporter")
     if reporter is not None:
         reporter.write_sep("=", "benchmark results")
-        reporter.write_line(gate.summary)
+        reporter.write_line(
+            str(recorder.metadata.get("comparison_note", gate.summary))
+            if report.same_commit(recorder.metadata)
+            else gate.summary
+        )
         # Repeated on the terminal as well as in the step summary: "the run
         # was too short for the number of arms you asked for" is the one
         # finding a reader is most likely to mistake for a real result.
@@ -474,8 +478,12 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     # regression. --bench is an explicit request for a measurement; answering
     # it with a green tick and an empty table is the one outcome nobody
     # inspects, so a benchmark that has quietly stopped measuring can survive
-    # indefinitely. Every reason a cell skips is already in the report.
-    if gate.should_fail or gate.nothing_measured:
+    # indefinitely. The exception is two requested names resolving to one SHA:
+    # that is a complete, neutral answer (there is no code difference to test),
+    # not a harness that failed to measure an existing difference.
+    if gate.should_fail or (
+        gate.nothing_measured and not report.same_commit(recorder.metadata)
+    ):
         session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -443,8 +443,15 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         out_dir / f"{name}.json", recorder, bench_config, gate
     )
 
-    summary = report.markdown(recorder, bench_config, gate)
-    report.append_step_summary(summary)
+    artifact_url = (
+        report.ARTIFACT_URL_PLACEHOLDER
+        if os.environ.get("BENCH_DEFER_SUMMARY", "").lower() in {"1", "true", "yes"}
+        else ""
+    )
+    summary = report.markdown(recorder, bench_config, gate, artifact_url=artifact_url)
+    report.write_markdown(out_dir / f"{name}.summary.md", summary)
+    if not artifact_url:
+        report.append_step_summary(summary)
     reporter = config.pluginmanager.get_plugin("terminalreporter")
     if reporter is not None:
         reporter.write_sep("=", "benchmark results")

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -23,9 +23,10 @@ from typing import cast
 import pytest
 
 import tdfs
+from fixtures.bench import payloads_from_options
 from otdfctl import OpentdfCommandLineTool
 from perf import report, stats
-from perf.cells import cells_for
+from perf.cells import DEFAULT_PAYLOAD_SPEC, cells_for
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"))
 
@@ -180,6 +181,16 @@ def _add_benchmark_options(parser: pytest.Parser):
         "--bench-candidate",
         help="build under test, e.g. go@main; defaults to the installed "
         "unreleased build of each sdk",
+    )
+    group.addoption(
+        "--bench-payloads",
+        default=DEFAULT_PAYLOAD_SPEC,
+        help="comma-separated payload sizes to measure, e.g. "
+        "'1KiB,1MiB,32MiB,1GiB' (default: %(default)s). Sizes above the "
+        "default are opt-in because they are what a throughput gate actually "
+        "needs and what a nightly cannot afford: each one adds two cells, and "
+        "a run holds roughly twice the total plus the largest twice over on "
+        "disk",
     )
     group.addoption(
         "--bench-threshold",
@@ -342,7 +353,7 @@ def _parametrize_bench_cells(metafunc: pytest.Metafunc):
         typing.get_args(tdfs.sdk_type)
     )
     names = list(dict.fromkeys(s.split("@", 1)[0] for s in str(specs).split()))
-    cells = cells_for(names)
+    cells = cells_for(names, payloads_from_options(metafunc.config))
     metafunc.config.stash[report.CELLS_KEY] = cells
     metafunc.parametrize("bench_cell", cells, ids=[c.id for c in cells])
 

--- a/xtest/conftest.py
+++ b/xtest/conftest.py
@@ -23,7 +23,7 @@ from typing import cast
 import pytest
 
 import tdfs
-from fixtures.bench import payloads_from_options
+from fixtures.bench import MAX_ARMS, payloads_from_options
 from otdfctl import OpentdfCommandLineTool
 from perf import report, stats
 from perf.cells import DEFAULT_PAYLOAD_SPEC, cells_for
@@ -173,14 +173,23 @@ def _add_benchmark_options(parser: pytest.Parser):
         "are opt-in and collect nothing otherwise)",
     )
     group.addoption(
+        "--bench-refs",
+        help=f"builds to compare, comma- or space-separated, e.g. "
+        f"'go@main,go@my-branch'. The first is the reference: every gated "
+        f"contrast is taken against it, and the rest are ranked head-to-head "
+        f"as a bake-off. 2 to {MAX_ARMS} entries (the ceiling is how "
+        f"many builds setup-cli-tool can install side by side). Defaults to "
+        f"the newest installed release against the branch build",
+    )
+    group.addoption(
         "--bench-baseline",
-        help="build to compare against, e.g. go@v0.29.0; defaults to the newest "
-        "installed release of each sdk",
+        help="two-arm shorthand for the reference half of --bench-refs, e.g. "
+        "go@v0.29.0; must be given with --bench-candidate",
     )
     group.addoption(
         "--bench-candidate",
-        help="build under test, e.g. go@main; defaults to the installed "
-        "unreleased build of each sdk",
+        help="two-arm shorthand for the candidate half of --bench-refs, e.g. "
+        "go@main; must be given with --bench-baseline",
     )
     group.addoption(
         "--bench-payloads",
@@ -189,8 +198,8 @@ def _add_benchmark_options(parser: pytest.Parser):
         "'1KiB,1MiB,32MiB,1GiB' (default: %(default)s). Sizes above the "
         "default are opt-in because they are what a throughput gate actually "
         "needs and what a nightly cannot afford: each one adds two cells, and "
-        "a run holds roughly twice the total plus the largest twice over on "
-        "disk",
+        "a run holds roughly twice the total plus one live output per arm of "
+        "the largest on disk",
     )
     group.addoption(
         "--bench-threshold",
@@ -222,8 +231,11 @@ def _add_benchmark_options(parser: pytest.Parser):
     group.addoption(
         "--bench-budget-seconds",
         type=float,
-        default=1500.0,
-        help="wall-clock allowance shared by every cell (default: %(default)s)",
+        default=None,
+        help="wall-clock allowance shared by every cell. Defaults to "
+        "1500s scaled by (arms / 2), because a K-arm round costs K "
+        "invocations and holding the same precision costs proportionally "
+        "more time",
     )
     group.addoption(
         "--bench-seed",
@@ -348,7 +360,7 @@ def _parametrize_bench_cells(metafunc: pytest.Metafunc):
         return
 
     # --sdks may be version-qualified (go@main); benchmark arms come from
-    # --bench-baseline/--bench-candidate instead, so only the name matters.
+    # --bench-refs instead, so only the name matters here.
     specs = metafunc.config.getoption("--sdks") or " ".join(
         typing.get_args(tdfs.sdk_type)
     )
@@ -372,6 +384,11 @@ def pytest_configure(config: pytest.Config):
             "--bench cannot run under pytest-xdist: parallel workers compete "
             "for the CPU being measured. Drop -n / --dist."
         )
+    # Resolve the arm specs now so a malformed --bench-refs is a usage error
+    # before anything is installed or measured, not an hour into the run.
+    from fixtures import bench
+
+    bench.arm_specs_from_options(config)
 
 
 def pytest_collection_modifyitems(
@@ -432,6 +449,16 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     if reporter is not None:
         reporter.write_sep("=", "benchmark results")
         reporter.write_line(gate.summary)
+        # Repeated on the terminal as well as in the step summary: "the run
+        # was too short for the number of arms you asked for" is the one
+        # finding a reader is most likely to mistake for a real result.
+        underpowered = report.underpowered_warning(recorder, bench_config, gate)
+        if underpowered:
+            reporter.write_line(underpowered)
+        for bake_off in report.bake_offs(recorder, bench_config, gate):
+            reporter.write_line(
+                f"{bake_off.cell_id} [{bake_off.metric}]: {bake_off.detail}"
+            )
         reporter.write_line(f"raw samples and statistics: {json_path}")
 
     if config.getoption("--bench-no-gate", default=False):

--- a/xtest/fixtures/bench.py
+++ b/xtest/fixtures/bench.py
@@ -9,6 +9,7 @@ pytest's world (options, fixtures, SDK discovery) into the runner's world
 
 from __future__ import annotations
 
+import json
 import os
 import platform
 import random
@@ -599,7 +600,8 @@ def runner_metadata(config: pytest.Config) -> dict[str, object]:
     here feeds the decision rule. It is recorded so that a human reading an
     old artifact can tell what they are looking at.
     """
-    return {
+    metadata: dict[str, object] = {
+        "sdk": os.environ.get("BENCH_SDK", ""),
         "python": platform.python_version(),
         "platform": platform.platform(),
         "processor": platform.processor() or "unknown",
@@ -607,9 +609,69 @@ def runner_metadata(config: pytest.Config) -> dict[str, object]:
         "runner_os": os.environ.get("RUNNER_OS", ""),
         "runner_arch": os.environ.get("RUNNER_ARCH", ""),
         "github_run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "github_run_url": _github_run_url(),
         "platform_version": _platform_version(),
         "seed": config.getoption("--bench-seed"),
     }
+    sources, warning = _arm_sources()
+    metadata["arm_sources"] = sources
+    if warning:
+        metadata["arm_sources_warning"] = warning
+    return metadata
+
+
+def _github_run_url() -> str:
+    server = os.environ.get("GITHUB_SERVER_URL", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if not (server and repository and run_id):
+        return ""
+    return f"{server}/{repository}/actions/runs/{run_id}"
+
+
+def _arm_sources() -> tuple[list[dict[str, object]], str]:
+    """Resolver metadata for the builds, enriched with their GitHub repository.
+
+    CI already paid to resolve every ref to an immutable SHA before installing
+    it. Carry that result into the benchmark rather than trying to infer a PR,
+    release, or branch from the flattened dist-directory name afterward.
+    """
+    raw = os.environ.get("BENCH_VERSION_INFO", "").strip()
+    if not raw:
+        return [], ""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return [], f"BENCH_VERSION_INFO was not valid JSON: {e}"
+    if not isinstance(parsed, list) or not all(isinstance(v, dict) for v in parsed):
+        return [], "BENCH_VERSION_INFO must be a JSON array of objects"
+
+    sources: list[dict[str, object]] = []
+    for value in parsed:
+        source = {str(k): v for k, v in value.items()}
+        source["repo_url"] = _repo_url_for(source)
+        sources.append(source)
+    return sources, ""
+
+
+def _repo_url_for(source: dict[str, object]) -> str:
+    sdk = str(source.get("sdk", ""))
+    if sdk == "java":
+        return "https://github.com/opentdf/java-sdk"
+    if sdk == "js":
+        return "https://github.com/opentdf/web-sdk"
+    if sdk != "go":
+        return ""
+
+    # otdfctl moved into the platform monorepo at v0.31.0. Resolver results
+    # from there use the namespaced release tag; old standalone releases do
+    # not. Branch/PR/SHA builds resolve against platform first.
+    release = str(source.get("release", ""))
+    if release and not release.startswith("otdfctl/"):
+        match = re.search(r"v?(\d+)\.(\d+)\.(\d+)", release)
+        if match and tuple(map(int, match.groups())) < (0, 31, 0):
+            return "https://github.com/opentdf/otdfctl"
+    return "https://github.com/opentdf/platform"
 
 
 def _platform_version() -> str:

--- a/xtest/fixtures/bench.py
+++ b/xtest/fixtures/bench.py
@@ -4,7 +4,7 @@ The experiment matrix, the payload files, the arm selection, and the shared
 time budget all live here. The measurement loop itself is in ``perf/runner.py``
 and the statistics in ``perf/stats.py``; this module is the glue that turns
 pytest's world (options, fixtures, SDK discovery) into the runner's world
-(two arms and a config).
+(K arms and a config).
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import platform
 import random
+import re
 import shutil
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -26,28 +27,59 @@ from perf import report
 from perf.cells import BenchCell, Payload, parse_payloads, payloads_to_generate
 from perf.runner import Arm, BenchConfig, Budget, Invocation
 
+#: Most builds one run can compare. The ceiling comes from
+#: ``xtest/setup-cli-tool/action.yaml``, which installs into four fixed slots
+#: (a/b/c/d) and refuses a fifth. Raising it here without raising it there
+#: gives a run that resolves five refs and then measures four of them.
+MAX_ARMS = 4
+
 
 class ArmSelectionError(Exception):
-    """The two builds a comparison needs are not both installed."""
+    """The builds a comparison needs are not all installed."""
+
+
+def parse_refs(spec: str) -> tuple[str, ...]:
+    """Split a ``--bench-refs`` value into build specs, first = reference.
+
+    Commas or whitespace, so both the shell-friendly
+    ``go@main,go@my-branch`` and a quoted space-separated list work.
+
+    Raises:
+        ValueError: if the result is not between 2 and :data:`MAX_ARMS`
+            entries, or if a build is named twice.
+    """
+    refs = tuple(p for p in re.split(r"[,\s]+", spec.strip()) if p)
+    if not 2 <= len(refs) <= MAX_ARMS:
+        raise ValueError(
+            f"need 2 to {MAX_ARMS} refs, got {len(refs)}: {spec!r}. The first "
+            "is the reference every gated contrast is taken against."
+        )
+    if len(set(refs)) != len(refs):
+        # Two arms running the same build is what the A/A control cell is for,
+        # and it is added automatically. Asking for it here would spend a slot
+        # measuring a comparison the run already makes.
+        raise ValueError(f"duplicate refs in {spec!r}; each arm needs a distinct build")
+    return refs
 
 
 def select_arms(
     sdk: str,
-    *,
-    baseline_spec: str | None = None,
-    candidate_spec: str | None = None,
-) -> tuple[tdfs.SDK, tdfs.SDK]:
-    """Pick (baseline, candidate) builds for one SDK.
+    specs: Sequence[str] | None = None,
+) -> tuple[tdfs.SDK, ...]:
+    """Pick the builds to compare for one SDK, reference first.
 
-    By default the candidate is the branch build (``main``) and the baseline
-    is the newest installed release, which is exactly what the CI setup action
-    lays down side by side. Explicit specs override either side, for
-    reproducing a comparison or for pinning a specific release.
+    With no specs the run is the nightly two-arm comparison: the reference is
+    the newest installed final release and the candidate is the branch build
+    (``main``), which is exactly what the CI setup action lays down side by
+    side. Explicit specs name the arms instead, for reproducing a comparison,
+    pinning a specific release, or running a bake-off between several
+    candidates.
 
     Raises:
-        ArmSelectionError: if either side is missing or the two resolve to the
-            same build (a comparison of a build against itself is only
-            meaningful as the explicit A/A control).
+        ArmSelectionError: if any named build is missing, if the default pair
+            cannot be found, or if two arms resolve to the same build (a
+            comparison of a build against itself is only meaningful as the
+            explicit A/A control).
     """
     installed = tdfs.all_versions_of(sdk)  # pyright: ignore[reportArgumentType]
     if not installed:
@@ -65,8 +97,11 @@ def select_arms(
             )
         return matches[0]
 
-    if candidate_spec:
-        candidate = resolve(candidate_spec, "candidate")
+    if specs:
+        arms = tuple(
+            resolve(spec, "reference" if i == 0 else f"arm {i + 1}")
+            for i, spec in enumerate(specs)
+        )
     else:
         heads = [s for s in installed if not s.is_released()]
         if not heads:
@@ -76,10 +111,6 @@ def select_arms(
             )
         # Prefer 'main' when several branch builds are present.
         candidate = next((s for s in heads if s.version == "main"), heads[0])
-
-    if baseline_spec:
-        baseline = resolve(baseline_spec, "baseline")
-    else:
         # Final releases only. A release candidate parses to the same semver
         # as its final release, so including them leaves `max` breaking a tie
         # on whatever order the directory listing happened to produce -- and a
@@ -91,42 +122,101 @@ def select_arms(
                 f"not count); installed: "
                 f"{', '.join(sorted(s.version for s in installed))}"
             )
-        baseline = max(releases, key=lambda s: s.semver() or (0, 0, 0))
+        arms = (max(releases, key=lambda s: s.semver() or (0, 0, 0)), candidate)
 
-    if baseline == candidate:
-        raise ArmSelectionError(
-            f"baseline and candidate are both {baseline}; nothing to compare"
-        )
-    return baseline, candidate
+    if len(set(arms)) != len(arms):
+        names = ", ".join(str(a) for a in arms)
+        raise ArmSelectionError(f"arms resolved to the same build: {names}")
+    return arms
 
 
 # --- Session-scoped configuration -------------------------------------------
 
 
+def arm_specs_from_options(config: pytest.Config) -> tuple[str, ...] | None:
+    """The run's build specs, reference first, or None for the default pair.
+
+    ``--bench-refs`` is the K-arm form. ``--bench-baseline`` /
+    ``--bench-candidate`` are the two-arm shorthand it grew out of; they are
+    still accepted because the shape reads better for the common case, but
+    mixing the two forms is an error rather than a merge -- there is no
+    reading of ``--bench-refs a,b --bench-candidate c`` that is not a mistake.
+    """
+    refs = cast(str | None, config.getoption("--bench-refs"))
+    baseline = cast(str | None, config.getoption("--bench-baseline"))
+    candidate = cast(str | None, config.getoption("--bench-candidate"))
+    if refs and (baseline or candidate):
+        raise pytest.UsageError(
+            "--bench-refs cannot be combined with --bench-baseline or "
+            "--bench-candidate; --bench-refs supersedes both"
+        )
+    if refs:
+        try:
+            return parse_refs(refs)
+        except ValueError as e:
+            raise pytest.UsageError(f"invalid --bench-refs: {e}") from e
+    if baseline and candidate:
+        return (baseline, candidate)
+    if baseline or candidate:
+        # Half a pair cannot be resolved: the unnamed side would fall back to
+        # a default chosen for a different question, and nothing in the report
+        # would say the comparison was not the one that was asked for.
+        raise pytest.UsageError(
+            "--bench-baseline and --bench-candidate must be given together"
+        )
+    return None
+
+
+def arm_count(config: pytest.Config) -> int:
+    """How many arms this run will measure per cell."""
+    specs = arm_specs_from_options(config)
+    return len(specs) if specs else 2
+
+
 def config_from_options(config: pytest.Config) -> BenchConfig:
     """Build a :class:`BenchConfig` from the ``--bench-*`` options.
 
-    Every option has a default, so ``getoption`` never returns None here; the
-    casts are for the type checker, which cannot see the parser setup.
+    Every option except the budget has a default, so ``getoption`` never
+    returns None here; the casts are for the type checker, which cannot see
+    the parser setup.
     """
 
     def as_int(name: str) -> int:
         return int(cast(int, config.getoption(name)))
 
-    def as_float(name: str) -> float:
-        return float(cast(float, config.getoption(name)))
-
+    budget = cast(float | None, config.getoption("--bench-budget-seconds"))
     try:
         return BenchConfig(
             min_rounds=as_int("--bench-min-rounds"),
             max_rounds=as_int("--bench-max-rounds"),
             warmup=as_int("--bench-warmup"),
-            budget_seconds=as_float("--bench-budget-seconds"),
+            budget_seconds=(
+                float(budget)
+                if budget is not None
+                else default_budget_seconds(arm_count(config))
+            ),
             seed=as_int("--bench-seed"),
-            threshold=as_float("--bench-threshold"),
+            threshold=float(cast(float, config.getoption("--bench-threshold"))),
         )
     except ValueError as e:
         raise pytest.UsageError(f"invalid benchmark options: {e}") from e
+
+
+def default_budget_seconds(n_arms: int) -> float:
+    """The default time allowance for a K-arm run.
+
+    A round costs one invocation per arm, so at a fixed budget the attained
+    round count falls as ``2/K`` and every interval widens as ``sqrt(K/2)``.
+    Scaling the default by ``K/2`` keeps a three-arm run about as precise as
+    the two-arm run the number was chosen for, instead of quietly trading
+    precision for arms and reporting the difference as INCONCLUSIVE.
+
+    An explicit ``--bench-budget-seconds`` is taken as given; someone who
+    named a number has already decided what they are willing to spend.
+    """
+    # `BenchConfig` has slots, so the class attribute is a slot descriptor
+    # rather than the default; an instance is how you read one back.
+    return BenchConfig().budget_seconds * n_arms / 2
 
 
 @pytest.fixture(scope="session")
@@ -173,7 +263,9 @@ def write_payload(path: Path, payload: Payload, seed: int) -> None:
             remaining -= n
 
 
-def disk_shortfall(tmp_dir: Path, payloads: Sequence[Payload]) -> str | None:
+def disk_shortfall(
+    tmp_dir: Path, payloads: Sequence[Payload], n_arms: int = 2
+) -> str | None:
     """Return why ``payloads`` will not fit in ``tmp_dir``, or None.
 
     Checked up front because the alternative is finding out mid-run: ENOSPC
@@ -183,13 +275,15 @@ def disk_shortfall(tmp_dir: Path, payloads: Sequence[Payload]) -> str | None:
     points at the wrong thing while they look.
 
     The estimate is the plaintexts, plus a cached ciphertext for each (the
-    decrypt cells share one per size), plus the two output files the largest
-    cell holds while it runs. Outputs are deleted as each cell finishes, so
-    only one cell's worth is ever live.
+    decrypt cells share one per size), plus one live output per arm in the
+    largest cell. Outputs are deleted as each cell finishes, so only one
+    cell's worth is ever live -- but that cell holds K of them, not two, and
+    at 1 GiB payloads the difference between K and 2 is the whole margin on a
+    GitHub runner.
     """
     total = sum(p.n_bytes for p in payloads)
     largest = max(p.n_bytes for p in payloads)
-    need = 2 * total + 2 * largest + _DISK_HEADROOM_BYTES
+    need = 2 * total + n_arms * largest + _DISK_HEADROOM_BYTES
     free = shutil.disk_usage(tmp_dir).free
     if free >= need:
         return None
@@ -204,9 +298,12 @@ def disk_shortfall(tmp_dir: Path, payloads: Sequence[Payload]) -> str | None:
 
 @pytest.fixture(scope="session")
 def bench_payloads(
-    tmp_dir: Path, bench_config: BenchConfig, bench_payload_set: tuple[Payload, ...]
+    request: pytest.FixtureRequest,
+    tmp_dir: Path,
+    bench_config: BenchConfig,
+    bench_payload_set: tuple[Payload, ...],
 ) -> dict[str, Path]:
-    """Generate one plaintext file per payload size, shared by both arms.
+    """Generate one plaintext file per payload size, shared by every arm.
 
     Content is pseudo-random but seeded, so a rerun measures byte-identical
     input. Random rather than repetitive because compressible input would let
@@ -223,7 +320,7 @@ def bench_payloads(
     :func:`perf.cells.payloads_to_generate`.
     """
     wanted = payloads_to_generate(bench_payload_set)
-    shortfall = disk_shortfall(tmp_dir, wanted)
+    shortfall = disk_shortfall(tmp_dir, wanted, arm_count(request.config))
     if shortfall:
         raise pytest.UsageError(shortfall)
     out: dict[str, Path] = {}
@@ -263,52 +360,70 @@ def _selected_cells(config: pytest.Config) -> list[BenchCell]:
 
 @dataclass(frozen=True, slots=True)
 class BenchArms:
-    baseline: tdfs.SDK
-    candidate: tdfs.SDK
+    """The builds one SDK's cells compare, reference first."""
+
+    arms: tuple[tdfs.SDK, ...]
+
+    @property
+    def reference(self) -> tdfs.SDK:
+        """The build every gated contrast is taken against."""
+        return self.arms[0]
+
+    @property
+    def candidates(self) -> tuple[tdfs.SDK, ...]:
+        """Everything else -- one arm in a regression run, more in a bake-off."""
+        return self.arms[1:]
 
 
 class ArmResolver:
-    """Resolves and memoizes the two builds to compare, per SDK.
+    """Resolves and memoizes the builds to compare, per SDK.
 
     Resolution is lazy so that a missing build skips one SDK's cells with a
     readable reason instead of erroring out every cell in the module.
     """
 
-    def __init__(self, baseline_spec: str | None, candidate_spec: str | None) -> None:
-        self._baseline_spec = baseline_spec
-        self._candidate_spec = candidate_spec
+    def __init__(self, specs: Sequence[str] | None) -> None:
+        self._specs = tuple(specs) if specs else None
         self._cache: dict[str, BenchArms] = {}
 
     def __call__(self, sdk: str) -> BenchArms:
         cached = self._cache.get(sdk)
         if cached is None:
-            baseline, candidate = select_arms(
-                sdk,
-                baseline_spec=_spec_for(self._baseline_spec, sdk),
-                candidate_spec=_spec_for(self._candidate_spec, sdk),
+            cached = self._cache[sdk] = BenchArms(
+                select_arms(sdk, _specs_for(self._specs, sdk))
             )
-            cached = self._cache[sdk] = BenchArms(baseline, candidate)
         return cached
 
 
 @pytest.fixture(scope="module")
 def bench_arms(request: pytest.FixtureRequest) -> ArmResolver:
-    """Resolver for the (baseline, candidate) pair of any SDK in the run."""
-    return ArmResolver(
-        cast(str | None, request.config.getoption("--bench-baseline")),
-        cast(str | None, request.config.getoption("--bench-candidate")),
-    )
+    """Resolver for the arms of any SDK in the run, reference first."""
+    return ArmResolver(arm_specs_from_options(request.config))
 
 
-def _spec_for(spec: str | None, sdk: str) -> str | None:
-    """Return ``spec`` only if it names this SDK, so one flag can cover a run."""
-    if not spec:
+def _specs_for(specs: Sequence[str] | None, sdk: str) -> tuple[str, ...] | None:
+    """Return ``specs`` only if they name this SDK, so one flag covers a run.
+
+    A run that measures several SDKs but names arms for one of them lets the
+    others fall back to their default pair. Specs that name a *mix* of SDKs
+    are an error: the arms of a cell are all one SDK by construction, so there
+    is nothing a mixed list could mean.
+    """
+    if not specs:
         return None
-    return spec if spec.split("@", 1)[0] == sdk else None
+    named = tuple(s for s in specs if s.split("@", 1)[0] == sdk)
+    if not named:
+        return None
+    if len(named) != len(specs):
+        raise ArmSelectionError(
+            f"benchmark refs name more than one SDK ({', '.join(specs)}); "
+            "the arms of a comparison must all be builds of the same SDK"
+        )
+    return named
 
 
 #: Features whose presence changes what an encrypt or decrypt actually *does*.
-#: If the two arms disagree on one of these they are not performing the same
+#: If two arms disagree on one of these they are not performing the same
 #: operation, and a timing difference between them is a difference in work,
 #: not in speed.
 _COMPARABILITY_FEATURES: tuple[tdfs.feature_type, ...] = (
@@ -319,13 +434,25 @@ _COMPARABILITY_FEATURES: tuple[tdfs.feature_type, ...] = (
 
 
 def comparability_problem(arms: BenchArms) -> str | None:
-    """Return why these two builds cannot be fairly compared, or None."""
+    """Return why these builds cannot be fairly compared, or None.
+
+    Every arm is checked against the reference rather than only pairwise
+    neighbours: the reference is what all the gated contrasts are taken
+    against, so a candidate that disagrees with it invalidates its own gate
+    whatever the other candidates do.
+    """
     for feature in _COMPARABILITY_FEATURES:
-        if arms.baseline.supports(feature) != arms.candidate.supports(feature):
+        ref_has = arms.reference.supports(feature)
+        for arm in arms.candidates:
+            if arm.supports(feature) == ref_has:
+                continue
             supporter, other = (
-                (arms.baseline, arms.candidate)
-                if arms.baseline.supports(feature)
-                else (arms.candidate, arms.baseline)
+                (arm, arms.reference)
+                if not ref_has
+                else (
+                    arms.reference,
+                    arm,
+                )
             )
             return (
                 f"{supporter} supports [{feature}] and {other} does not, so the "
@@ -335,28 +462,25 @@ def comparability_problem(arms: BenchArms) -> str | None:
 
 
 def pinned_target_mode(arms: BenchArms) -> tdfs.container_version | None:
-    """Pick one container version both arms emit, or None for their default.
+    """Pick one container version every arm emits, or None for their default.
 
-    Letting each arm choose its own target would compare two output formats.
-    ``None`` is only returned when neither arm can be told which to use, in
+    Letting each arm choose its own target would compare output formats.
+    ``None`` is only returned when the arms cannot be told which to use, in
     which case :func:`comparability_problem` has already established that they
     agree on the relevant features and will pick the same one.
     """
-    if not (
-        arms.baseline.supports("hexaflexible")
-        and arms.candidate.supports("hexaflexible")
-    ):
+    if not all(a.supports("hexaflexible") for a in arms.arms):
         return None
-    if arms.baseline.supports("hexless") and arms.candidate.supports("hexless"):
+    if all(a.supports("hexless") for a in arms.arms):
         return "4.3.0"
     return "4.2.2"
 
 
 class CiphertextFactory:
-    """Baseline-produced ciphertexts for the decrypt cells, made on demand.
+    """Reference-produced ciphertexts for the decrypt cells, made on demand.
 
-    Both arms of a decrypt comparison must read the *same* file. If each arm
-    decrypted its own output, a difference in how the two builds *write* a TDF
+    Every arm of a decrypt comparison must read the *same* file. If each arm
+    decrypted its own output, a difference in how the builds *write* a TDF
     would show up as a difference in how fast they read one.
     """
 
@@ -372,12 +496,13 @@ class CiphertextFactory:
         self._cache: dict[tuple[str, str], Path] = {}
 
     def __call__(self, arms: BenchArms, payload_label: str) -> Path:
-        key = (str(arms.baseline), payload_label)
+        reference = arms.reference
+        key = (str(reference), payload_label)
         cached = self._cache.get(key)
         if cached is not None:
             return cached
-        ct_file = self._tmp_dir / f"bench-ct-{arms.baseline}-{payload_label}.tdf"
-        arms.baseline.encrypt(
+        ct_file = self._tmp_dir / f"bench-ct-{reference}-{payload_label}.tdf"
+        reference.encrypt(
             self._payloads[payload_label],
             ct_file,
             container="ztdf",
@@ -413,28 +538,30 @@ def build_arms(
     ct_file: Path | None,
     tmp_dir: Path,
     attr_values: list[str],
-) -> tuple[Arm, Arm]:
-    """Turn a cell plus its two builds into two ready-to-run invocations.
+) -> tuple[Arm, ...]:
+    """Turn a cell plus its builds into one ready-to-run invocation each.
 
     Everything that is not the build under test is pinned identically across
-    the arms: same plaintext, same attribute (so both wrap with RSA), same
-    container, same target mode. A functional difference between the builds
-    that changed any of these would otherwise show up as a speed difference.
+    the arms: same plaintext, same attribute (so every arm wraps with RSA),
+    same container, same target mode. A functional difference between the
+    builds that changed any of these would otherwise show up as a speed
+    difference.
 
-    For decrypt, both arms read the *same* ``ct_file``, produced once by the
-    baseline. Letting each arm decrypt its own output would compare the cost
-    of reading two different files.
+    For decrypt, every arm reads the *same* ``ct_file``, produced once by the
+    reference. Letting each arm decrypt its own output would compare the cost
+    of reading different files.
 
-    In a control cell both arms are the baseline build, so the pair differs
-    only in the output path -- exactly the harness overhead the A/A cell
-    exists to measure.
+    In a control cell every arm is the reference build, so they differ only in
+    the output path -- exactly the harness overhead the A/A cell exists to
+    measure. It is built with as many arms as the real cells have rather than
+    a cheap pair, because in a K-arm round the last arm runs K-1 invocations
+    after the first and carries more drift than an adjacent pair does; a
+    two-arm control would understate the noise of the contrasts being judged.
     """
-    baseline_sdk = arms.baseline
-    candidate_sdk = arms.baseline if cell.control else arms.candidate
     target_mode = pinned_target_mode(arms)
 
-    def invocation(sdk: tdfs.SDK, role: str) -> Invocation:
-        out = tmp_dir / f"bench-{cell.id}-{role}"
+    def invocation(sdk: tdfs.SDK, arm_id: str) -> Invocation:
+        out = tmp_dir / f"bench-{cell.id}-{arm_id}"
         if cell.operation == "encrypt":
             out = out.with_suffix(".tdf")
             argv, env = sdk.encrypt_command(
@@ -451,9 +578,17 @@ def build_arms(
             argv, env = sdk.decrypt_command(ct_file, out, container="ztdf")
         return Invocation(argv, env, out)
 
-    return (
-        Arm("baseline", str(baseline_sdk), invocation(baseline_sdk, "baseline")),
-        Arm("candidate", str(candidate_sdk), invocation(candidate_sdk, "candidate")),
+    if cell.control:
+        # Same build K times. The ids have to differ -- they key the sample
+        # vectors -- so they are numbered rather than named after the version.
+        builds = [
+            (f"{arms.reference.version}#{i + 1}", arms.reference)
+            for i in range(len(arms.arms))
+        ]
+    else:
+        builds = [(sdk.version, sdk) for sdk in arms.arms]
+    return tuple(
+        Arm(arm_id, str(sdk), invocation(sdk, arm_id)) for arm_id, sdk in builds
     )
 
 

--- a/xtest/fixtures/bench.py
+++ b/xtest/fixtures/bench.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import os
 import platform
 import random
+import shutil
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -21,7 +23,7 @@ import pytest
 import abac
 import tdfs
 from perf import report
-from perf.cells import PAYLOADS, BenchCell
+from perf.cells import BenchCell, Payload, parse_payloads, payloads_to_generate
 from perf.runner import Arm, BenchConfig, Budget, Invocation
 
 
@@ -133,8 +135,77 @@ def bench_config(request: pytest.FixtureRequest) -> BenchConfig:
     return config_from_options(request.config)
 
 
+def payloads_from_options(config: pytest.Config) -> tuple[Payload, ...]:
+    """The run's payload set, from ``--bench-payloads``."""
+    spec = cast(str, config.getoption("--bench-payloads"))
+    try:
+        return parse_payloads(spec)
+    except ValueError as e:
+        raise pytest.UsageError(f"invalid --bench-payloads: {e}") from e
+
+
 @pytest.fixture(scope="session")
-def bench_payloads(tmp_dir: Path, bench_config: BenchConfig) -> dict[str, Path]:
+def bench_payload_set(request: pytest.FixtureRequest) -> tuple[Payload, ...]:
+    """Payload sizes this run measures, from --bench-payloads."""
+    return payloads_from_options(request.config)
+
+
+#: Bytes generated per ``randbytes`` call. Must stay a multiple of 4: CPython
+#: draws a 32-bit word at a time, so chunking on a 4-byte boundary yields the
+#: same stream as one call for the whole payload, and the promise below --
+#: that a given seed and label always produce the same bytes -- survives both
+#: this constant changing and a payload growing past it.
+_CHUNK_BYTES = 8 * 2**20
+
+#: Free space a run keeps in hand beyond its payload arithmetic, for the
+#: platform's own logs and database growth over a long benchmark.
+_DISK_HEADROOM_BYTES = 2**30
+
+
+def write_payload(path: Path, payload: Payload, seed: int) -> None:
+    """Write one payload file, in chunks so a 1 GiB file is not built in RAM."""
+    rng = random.Random(f"{seed}:{payload.label}")
+    remaining = payload.n_bytes
+    with path.open("wb") as f:
+        while remaining > 0:
+            n = min(remaining, _CHUNK_BYTES)
+            f.write(rng.randbytes(n))
+            remaining -= n
+
+
+def disk_shortfall(tmp_dir: Path, payloads: Sequence[Payload]) -> str | None:
+    """Return why ``payloads`` will not fit in ``tmp_dir``, or None.
+
+    Checked up front because the alternative is finding out mid-run: ENOSPC
+    reaches the harness as a non-zero exit from the CLI under measurement,
+    which is reported as a failed measurement of that build. A run can lose
+    an hour before anyone notices the disk was the problem, and the report
+    points at the wrong thing while they look.
+
+    The estimate is the plaintexts, plus a cached ciphertext for each (the
+    decrypt cells share one per size), plus the two output files the largest
+    cell holds while it runs. Outputs are deleted as each cell finishes, so
+    only one cell's worth is ever live.
+    """
+    total = sum(p.n_bytes for p in payloads)
+    largest = max(p.n_bytes for p in payloads)
+    need = 2 * total + 2 * largest + _DISK_HEADROOM_BYTES
+    free = shutil.disk_usage(tmp_dir).free
+    if free >= need:
+        return None
+    gib = 2**30
+    sizes = ", ".join(p.label for p in payloads)
+    return (
+        f"payloads {sizes} need about {need / gib:.1f} GiB of scratch space "
+        f"in {tmp_dir} but only {free / gib:.1f} GiB is free; drop the largest "
+        "size from --bench-payloads or run somewhere with more disk"
+    )
+
+
+@pytest.fixture(scope="session")
+def bench_payloads(
+    tmp_dir: Path, bench_config: BenchConfig, bench_payload_set: tuple[Payload, ...]
+) -> dict[str, Path]:
     """Generate one plaintext file per payload size, shared by both arms.
 
     Content is pseudo-random but seeded, so a rerun measures byte-identical
@@ -147,13 +218,19 @@ def bench_payloads(tmp_dir: Path, bench_config: BenchConfig) -> dict[str, Path]:
     calls and shifts the stream for every payload after it. Deriving each
     payload's bytes from the seed *and* its label keeps the promise above true
     whether the cache is empty, full, or half there.
+
+    The control's payload is generated whether or not it was selected -- see
+    :func:`perf.cells.payloads_to_generate`.
     """
+    wanted = payloads_to_generate(bench_payload_set)
+    shortfall = disk_shortfall(tmp_dir, wanted)
+    if shortfall:
+        raise pytest.UsageError(shortfall)
     out: dict[str, Path] = {}
-    for payload in PAYLOADS:
+    for payload in wanted:
         path = tmp_dir / f"bench-plain-{payload.label}.bin"
         if not path.is_file() or path.stat().st_size != payload.n_bytes:
-            rng = random.Random(f"{bench_config.seed}:{payload.label}")
-            path.write_bytes(rng.randbytes(payload.n_bytes))
+            write_payload(path, payload, bench_config.seed)
         out[payload.label] = path
     return out
 

--- a/xtest/fixtures/bench.py
+++ b/xtest/fixtures/bench.py
@@ -615,6 +615,16 @@ def runner_metadata(config: pytest.Config) -> dict[str, object]:
     }
     sources, warning = _arm_sources()
     metadata["arm_sources"] = sources
+    requested = _requested_refs()
+    metadata["requested_refs"] = requested
+    if len(requested) >= 2 and len(sources) == 1 and sources[0].get("sha"):
+        sha = str(sources[0].get("sha", ""))
+        names = ", ".join(requested)
+        metadata["comparison_status"] = "same_commit"
+        metadata["comparison_note"] = (
+            f"{names} resolve to the same commit"
+            f"{f' {sha[:7]}' if sha else ''}; there is no code difference to benchmark."
+        )
     if warning:
         metadata["arm_sources_warning"] = warning
     return metadata
@@ -627,6 +637,12 @@ def _github_run_url() -> str:
     if not (server and repository and run_id):
         return ""
     return f"{server}/{repository}/actions/runs/{run_id}"
+
+
+def _requested_refs() -> list[str]:
+    """The caller's names, retained even when resolution deduplicates a SHA."""
+    value = os.environ.get("BENCH_REQUESTED_REFS", "")
+    return [part for part in re.split(r"[,\s]+", value.strip()) if part]
 
 
 def _arm_sources() -> tuple[list[dict[str, object]], str]:

--- a/xtest/perf/README.md
+++ b/xtest/perf/README.md
@@ -19,6 +19,10 @@ measure.
 > baseline — and every cell skips. The run fails rather than passing empty
 > (see [NOTHING MEASURED](#the-verdicts)), but it will have wasted 45 minutes
 > to tell you that.
+>
+> To compare **two named refs** instead — a branch against `main`, say — use
+> `bench-baseline-ref` / `bench-candidate-ref` and skip all of the above; see
+> [Benchmarking one branch against another](#benchmarking-one-branch-against-another).
 
 - **Section 1 — [Reading a result](#1-reading-a-result)** is for developers on
   the SDKs and the platform: your build got flagged, what does that mean.
@@ -169,6 +173,42 @@ Useful knobs while investigating:
 
 A local run is noisier than CI unless the machine is otherwise idle. Close
 things; the noise floor will tell you whether you succeeded.
+
+### Benchmarking one branch against another
+
+The nightly comparison is newest-release vs branch head, which is the right
+question to ask every night and the wrong one to ask about a specific change:
+the baseline carries every other commit that landed since the release. To
+point the harness at two refs you name, dispatch X-Test with:
+
+| Input | Example | Meaning |
+| --- | --- | --- |
+| `run-benchmarks` | ✅ | Required; the bench job is off otherwise |
+| `focus-sdk` | `go` | Must name one SDK — the matrix runs only this one |
+| `bench-baseline-ref` | `main` | The build you are comparing *against* |
+| `bench-candidate-ref` | `feat/DSPX-2604-createtdf-chunked` | The build under suspicion |
+
+Either ref can be anything `otdf-sdk-mgr versions resolve` accepts: a branch, a
+tag, a full or short SHA, or `refs/pull/N/head`. Both are built from source and
+installed side by side, and arm selection is told which is which explicitly —
+so neither has to be a release, which is the whole point.
+
+The `*-ref` inputs are ignored by the bench job in this mode. They still drive
+the functional test matrix, so a dispatch can answer "is it slower?" without
+also changing what the rest of the run tests.
+
+Two things this mode does **not** change, both of which bound what a result
+means:
+
+- **The server stays on `main`.** The bench job pins the platform and runs a
+  single KAS, whatever the refs say. A candidate whose speed depends on a
+  matching server change will not show it here.
+- **The baseline is whatever you named.** For a stacked branch, `main` as the
+  baseline measures the whole stack. Name the parent branch instead to isolate
+  the top commit.
+
+It fails fast, before spending a runner, when the two refs resolve to the same
+commit or when `focus-sdk` is `all`.
 
 ### What this benchmark cannot tell you
 
@@ -326,6 +366,18 @@ show up as a difference in how fast they read one.
 and the directory listing breaks the tie. That is a baseline nobody chose, and it
 differs run to run. Baseline selection uses `is_final_release()`, which matches
 only a plain `vX.Y.Z`.
+
+#### A dist tag is one path component
+
+`otdf-sdk-mgr` flattens `/` to `--` when it resolves a ref, so
+`feat/DSPX-2604-createtdf-chunked` installs as
+`dist/feat--DSPX-2604-createtdf-chunked/`. Everything downstream walks those
+directories exactly one level deep — `tdfs.all_versions_of()` lists `dist/*/`,
+the go `Makefile` finds `src/*/` — so a slash that survives resolution is
+discovered as a build named `feat` with no `cli.sh` in it, which
+`all_versions_of()` raises on before any cell runs. Branch-vs-branch dispatch
+is the first thing to routinely feed it a slashed ref, and the `--bench-*`
+specs name the flattened tag: `go@feat--DSPX-2604-createtdf-chunked`.
 
 #### Payloads are seeded per payload, not per run
 

--- a/xtest/perf/README.md
+++ b/xtest/perf/README.md
@@ -64,9 +64,12 @@ The summary is ordered for progressive disclosure:
    diff against the reference where those links exist.
 3. **What changed** shows only regressions, inconclusive rows, and confirmed
    improvements. Clean and ungated rows do not crowd the decision.
-4. **Effect at a glance** puts those rows on one fixed log-ratio scale. `┆`
-   marks the practical threshold, `│` means no change, the bracket is the 95%
-   interval, and `●` is the point estimate.
+4. **Effect at a glance** puts those rows on one shared, tail-compressed
+   log-ratio scale. This preserves space around the practical gate while still
+   fitting unusually large effects. `┆` marks the threshold, `│` means no
+   change, the bracket is the 95% interval, `●` is the point estimate, and `◆`
+   is an interval narrower than one character. Stable candidate letters map
+   duplicate measurement names back to the **Compared builds** table.
 5. Expandable blocks hold per-round Braille traces, all measurements and
    controls, skipped cells, and the statistical rule.
 6. **Run facts** closes the SDK summary with rounds, elapsed time, A/A noise,

--- a/xtest/perf/README.md
+++ b/xtest/perf/README.md
@@ -1,12 +1,14 @@
 # SDK performance regression benchmarks
 
-A paired A/B benchmark for the OpenTDF SDK CLIs. It answers one question:
-**did this change make the SDK measurably and meaningfully slower?**
+A paired benchmark for the OpenTDF SDK CLIs. It answers one question:
+**did this change make the SDK measurably and meaningfully slower?** — and,
+with more than two arms, the follow-up: **which of these implementations is
+faster?**
 
-Two builds — normally the newest installed release and the branch build —
-are measured on the *same* runner, interleaved round by round, and only their
-*ratio* is reported. Nothing is ever compared against a stored historical
-number.
+Two to four builds — normally the newest installed release and the branch
+build — are measured on the *same* runner, interleaved round by round, and only
+their *ratios* are reported. Nothing is ever compared against a stored
+historical number.
 
 It runs nightly (one runner per SDK) and on `workflow_dispatch` with
 `run-benchmarks` checked. It never runs on pull requests: 30 minutes of serial
@@ -20,9 +22,10 @@ measure.
 > (see [NOTHING MEASURED](#the-verdicts)), but it will have wasted 45 minutes
 > to tell you that.
 >
-> To compare **two named refs** instead — a branch against `main`, say — use
-> `bench-baseline-ref` / `bench-candidate-ref` and skip all of the above; see
-> [Benchmarking one branch against another](#benchmarking-one-branch-against-another).
+> To compare **refs you name** instead — a branch against `main`, or two
+> competing implementations against their shared parent — use `bench-refs` and
+> skip all of the above; see [Benchmarking named refs against each
+> other](#benchmarking-named-refs-against-each-other).
 
 - **Section 1 — [Reading a result](#1-reading-a-result)** is for developers on
   the SDKs and the platform: your build got flagged, what does that mean.
@@ -41,23 +44,31 @@ measure.
 | `bench-<sdk>` artifact | Run artifacts | `<sdk>.json` with **every raw per-round sample**, and an HTML report |
 | Terminal | Job log tail | One-line summary and the JSON path |
 
-The JSON is the useful one. It holds each cell's full per-round vectors for both
-arms, so a surprising verdict can be re-analysed offline instead of by re-running
-a 30-minute job to look at the same numbers again.
+The JSON is the useful one. It holds each cell's full per-round vectors for
+every arm, so a surprising verdict can be re-analysed offline instead of by
+re-running a 30-minute job to look at the same numbers again. It is `"schema":
+2`: each cell carries `arms`, `reference`, and `contrasts` keyed `"<b>_vs_<a>"`.
+`baseline` and `candidate` are still there for readers that predate the K-arm
+schema, but past two arms they name only the reference and the *first*
+candidate — use `arms` and `contrasts`.
 
 ### The table
 
 ```
-| cell                | metric     | baseline | candidate | ratio (95% CI)        | p (BH) | n  | verdict |
-| go-encrypt-1MiB     | wall clock | 412.3 ms | 498.1 ms  | 1.208x [1.171, 1.245] | <0.001 | 22 | **REGRESSION** |
+| cell            | contrast          | metric     | a        | b        | ratio (95% CI)        | p (BH) | n  | verdict |
+| go-encrypt-1MiB | `cand` vs `main`  | wall clock | 412.3 ms | 498.1 ms | 1.208x [1.171, 1.245] | <0.001 | 22 | **REGRESSION** |
 ```
 
 - **cell** — `<sdk>-<operation>-<payload>`, plus `-control` for the A/A cell.
   Payload sizes default to 1 KiB, 1 MiB, and 32 MiB; `--bench-payloads` selects
   others. See [Payload sizes and what they can gate](#payload-sizes-and-what-they-can-gate)
   before reading a throughput result — at the default sizes there is not one.
-- **ratio** — candidate ÷ baseline. `1.208x` means the candidate took 20.8%
-  longer. Below 1.0 means faster.
+- **contrast** — `b` vs `a`, the two arms this row compares. A two-arm run has
+  one row per cell and metric; a K-arm run has one per *pair*, so three arms
+  give three rows. Only the rows whose `a` is the **reference** (the first arm)
+  can fail the build; see [Bake-offs](#bake-offs-more-than-two-arms).
+- **ratio** — `b` ÷ `a`. `1.208x` means `b` took 20.8% longer. Below 1.0 means
+  `b` is faster.
 - **95% CI** — the bootstrap interval on that ratio. Its *width* is how precisely
   this run could measure; a wide interval means a noisy runner, not a big change.
 - **p (BH)** — one-sided p-value, Benjamini–Hochberg adjusted across the run.
@@ -90,6 +101,21 @@ note beside the verdict:
 change you expect to be performance-sensitive comes back inconclusive on every
 cell, the run told you nothing and re-running it is reasonable.
 
+A head-to-head between two arms that are *not* the reference gets a different
+vocabulary, because the question has no privileged direction — neither arm is
+the incumbent — and it can never fail the build:
+
+**FASTER** / **SLOWER** — the whole CI sits outside the equivalence band
+`[1/1.15, 1.15]` on one side. `b` is meaningfully faster (or slower) than `a`.
+
+**TIED** — the whole CI sits *inside* the band. This is a real answer, not the
+absence of one: the two implementations are indistinguishable at 15%, and the
+choice between them should be made on something other than speed. It is
+reported as TIED rather than PASS because PASS is a one-sided claim.
+
+**inconclusive** — the CI straddles a band edge, so the run cannot say which of
+the three it is.
+
 **NOTHING MEASURED** — no cell produced a comparison at all, usually because
 only one build was installed so there was no baseline to compare against. This
 **fails the job**. An empty run and a clean run have the same empty list of
@@ -108,9 +134,11 @@ lists the reason for each cell.
 
 ### The A/A control
 
-Each SDK gets a control cell that compares the baseline build **against itself**
-through the identical pipeline. Its true ratio is exactly 1.0 by construction, so
-whatever it reports is the harness's own error on this runner. It does two jobs:
+Each SDK gets a control cell that runs the reference build **against itself**,
+as many arms as the real cells have, through the identical pipeline. Every one
+of its C(K,2) contrasts has a true ratio of exactly 1.0 by construction, so
+whatever they report is the harness's own error on this runner. It does two
+jobs:
 
 - If the control *trips* — its own A/A comparison looks like a real effect — then
   something is systematically biased and **the whole run stops being able to fail
@@ -118,6 +146,12 @@ whatever it reports is the harness's own error on this runner. It does two jobs:
 - Its interval width is the run's **noise floor**: the smallest effect this
   runner could have resolved. If the floor is wider than the threshold, cells
   report inconclusive rather than PASS.
+
+The floor is the **worst** of the control's pairwise contrasts, and at K > 2 it
+has to be: in a three-arm round the third invocation happens two commands after
+the first, so that pair carries more drift than an adjacent one does. A cheap
+two-arm control alongside three-arm cells would understate the noise of exactly
+the contrasts being judged.
 
 In a multi-SDK run each SDK is judged against *its own* control — go's harness
 path says nothing about java's. `noise_floor_by_control` in the JSON has each
@@ -135,8 +169,8 @@ Ungated rows are labelled `(ungated)` and reported for context only. They cannot
 fail the build.
 
 Peak RSS additionally gets **censored** when a cell's readings sit at the
-measurement floor (the RSS of the process that forked the command). Both arms
-clip to the same value there, producing a `1.000x` ratio with a tight interval —
+measurement floor (the RSS of the process that forked the command). Every arm
+clips to the same value there, producing a `1.000x` ratio with a tight interval —
 the most convincing-looking PASS the harness can emit, and completely meaningless.
 Censored cells report inconclusive with the floor named in the note.
 
@@ -156,10 +190,9 @@ Censored cells report inconclusive with the floor named in the note.
 ```bash
 cd xtest && set -a && source test.env && set +a
 
-# whatever two builds you want, side by side under sdk/<name>/dist/
+# whatever builds you want, side by side under sdk/<name>/dist/
 uv run pytest --bench --sdks go \
-  --bench-baseline go@v0.29.0 \
-  --bench-candidate go@main \
+  --bench-refs "go@v0.29.0,go@main" \
   -v test_benchmarks.py
 ```
 
@@ -167,14 +200,18 @@ Useful knobs while investigating:
 
 | Option | Default | Use |
 | --- | --- | --- |
+| `--bench-refs` | newest release, branch head | 2–4 build specs, first is the reference |
 | `--bench-threshold` | `1.15` | Smallest slowdown worth failing on |
 | `--bench-payloads` | `1KiB,1MiB,32MiB` | Sizes to measure, e.g. `1KiB,1GiB` |
 | `--bench-min-rounds` / `--bench-max-rounds` | `20` / `60` | Rounds per cell |
 | `--bench-warmup` | `5` | Discarded rounds paying one-time costs |
-| `--bench-budget-seconds` | `1500` | Wall-clock allowance shared by all cells |
+| `--bench-budget-seconds` | `1500` × K/2 | Wall-clock allowance shared by all cells |
 | `--bench-seed` | `0` | Payloads, round order, bootstrap. Fix it to reproduce |
 | `--bench-out` | `test-results/benchmarks` | JSON destination |
 | `--bench-no-gate` | off | Measure and report, never fail |
+
+`--bench-baseline` / `--bench-candidate` still work as the two-arm spelling of
+`--bench-refs`; giving both forms is a usage error.
 
 A local run is noisier than CI unless the machine is otherwise idle. Close
 things; the noise floor will tell you whether you succeeded.
@@ -216,8 +253,9 @@ Three things to know before adding a large size:
 - **Budget.** Each size adds an encrypt and a decrypt cell, and the budget is
   divided evenly as cells start. A 1 GiB round costs ~6 s against ~1 s at 32
   MiB, so the default 1500 s will not reach `min_rounds` on both new cells.
-- **Disk.** A run holds roughly twice the payload total plus the largest size
-  twice over. 1 GiB needs ~5 GiB free. This is checked before the first
+- **Disk.** A run holds roughly twice the payload total plus one live output per
+  arm at the largest size — `2 × total + K × largest` plus headroom. Two arms at
+  1 GiB needs ~5 GiB free, three needs ~6. This is checked before the first
   measurement, because running out mid-run arrives as a non-zero exit from the
   CLI under test and reads as "this build is broken".
 - **`max_rounds` binds before the budget does.** In the run these numbers come
@@ -229,21 +267,20 @@ floor and every other cell is judged against it, so it must not move with the
 matrix — otherwise two runs of the same comparison can disagree about which
 cells were trustworthy for a reason unrelated to either build.
 
-### Benchmarking one branch against another
+### Benchmarking named refs against each other
 
 The nightly comparison is newest-release vs branch head, which is the right
 question to ask every night and the wrong one to ask about a specific change:
 the baseline carries every other commit that landed since the release. To
-point the harness at two refs you name, dispatch X-Test with:
+point the harness at refs you name, dispatch X-Test with:
 
 | Input | Example | Meaning |
 | --- | --- | --- |
 | `run-benchmarks` | ✅ | Required; the bench job is off otherwise |
 | `focus-sdk` | `go` | Must name one SDK — the matrix runs only this one |
-| `bench-baseline-ref` | `main` | The build you are comparing *against* |
-| `bench-candidate-ref` | `feat/DSPX-2604-createtdf-chunked` | The build under suspicion |
+| `bench-refs` | `main,feat/DSPX-2604-createtdf-chunked` | 2–4 refs; **the first is the reference** |
 | `bench-payloads` | `1KiB,1GiB` | Sizes to measure; default `1KiB,1MiB,32MiB` |
-| `bench-budget-seconds` | `5400` | Shared allowance; default `1500` |
+| `bench-budget-seconds` | `5400` | Shared allowance; default `1500` × K/2 |
 | `bench-max-rounds` | `200` | Cap per cell; default `60` |
 
 The last three are why a dispatch can answer a question the nightly cannot. A
@@ -253,10 +290,10 @@ claim, spend the budget — see [Payload sizes and what they can
 gate](#payload-sizes-and-what-they-can-gate), because at the defaults the
 answer will be **PASS** whatever the change did.
 
-Either ref can be anything `otdf-sdk-mgr versions resolve` accepts: a branch, a
-tag, a full or short SHA, or `refs/pull/N/head`. Both are built from source and
+Any ref `otdf-sdk-mgr versions resolve` accepts works: a branch, a tag, a full
+or short SHA, or `refs/pull/N/head`. All of them are built from source and
 installed side by side, and arm selection is told which is which explicitly —
-so neither has to be a release, which is the whole point.
+so none has to be a release, which is the whole point.
 
 The `*-ref` inputs are ignored by the bench job in this mode. They still drive
 the functional test matrix, so a dispatch can answer "is it slower?" without
@@ -268,12 +305,71 @@ means:
 - **The server stays on `main`.** The bench job pins the platform and runs a
   single KAS, whatever the refs say. A candidate whose speed depends on a
   matching server change will not show it here.
-- **The baseline is whatever you named.** For a stacked branch, `main` as the
-  baseline measures the whole stack. Name the parent branch instead to isolate
+- **The reference is whatever you named.** For a stacked branch, `main` as the
+  reference measures the whole stack. Name the parent branch instead to isolate
   the top commit.
 
-It fails fast, before spending a runner, when the two refs resolve to the same
-commit or when `focus-sdk` is `all`.
+It fails fast, before spending a runner, when two refs resolve to the same
+commit, when there are fewer than 2 or more than 4 of them, or when `focus-sdk`
+is `all`.
+
+`bench-baseline-ref` / `bench-candidate-ref` remain as the deprecated two-arm
+spelling; setting both forms is an error.
+
+### Bake-offs: more than two arms
+
+Two implementations of the same feature, and the only question that matters is
+which one to merge. This **cannot** be answered with two dispatches: the two
+candidates would land on different runners, their ratios would share no
+denominator, and comparing them would violate the premise the whole harness
+rests on ([Ratios within a run](#ratios-within-a-run-never-comparison-against-history)).
+
+Name them all in one dispatch instead. Every arm is then measured in the *same*
+round on the *same* runner, so every pair is a valid within-run ratio —
+including the two candidates against each other, where neither side is the
+reference:
+
+```
+bench-refs: main,fix/otdfctl-streaming-encrypt-writer,DSPX-4499-streaming-codec
+```
+
+- **The reference is `bench-refs[0]`.** Only contrasts against it are gated;
+  every other pair is judged symmetrically, reported, ranked, and can never
+  fail the build (invariant 9). A bake-off ranks, it does not gate.
+- **Pick the reference deliberately.** If the two candidates are stacked on a
+  shared parent, `main` as the reference measures each candidate's whole stack —
+  the vs-reference numbers then answer "how much did this branch cost overall",
+  not "what did this implementation do". The head-to-head that decides the
+  bake-off is unaffected either way, so `main` is a fine default and the parent
+  is the sharper one.
+- **Four arms is the ceiling.** `xtest/setup-cli-tool` installs at most four
+  builds side by side (slots a/b/c/d). A fifth would be dropped there and then
+  be missing from every round.
+
+The summary gains a **Bake-off** block: the candidates ranked per metric, with
+the head-to-head contrast and its verdict. It names a winner only when that
+head-to-head is FASTER — a TIED top pair reports "no measurable difference
+between A and B", which is an answer, and an unresolved one says it cannot
+separate them rather than pointing at whichever point estimate landed lower.
+
+#### Budget: a K-arm round costs K invocations
+
+At a fixed budget, K arms buy `2/K` as many rounds as two arms would, and CI
+width scales as `1/sqrt(n)` — so **every interval widens by ~`sqrt(K/2)`**.
+Three arms on a two-arm budget is how a run comes back as a wall of
+inconclusive after burning the whole runner.
+
+So the default budget scales with the arm count: `1500 × K/2`, applied both by
+the workflow and by the pytest fixture when `--bench-budget-seconds` is not
+given explicitly. An explicit value is taken as given — someone who names a
+budget has already decided what to spend. If the attained rounds still leave
+the gated contrasts unresolved, the report says so in an "Underpowered" warning
+naming the arm count, rather than leaving the reader to infer that time was the
+missing ingredient.
+
+`max_rounds` binds before the budget does at its default of 60; raise both.
+A 3-arm 1 GiB run wants roughly `--bench-payloads 1KiB,1GiB
+--bench-budget-seconds 8100 --bench-max-rounds 200`.
 
 ### What this benchmark cannot tell you
 
@@ -310,7 +406,7 @@ Offline tests, no platform and no subprocesses needed:
 ```bash
 cd xtest
 uv run pytest -q test_bench_stats.py test_bench_measure.py \
-                 test_bench_runner.py test_bench_arms.py
+                 test_bench_runner.py test_bench_arms.py test_bench_report.py
 ```
 
 These run on every PR via `check.yml`, so the harness is exercised continuously
@@ -322,25 +418,36 @@ even though the benchmark itself runs nightly.
 
 CPU models vary, tenancy is shared, and steal time is unbounded on a hosted
 runner. Storing a baseline and diffing against it produces false alarms until
-people mute the job. Both builds are measured on the same runner and the
+people mute the job. Every build is measured on the same runner and the
 statistic is the within-round ratio, so runner speed is a shared factor that
 divides out.
+
+The same premise is what forces a bake-off into one job: results from two
+dispatches have two different shared factors, and dividing one by the other
+does not cancel anything.
 
 #### Interleaved rounds, randomized within the round
 
 Running all of A then all of B lands every drift effect — a noisy neighbour
 arriving, thermal throttling, the page cache warming — entirely on one arm, where
-it reads as a difference between builds. Both arms run once per round instead.
+it reads as a difference between builds. Every arm runs once per round instead.
 The order *within* a round is shuffled because a fixed order is itself a
 confounder: whichever arm goes second inherits the first one's cache state.
+At K arms the shuffle matters more, not less — there are K positions to be
+last in, and an unshuffled third slot would be a systematic penalty.
 
 The shuffle is seeded per cell (`f"{seed}:{cell_id}"`), so a rerun reproduces the
 interleaving exactly while different cells do not share one order — which would
 correlate their noise.
 
+The stopping rule reads *every* gated contrast, not the first: with K-1
+candidates against the reference, one of them converging says nothing about the
+others, and stopping there would leave the rest reported at whatever width they
+happened to have reached.
+
 #### Log-ratios
 
-`d_i = ln(candidate_i) - ln(baseline_i)`. Logs make ratios symmetric (a 2x
+`d_i = ln(b_i) - ln(a_i)`. Logs make ratios symmetric (a 2x
 slowdown and a 2x speedup are equal and opposite) and additive, which is what
 the median and the bootstrap want. Everything is exponentiated back for reporting.
 
@@ -367,20 +474,50 @@ BH-adjusted p is below alpha. Clause 1 alone fires on real-but-trivial effects
 measured precisely; clause 2 alone fires on noise roughly alpha of the time per
 cell, and a run has enough cells that "roughly alpha" becomes "most nights".
 
-#### Separate BH families
+#### The symmetric rule for head-to-heads
 
-Gated keys are corrected as their own family. Ungated metrics get a family of
-their own so they still carry a reportable verdict. Adjusting the gated metrics
-against metrics nobody gates on would only make a real regression harder to
-confirm. Controls and censored keys are excluded from correction entirely — an
-A/A cell is not a hypothesis about the candidate.
+A vs-reference contrast asks a one-sided question: did the candidate get
+slower? A head-to-head between two candidates has no incumbent, so it gets an
+equivalence-band rule against `[1/threshold, threshold]` instead — CI wholly
+above the band is SLOWER, wholly below is FASTER, wholly inside is TIED, and
+anything straddling an edge is inconclusive.
 
-#### One A/A control per SDK, running first
+The TIED arm of that is the interesting one. A CI-inside-band test at 95% is
+TOST at 2.5% per side, so declaring TIED is *conservative*: it is harder to
+claim equivalence than the nominal alpha suggests, which is the right direction
+for a claim that will be used to stop looking. Reusing PASS here would be
+wrong — PASS says "not slower", which is not the same as "the same".
+
+Invariant 4 still applies: a symmetric verdict, like a gated one, needs a noise
+floor narrower than the band before it may say anything but inconclusive.
+
+#### Three separate BH families
+
+Gated keys — non-reference arm vs the reference, on a gated metric — are
+corrected as their own family. Head-to-head contrasts get a second family, and
+ungated metrics a third, so both still carry a reportable verdict. Adjusting
+the gated metrics against metrics nobody gates on would only make a real
+regression harder to confirm, and the same argument covers the bake-off: it is
+a question of interest, not a build gate, so it must not dilute the gate
+either. A key that is somehow in both the gated and symmetric sets is treated
+as gated, because the one-sided rule is the one that can turn the build red.
+
+Controls and censored keys are excluded from correction entirely — an A/A cell
+is not a hypothesis about the candidate.
+
+#### One A/A control per SDK, running first, with as many arms as the run
 
 A control measures a particular SDK's harness path. `cells_for()` emits each
 SDK's control first, because a run that overruns its budget loses whatever is at
 the end: losing one comparison leaves the rest trustworthy, losing the control
 leaves nothing trustworthy, since without a noise floor no cell may report PASS.
+
+It runs K copies of the reference build — same binary, distinct output paths —
+so it produces C(K,2) contrasts, and the floor is the worst of them. Keeping a
+cheap two-arm control while the real cells run three would measure the noise of
+a different experiment: the gap between the first and third invocation of a
+round is not the gap between the first and second, and it is the widest pairs
+that decide whether a run had the power to fail.
 
 `GateResult.noise` is the *worst* control in the run, not the average. A single
 tripped control means the harness may be biased on this runner, and averaging
@@ -414,23 +551,28 @@ delta reads zero.
 
 #### Everything except the build is pinned
 
-Both arms get the same plaintext, the same attribute (explicit RSA, so an arm
+Every arm gets the same plaintext, the same attribute (explicit RSA, so an arm
 does not silently switch to EC), the same container, and the same target mode.
-`comparability_problem()` refuses the comparison outright when the two builds
-disagree on `hexless`, `hexaflexible`, or `autoconfigure` — a timing difference
-there is a difference in *work*, not in speed.
+`comparability_problem()` refuses the comparison outright when any arm
+disagrees with the reference on `hexless`, `hexaflexible`, or `autoconfigure` —
+a timing difference there is a difference in *work*, not in speed. Pinned
+target mode likewise requires *all* arms to support the feature, not a
+majority; one arm falling back would be measuring a different format.
 
-For decrypt, both arms read one ciphertext produced by the baseline. If each arm
-decrypted its own output, a difference in how the two builds *write* a TDF would
-show up as a difference in how fast they read one.
+For decrypt, every arm reads one ciphertext produced by the reference. If each
+arm decrypted its own output, a difference in how the builds *write* a TDF
+would show up as a difference in how fast they read one.
 
-#### Baselines must be final releases
+#### The default reference must be a final release
 
+When no refs are named, the reference is the newest installed release.
 `SDK.is_released()` accepts `v0.29.0-rc.1`, and `semver()` parses it to the same
 `(0, 29, 0)` as the final release — so ordering by semver alone leaves them tied
-and the directory listing breaks the tie. That is a baseline nobody chose, and it
-differs run to run. Baseline selection uses `is_final_release()`, which matches
-only a plain `vX.Y.Z`.
+and the directory listing breaks the tie. That is a reference nobody chose, and
+it differs run to run. Default selection uses `is_final_release()`, which
+matches only a plain `vX.Y.Z`. With explicit refs the question does not arise:
+the reference is `bench-refs[0]`, released or not, which is the point of naming
+them.
 
 #### A dist tag is one path component
 
@@ -441,8 +583,10 @@ directories exactly one level deep — `tdfs.all_versions_of()` lists `dist/*/`,
 the go `Makefile` finds `src/*/` — so a slash that survives resolution is
 discovered as a build named `feat` with no `cli.sh` in it, which
 `all_versions_of()` raises on before any cell runs. Branch-vs-branch dispatch
-is the first thing to routinely feed it a slashed ref, and the `--bench-*`
-specs name the flattened tag: `go@feat--DSPX-2604-createtdf-chunked`.
+is the first thing to routinely feed it a slashed ref, and `--bench-refs` names
+the flattened tag: `go@feat--DSPX-2604-createtdf-chunked`. The workflow input
+`bench-refs` takes the *unflattened* ref, because it hands it to
+`versions resolve`, which is what does the flattening.
 
 #### Payloads are seeded per payload, not per run
 
@@ -507,8 +651,8 @@ noise floor over several nights.
 
 **A new operation** — extend `operation_type` and `cells_for()` in `cells.py`,
 then handle it in `build_arms()` in `fixtures/bench.py`. If it needs an input
-produced by the baseline, follow `CiphertextFactory`: build it once, from the
-baseline only, and share it between the arms.
+produced by another arm, follow `CiphertextFactory`: build it once, from the
+reference only, and share it across every arm.
 
 **A new SDK** — nothing here needs to change; it comes from `--sdks` and the
 matrix in `xtest.yml`.
@@ -524,10 +668,12 @@ two builds doing different amounts of work) is invisible in the output.
 3. Never let a cell assert; the gate is run-level.
 4. Never report PASS without a noise floor establishing the run had the power to
    fail.
-5. Never let the two arms differ in anything but the build.
+5. Never let the arms differ in anything but the build.
 6. Never run the measured command from a process holding memory.
 7. Never run the benchmark in parallel with anything, including itself.
 8. Never let a run that measured nothing report success.
+9. Never gate a contrast that does not involve the reference. A bake-off ranks;
+   it does not fail the build.
 
 Every one of these fails *silently* and *plausibly* when broken: the numbers
 still look like numbers. That is why they are written down.

--- a/xtest/perf/README.md
+++ b/xtest/perf/README.md
@@ -53,7 +53,9 @@ a 30-minute job to look at the same numbers again.
 ```
 
 - **cell** — `<sdk>-<operation>-<payload>`, plus `-control` for the A/A cell.
-  Payload sizes are 1 KiB, 1 MiB, and 32 MiB.
+  Payload sizes default to 1 KiB, 1 MiB, and 32 MiB; `--bench-payloads` selects
+  others. See [Payload sizes and what they can gate](#payload-sizes-and-what-they-can-gate)
+  before reading a throughput result — at the default sizes there is not one.
 - **ratio** — candidate ÷ baseline. `1.208x` means the candidate took 20.8%
   longer. Below 1.0 means faster.
 - **95% CI** — the bootstrap interval on that ratio. Its *width* is how precisely
@@ -145,8 +147,10 @@ Censored cells report inconclusive with the floor named in the note.
 2. **Check the control row.** If the A/A cell for your SDK also looks strange,
    suspect the runner before your code.
 3. **Look at which cells fired.** Only the 1 KiB cells means startup cost —
-   process boot, package resolution, TLS handshake, token fetch. Only 32 MiB
-   means throughput — the crypto and IO path. Both means something structural.
+   process boot, package resolution, TLS handshake, token fetch. The largest
+   cell firing on its own points at throughput — the crypto and IO path — but
+   only if that cell is large enough for throughput to be most of it, which at
+   32 MiB it is not. Both means something structural.
 4. **Reproduce locally.** The comparison is self-contained; it does not need CI.
 
 ```bash
@@ -164,6 +168,7 @@ Useful knobs while investigating:
 | Option | Default | Use |
 | --- | --- | --- |
 | `--bench-threshold` | `1.15` | Smallest slowdown worth failing on |
+| `--bench-payloads` | `1KiB,1MiB,32MiB` | Sizes to measure, e.g. `1KiB,1GiB` |
 | `--bench-min-rounds` / `--bench-max-rounds` | `20` / `60` | Rounds per cell |
 | `--bench-warmup` | `5` | Discarded rounds paying one-time costs |
 | `--bench-budget-seconds` | `1500` | Wall-clock allowance shared by all cells |
@@ -173,6 +178,56 @@ Useful knobs while investigating:
 
 A local run is noisier than CI unless the machine is otherwise idle. Close
 things; the noise floor will tell you whether you succeeded.
+
+### Payload sizes and what they can gate
+
+**At the default sizes this harness cannot fail a build on throughput.** Not
+"is unlikely to" — cannot. On a 4-core Linux runner a go encrypt costs about
+450 ms before it touches the payload: runtime start, config load, TLS
+handshake, token fetch, KAS key fetch. Going from 1 KiB to 32 MiB — a 32,000x
+increase in bytes — adds about 72 ms on top of that.
+
+| operation | 1 KiB | 1 MiB | 32 MiB | payload-dependent |
+| --- | --- | --- | --- | --- |
+| encrypt | 455.0 ms | 447.6 ms | 526.7 ms | ~72 ms (13.6%) |
+| decrypt | 533.6 ms | 513.1 ms | 600.7 ms | ~67 ms (11.2%) |
+
+The gate is 1.15x of the *whole cell*, which at 32 MiB encrypt is +79 ms —
+more than the entire payload-dependent portion. A candidate that doubled every
+per-segment cost would come in at 1.136x and report **PASS**. The 1 MiB cells
+are worse: indistinguishable from 1 KiB, so they measure startup twice.
+
+This is not a statistics problem. The intervals are tight and the control is
+clean; the matrix is simply asking the wrong sizes. To gate throughput the
+payload term has to dominate, which means going much larger:
+
+```bash
+uv run pytest --bench --sdks go \
+  --bench-payloads 1KiB,1GiB \
+  --bench-budget-seconds 5400 --bench-max-rounds 200 \
+  -v test_benchmarks.py
+```
+
+At 1 GiB the payload term is ~2.3 s against the same ~450 ms fixed cost, so it
+is ~84% of the cell and a 15% gate lands inside the part being tested.
+
+Three things to know before adding a large size:
+
+- **Budget.** Each size adds an encrypt and a decrypt cell, and the budget is
+  divided evenly as cells start. A 1 GiB round costs ~6 s against ~1 s at 32
+  MiB, so the default 1500 s will not reach `min_rounds` on both new cells.
+- **Disk.** A run holds roughly twice the payload total plus the largest size
+  twice over. 1 GiB needs ~5 GiB free. This is checked before the first
+  measurement, because running out mid-run arrives as a non-zero exit from the
+  CLI under test and reads as "this build is broken".
+- **`max_rounds` binds before the budget does.** In the run these numbers come
+  from, 3 of 7 cells stopped on `max_rounds` while only 418 s of 1500 s was
+  spent. Raising the budget alone buys nothing; raise both.
+
+The control stays at 1 MiB whatever you select. Its CI width is the run's noise
+floor and every other cell is judged against it, so it must not move with the
+matrix — otherwise two runs of the same comparison can disagree about which
+cells were trustworthy for a reason unrelated to either build.
 
 ### Benchmarking one branch against another
 
@@ -187,6 +242,16 @@ point the harness at two refs you name, dispatch X-Test with:
 | `focus-sdk` | `go` | Must name one SDK — the matrix runs only this one |
 | `bench-baseline-ref` | `main` | The build you are comparing *against* |
 | `bench-candidate-ref` | `feat/DSPX-2604-createtdf-chunked` | The build under suspicion |
+| `bench-payloads` | `1KiB,1GiB` | Sizes to measure; default `1KiB,1MiB,32MiB` |
+| `bench-budget-seconds` | `5400` | Shared allowance; default `1500` |
+| `bench-max-rounds` | `200` | Cap per cell; default `60` |
+
+The last three are why a dispatch can answer a question the nightly cannot. A
+nightly runs unattended every day and has to stay inside a sensible cost; a
+dispatch is asked for, once, about one thing. If the change is a throughput
+claim, spend the budget — see [Payload sizes and what they can
+gate](#payload-sizes-and-what-they-can-gate), because at the defaults the
+answer will be **PASS** whatever the change did.
 
 Either ref can be anything `otdf-sdk-mgr versions resolve` accepts: a branch, a
 tag, a full or short SHA, or `refs/pull/N/head`. Both are built from source and
@@ -389,6 +454,12 @@ be comparable with. Each payload derives from `f"{seed}:{label}"` instead.
 Content is random rather than repetitive because compressible input would let an
 SDK that happens to compress look faster for reasons unrelated to crypto.
 
+Large payloads are written in chunks so a 1 GiB file is not first built as a
+1 GiB `bytes` in RAM. The chunk size must stay a multiple of 4: CPython's
+`randbytes` draws a 32-bit word at a time, so a 4-byte-aligned split produces
+the same stream as one call would, and the seed-to-bytes promise survives both
+the constant changing and a payload growing past it.
+
 #### Cells record; the session gates
 
 The verdict cannot be reached cell by cell — the multiplicity correction spans
@@ -421,11 +492,13 @@ CPU under measurement.
 
 ### Adding to it
 
-**A new payload size** — add a `Payload` to `PAYLOADS` in `cells.py`. Note that
-`CONTROL_PAYLOAD = PAYLOADS[1]`, so inserting at the front moves the control.
-Cell count per SDK is `1 + 2 × len(PAYLOADS)`; the 1500s budget is divided
-across all of them, so adding sizes makes every cell poorer unless the budget
-grows too.
+**A new payload size** — no code change: `--bench-payloads 1KiB,1GiB` (or the
+`bench-payloads` dispatch input). Sizes parse as a count and a binary unit —
+`B`, `KiB`, `MiB`, `GiB` — and the list is sorted ascending and deduplicated by
+byte count, so `1KiB,1024B` is one cell rather than two identical ones. Changing
+`DEFAULT_PAYLOAD_SPEC` in `cells.py` changes what the nightly measures; think
+about the budget first. Cell count per SDK is `1 + 2 × len(payloads)`, and the
+budget is divided evenly across all of them.
 
 **A new metric** — add it to `METRICS` and `METRIC_LABELS` in `measure.py`, teach
 `Sample.metric()` and `format_metric()` about it, and decide whether it belongs

--- a/xtest/perf/README.md
+++ b/xtest/perf/README.md
@@ -151,6 +151,11 @@ reported as TIED rather than PASS because PASS is a one-sided claim.
 **inconclusive** — the CI straddles a band edge, so the run cannot say which of
 the three it is.
 
+**SAME COMMIT** — the caller requested two names (typically `main latest`) but
+both resolved to one immutable SHA. There is no code difference that could
+produce a performance difference, so no cell runs and the job remains neutral.
+This is distinct from an empty or broken benchmark.
+
 **NOTHING MEASURED** — no cell produced a comparison at all, usually because
 only one build was installed so there was no baseline to compare against. This
 **fails the job**. An empty run and a clean run have the same empty list of
@@ -160,10 +165,9 @@ lists the reason for each cell.
 
 > One cause looks like a bug and is not. If an SDK's newest release tags the same
 > commit as `main` — java sat at `v0.18.0 == main == dev == 57d070b0` through
-> August 2026 — then `main latest` resolves both arms to one SHA, `otdf-sdk-mgr`
-> installs a single build, and every cell skips with *"no final release to compare
-> against; installed: main"*. The message is true from where the harness stands, but
-> the release it is looking for does exist; the two arms are just the same code.
+> August 2026 — then `main latest` resolves both arms to one SHA and
+> `otdf-sdk-mgr` installs a single build. The report calls this **SAME COMMIT**,
+> not NOTHING MEASURED: the release exists, but the two arms are the same code.
 > Check with `otdf-sdk-mgr versions resolve <sdk> main latest` — one entry back
 > instead of two means there is nothing to measure until `main` moves.
 
@@ -717,7 +721,8 @@ two builds doing different amounts of work) is invisible in the output.
 5. Never let the arms differ in anything but the build.
 6. Never run the measured command from a process holding memory.
 7. Never run the benchmark in parallel with anything, including itself.
-8. Never let a run that measured nothing report success.
+8. Never let a run that measured nothing report success, unless every requested
+   arm resolved to the same immutable commit and there is no difference to test.
 9. Never gate a contrast that does not involve the reference. A bake-off ranks;
    it does not fail the build.
 

--- a/xtest/perf/README.md
+++ b/xtest/perf/README.md
@@ -40,8 +40,9 @@ measure.
 
 | Artifact | Where | Contents |
 | --- | --- | --- |
-| Job summary | The Actions run page | The table below, plus the verdict |
-| `bench-<sdk>` artifact | Run artifacts | `<sdk>.json` with **every raw per-round sample**, and an HTML report |
+| SDK job summary | Each matrix job | TL;DR, linked build provenance, attention rows, Unicode effect views, and run facts |
+| Workflow roll-up | `Performance benchmark roll-up` job | One bottom line across Go, Java, and JS, with matrix health and links to each artifact |
+| `bench-result-<sdk>` artifact | Run artifacts | `<sdk>.json` with **every raw per-round sample**, the rendered summary, and an HTML report |
 | Terminal | Job log tail | One-line summary and the JSON path |
 
 The JSON is the useful one. It holds each cell's full per-round vectors for
@@ -50,9 +51,37 @@ re-running a 30-minute job to look at the same numbers again. It is `"schema":
 2`: each cell carries `arms`, `reference`, and `contrasts` keyed `"<b>_vs_<a>"`.
 `baseline` and `candidate` are still there for readers that predate the K-arm
 schema, but past two arms they name only the reference and the *first*
-candidate — use `arms` and `contrasts`.
+candidate — use `arms` and `contrasts`. Resolver metadata beside it records the
+immutable commit and whether each arm came from a PR, branch, or release.
 
-### The table
+### Reading the summary
+
+The summary is ordered for progressive disclosure:
+
+1. **TL;DR** gives the run status and counts of confirmed, unresolved, and
+   improved gated comparisons.
+2. **Compared builds** links each arm to its PR, release/tag, commit, and GitHub
+   diff against the reference where those links exist.
+3. **What changed** shows only regressions, inconclusive rows, and confirmed
+   improvements. Clean and ungated rows do not crowd the decision.
+4. **Effect at a glance** puts those rows on one fixed log-ratio scale. `┆`
+   marks the practical threshold, `│` means no change, the bracket is the 95%
+   interval, and `●` is the point estimate.
+5. Expandable blocks hold per-round Braille traces, all measurements and
+   controls, skipped cells, and the statistical rule.
+6. **Run facts** closes the SDK summary with rounds, elapsed time, A/A noise,
+   platform/runner identity, seed, and a direct evidence link.
+7. After every matrix job finishes, the workflow roll-up combines verdicts and
+   run health across SDKs. It deliberately does not compare absolute timings
+   from different runners.
+
+The Unicode plots are plain text, so they remain legible in copied comments,
+logs, dark mode, and restricted GitHub Markdown without external image assets.
+
+### The full measurement table
+
+The complete table is collapsed by default under **All measurements, controls,
+and statistical details**:
 
 ```
 | cell            | contrast          | metric     | a        | b        | ratio (95% CI)        | p (BH) | n  | verdict |
@@ -71,7 +100,9 @@ candidate — use `arms` and `contrasts`.
   `b` is faster.
 - **95% CI** — the bootstrap interval on that ratio. Its *width* is how precisely
   this run could measure; a wide interval means a noisy runner, not a big change.
-- **p (BH)** — one-sided p-value, Benjamini–Hochberg adjusted across the run.
+- **p (BH)** — one-sided p-value in the direction of the observed effect,
+  Benjamini–Hochberg adjusted across the run. Slower and faster tails are
+  calculated and adjusted separately; the JSON records both.
 - **n** — paired rounds actually measured (20–60; the loop stops early once the
   interval is narrow enough).
 
@@ -79,9 +110,10 @@ candidate — use `arms` and `contrasts`.
 
 **REGRESSION** — the CI lower bound exceeds the threshold (default **1.15x**,
 i.e. 15% slower) *and* the adjusted p < 0.05. Both clauses are required, and
-neither is redundant: the threshold alone would fire on a reproducible 0.5%
-slowdown nobody cares about, and significance alone would fire on noise often
-enough to be ignored within a week. This fails the job.
+neither is redundant: the CI establishes that the effect exceeds the practical
+threshold but is not multiplicity-adjusted, while significance alone would
+flag both reproducible 0.5% slowdowns nobody cares about and pure-noise false
+positives. This fails the job.
 
 **PASS** — not a regression, *and* the run had enough precision to have found
 one. "We looked and found nothing" only counts when we could have found
@@ -396,7 +428,8 @@ A 3-arm 1 GiB run wants roughly `--bench-payloads 1KiB,1GiB
 | `_launcher.py` | The separate process that actually forks the measured command |
 | `runner.py` | The paired round loop, the stopping rule, the budget, `analyze()` |
 | `stats.py` | Pure functions: log-ratios, bootstrap CI, Wilcoxon, BH, the decision rule |
-| `report.py` | Session recorder, JSON artifact, step-summary markdown |
+| `report.py` | Session recorder, JSON artifact, decision-first SDK summary markdown |
+| `aggregate.py` | Pure-stdlib workflow roll-up over downloaded SDK JSON artifacts |
 | `../fixtures/bench.py` | The pytest glue: arm selection, payloads, ciphertexts, budget |
 | `../test_benchmarks.py` | One test per cell. **Records; never asserts** |
 | `../conftest.py` | `--bench*` options, cell parametrization, the session-finish gate |
@@ -406,7 +439,8 @@ Offline tests, no platform and no subprocesses needed:
 ```bash
 cd xtest
 uv run pytest -q test_bench_stats.py test_bench_measure.py \
-                 test_bench_runner.py test_bench_arms.py test_bench_report.py
+                 test_bench_runner.py test_bench_arms.py test_bench_report.py \
+                 test_bench_aggregate.py
 ```
 
 These run on every PR via `check.yml`, so the harness is exercised continuously
@@ -470,9 +504,18 @@ because a NaN width must read as "keep going" and `NaN > target` is `False`.
 #### Both clauses of the decision rule
 
 A cell is a regression iff the CI lower bound exceeds `threshold` **and** the
-BH-adjusted p is below alpha. Clause 1 alone fires on real-but-trivial effects
-measured precisely; clause 2 alone fires on noise roughly alpha of the time per
-cell, and a run has enough cells that "roughly alpha" becomes "most nights".
+BH-adjusted p is below alpha. Clause 1 establishes practical significance but
+does not adjust the many intervals examined in a run. Clause 2 supplies
+multiplicity control but, alone, fires on real-but-trivial effects and on
+pure-noise false positives. Faster findings use a separately computed and
+BH-adjusted lower-tail p-value; an adjusted upper-tail probability cannot be
+read backwards as evidence for the opposite direction.
+
+The signed-rank test does not require normal raw latencies and is resistant to
+the magnitude of a stray stalled invocation. Its location-test interpretation
+does assume the paired *log differences* are approximately symmetric. The log
+transform and the harness's multiplicative-jitter model are intended to make
+that reasonable; the raw vectors remain in the artifact for checking it.
 
 #### The symmetric rule for head-to-heads
 

--- a/xtest/perf/aggregate.py
+++ b/xtest/perf/aggregate.py
@@ -16,6 +16,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,7 +53,15 @@ class Run:
         return [r for r in self.gated if r[2].get("verdict") == "REGRESSION"]
 
     @property
+    def same_commit(self) -> bool:
+        return (
+            self.document.get("metadata", {}).get("comparison_status") == "same_commit"
+        )
+
+    @property
     def status(self) -> str:
+        if self.same_commit:
+            return "SAME COMMIT"
         if self.document.get("nothing_measured") or not self.gated:
             return "NOTHING MEASURED"
         if not self.document.get("trustworthy", True):
@@ -178,6 +187,8 @@ def _overall_status(runs: list[Run], missing: list[str]) -> str:
         return "INCOMPLETE"
     if any(r.status == "INCONCLUSIVE" for r in runs):
         return "INCONCLUSIVE"
+    if runs and all(r.same_commit for r in runs):
+        return "SAME COMMIT"
     return "PASS" if runs else "NO RESULTS"
 
 
@@ -186,23 +197,63 @@ def _overall_headline(runs: list[Run], missing: list[str]) -> str:
         return "No benchmark result artifacts were found."
     regressions = sum(len(r.regressions) for r in runs)
     unresolved = sum(r.inconclusive for r in runs)
+    same = sum(r.same_commit for r in runs)
     outcomes = ", ".join(f"{r.sdk}: {r.status}" for r in runs)
     missing_text = f" Missing result(s): {', '.join(missing)}." if missing else ""
     return (
         f"{regressions} confirmed regression(s), {unresolved} unresolved gated "
-        f"comparison(s) across {len(runs)} available SDK result(s). {outcomes}."
+        f"comparison(s), and {same} same-commit result(s) across {len(runs)} "
+        f"available SDK result(s). {outcomes}."
         f"{missing_text}"
     )
 
 
 def _arms(run: Run) -> str:
     sources = run.document.get("metadata", {}).get("arm_sources", [])
-    if isinstance(sources, list) and sources:
-        return " → ".join(
-            f"`{s.get('tag', '?')}`" for s in sources if isinstance(s, dict)
-        )
+    source_list = [source for source in sources if isinstance(source, dict)]
+    by_tag = {str(source.get("tag", "")): source for source in source_list}
+    if run.same_commit:
+        requested = run.document.get("metadata", {}).get("requested_refs", [])
+        source = source_list[0] if source_list else None
+        if isinstance(requested, list):
+            return (
+                " = ".join(_aggregate_arm(str(arm), source) for arm in requested)
+                + " (same commit)"
+            )
     cells = [c for c in run.document.get("cells", []) if not c.get("control")]
-    return " → ".join(f"`{a}`" for a in cells[0].get("arms", [])) if cells else "—"
+    if cells:
+        return " → ".join(
+            _aggregate_arm(str(arm), by_tag.get(str(arm)))
+            for arm in cells[0].get("arms", [])
+        )
+    if source_list:
+        return " → ".join(
+            _aggregate_arm(str(source.get("tag", "?")), source)
+            for source in source_list
+        )
+    return "—"
+
+
+def _aggregate_arm(arm: str, source: object) -> str:
+    url = _aggregate_source_url(source)
+    code = f"`{arm}`"
+    return f"[{code}]({url})" if url else code
+
+
+def _aggregate_source_url(source: object) -> str:
+    if not isinstance(source, dict):
+        return ""
+    repo = str(source.get("repo_url", ""))
+    pr = str(source.get("pr", ""))
+    release = str(source.get("release", ""))
+    sha = str(source.get("sha", ""))
+    if repo and pr:
+        return f"{repo}/pull/{quote(pr, safe='')}"
+    if repo and release:
+        return f"{repo}/releases/tag/{quote(release, safe='')}"
+    if repo and sha:
+        return f"{repo}/tree/{quote(sha, safe='')}"
+    return ""
 
 
 def _change(comparison: dict[str, Any]) -> str:

--- a/xtest/perf/aggregate.py
+++ b/xtest/perf/aggregate.py
@@ -1,0 +1,266 @@
+"""Pure-stdlib cross-SDK renderer for benchmark JSON artifacts.
+
+The workflow runs this after downloading every matrix artifact. Keeping it
+free of pytest/numpy/scipy means the roll-up needs no environment setup and can
+still explain a partially failed matrix whose artifact set is incomplete.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class Run:
+    sdk: str
+    document: dict[str, Any]
+
+    @property
+    def gated(self) -> list[tuple[str, str, dict[str, Any]]]:
+        metrics = set(self.document.get("config", {}).get("gated_metrics", []))
+        rows: list[tuple[str, str, dict[str, Any]]] = []
+        for cell in self.document.get("cells", []):
+            if cell.get("control"):
+                continue
+            reference = cell.get("reference")
+            for name, by_metric in cell.get("contrasts", {}).items():
+                if not name.endswith(f"_vs_{reference}"):
+                    continue
+                for metric, comparison in by_metric.items():
+                    if metric in metrics:
+                        rows.append((str(cell.get("id", "")), metric, comparison))
+        return rows
+
+    @property
+    def inconclusive(self) -> int:
+        return sum(c.get("verdict") == "INCONCLUSIVE" for _, _, c in self.gated)
+
+    @property
+    def improvements(self) -> int:
+        return sum(c.get("verdict") == "IMPROVED" for _, _, c in self.gated)
+
+    @property
+    def regressions(self) -> list[tuple[str, str, dict[str, Any]]]:
+        return [r for r in self.gated if r[2].get("verdict") == "REGRESSION"]
+
+    @property
+    def status(self) -> str:
+        if self.document.get("nothing_measured") or not self.gated:
+            return "NOTHING MEASURED"
+        if not self.document.get("trustworthy", True):
+            return "UNTRUSTWORTHY"
+        if self.regressions:
+            return "REGRESSION"
+        if self.inconclusive:
+            return "INCONCLUSIVE"
+        return "PASS"
+
+
+def load_runs(root: Path) -> list[Run]:
+    runs: list[Run] = []
+    for path in root.rglob("*.json"):
+        try:
+            document = json.loads(path.read_text())
+        except OSError, json.JSONDecodeError:
+            continue
+        if not isinstance(document, dict) or "config" not in document:
+            continue
+        metadata = document.get("metadata", {})
+        sdk = str(metadata.get("sdk", "")) if isinstance(metadata, dict) else ""
+        if not sdk:
+            cells = document.get("cells", [])
+            cell_id = str(cells[0].get("id", "")) if cells else path.stem
+            sdk = cell_id.split("-", 1)[0]
+        runs.append(Run(sdk=sdk, document=document))
+    order = {"go": 0, "java": 1, "js": 2}
+    return sorted(runs, key=lambda r: (order.get(r.sdk, 99), r.sdk))
+
+
+def markdown(
+    runs: list[Run],
+    *,
+    artifact_urls: dict[str, str] | None = None,
+    run_url: str = "",
+    expected_sdks: list[str] | None = None,
+) -> str:
+    artifact_urls = artifact_urls or {}
+    expected = expected_sdks or [run.sdk for run in runs]
+    missing = [sdk for sdk in expected if sdk not in {run.sdk for run in runs}]
+    overall = _overall_status(runs, missing)
+    lines = [
+        f"# SDK performance benchmark roll-up — {overall}",
+        "",
+        "### TL;DR",
+        "",
+        f"> **{_overall_headline(runs, missing)}**",
+        "",
+    ]
+    if run_url:
+        lines += [f"[Workflow run]({run_url})", ""]
+    if not runs:
+        return "\n".join(
+            lines
+            + [
+                "> [!WARNING]",
+                "> No benchmark JSON artifacts were available. The matrix may have "
+                "failed before session-final reporting.",
+                "",
+            ]
+        )
+
+    lines += [
+        "| SDK | outcome | compared builds | regressions | unresolved | improvements | A/A noise | evidence |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for run in runs:
+        noise = run.document.get("noise_floor", {})
+        width = noise.get("width_ratio") if isinstance(noise, dict) else None
+        noise_text = (
+            f"±{(float(width) - 1) * 100:.1f}%"
+            if isinstance(width, (int, float)) and math.isfinite(width)
+            else "—"
+        )
+        evidence = (
+            f"[artifact]({artifact_urls[run.sdk]})"
+            if artifact_urls.get(run.sdk)
+            else "—"
+        )
+        lines.append(
+            f"| **{run.sdk}** | **{run.status}** | {_arms(run)} "
+            f"| {len(run.regressions)} | {run.inconclusive} | {run.improvements} "
+            f"| {noise_text} | {evidence} |"
+        )
+    for sdk in missing:
+        lines.append(f"| **{sdk}** | **MISSING** | — | — | — | — | — | — |")
+
+    regressions = [(run, *row) for run in runs for row in run.regressions]
+    if regressions:
+        lines += [
+            "",
+            "### Confirmed regressions",
+            "",
+            "| SDK | measurement | metric | change (95% CI) |",
+            "| --- | --- | --- | --- |",
+        ]
+        for run, cell, metric, comparison in regressions:
+            lines.append(f"| {run.sdk} | `{cell}` | {metric} | {_change(comparison)} |")
+
+    lines += [
+        "",
+        "### Combined run facts",
+        "",
+        "| matrix results | measured cells | skipped cells | total measured time | platform versions |",
+        "| ---: | ---: | ---: | ---: | --- |",
+        f"| {len(runs)}/{len(expected)} | {sum(_measured_cells(r) for r in runs)} "
+        f"| {sum(len(r.document.get('skipped', {})) for r in runs)} "
+        f"| {sum(_elapsed(r) for r in runs):.0f}s "
+        f"| {', '.join(_platform_versions(runs)) or 'unknown'} |",
+        "",
+        "<sub>Each SDK was measured on its own runner. Absolute timings are not "
+        "compared across SDKs; this block combines verdicts and run health only.</sub>",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _overall_status(runs: list[Run], missing: list[str]) -> str:
+    for status in ("REGRESSION", "UNTRUSTWORTHY", "NOTHING MEASURED"):
+        if any(r.status == status for r in runs):
+            return status
+    if missing:
+        return "INCOMPLETE"
+    if any(r.status == "INCONCLUSIVE" for r in runs):
+        return "INCONCLUSIVE"
+    return "PASS" if runs else "NO RESULTS"
+
+
+def _overall_headline(runs: list[Run], missing: list[str]) -> str:
+    if not runs:
+        return "No benchmark result artifacts were found."
+    regressions = sum(len(r.regressions) for r in runs)
+    unresolved = sum(r.inconclusive for r in runs)
+    outcomes = ", ".join(f"{r.sdk}: {r.status}" for r in runs)
+    missing_text = f" Missing result(s): {', '.join(missing)}." if missing else ""
+    return (
+        f"{regressions} confirmed regression(s), {unresolved} unresolved gated "
+        f"comparison(s) across {len(runs)} available SDK result(s). {outcomes}."
+        f"{missing_text}"
+    )
+
+
+def _arms(run: Run) -> str:
+    sources = run.document.get("metadata", {}).get("arm_sources", [])
+    if isinstance(sources, list) and sources:
+        return " → ".join(
+            f"`{s.get('tag', '?')}`" for s in sources if isinstance(s, dict)
+        )
+    cells = [c for c in run.document.get("cells", []) if not c.get("control")]
+    return " → ".join(f"`{a}`" for a in cells[0].get("arms", [])) if cells else "—"
+
+
+def _change(comparison: dict[str, Any]) -> str:
+    def pct(value: object) -> str:
+        return (
+            f"{(float(value) - 1) * 100:+.1f}%"
+            if isinstance(value, (int, float))
+            else "—"
+        )
+
+    return (
+        f"{pct(comparison.get('ratio'))} "
+        f"[{pct(comparison.get('ci_low'))}, {pct(comparison.get('ci_high'))}]"
+    )
+
+
+def _measured_cells(run: Run) -> int:
+    return sum(not c.get("control") for c in run.document.get("cells", []))
+
+
+def _elapsed(run: Run) -> float:
+    return sum(float(c.get("elapsed_s", 0)) for c in run.document.get("cells", []))
+
+
+def _platform_versions(runs: list[Run]) -> list[str]:
+    return sorted(
+        {
+            str(r.document.get("metadata", {}).get("platform_version", ""))
+            for r in runs
+            if r.document.get("metadata", {}).get("platform_version")
+        }
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        print("usage: aggregate.py RESULTS_DIR", file=sys.stderr)
+        return 2
+    try:
+        urls = json.loads(os.environ.get("BENCH_ARTIFACT_URLS", "{}"))
+    except json.JSONDecodeError:
+        urls = {}
+    try:
+        expected = json.loads(os.environ.get("BENCH_EXPECTED_SDKS", "[]"))
+    except json.JSONDecodeError:
+        expected = []
+    print(
+        markdown(
+            load_runs(Path(args[0])),
+            artifact_urls=urls if isinstance(urls, dict) else {},
+            run_url=os.environ.get("BENCH_RUN_URL", ""),
+            expected_sdks=(
+                [str(sdk) for sdk in expected] if isinstance(expected, list) else []
+            ),
+        ),
+        end="",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/xtest/perf/aggregate.py
+++ b/xtest/perf/aggregate.py
@@ -1,8 +1,10 @@
 """Pure-stdlib cross-SDK renderer for benchmark JSON artifacts.
 
-The workflow runs this after downloading every matrix artifact. Keeping it
-free of pytest/numpy/scipy means the roll-up needs no environment setup and can
-still explain a partially failed matrix whose artifact set is incomplete.
+The workflow runs this after downloading every matrix artifact. It has no
+third-party imports, so the roll-up needs no dependency sync and can still
+explain a partially failed matrix whose artifact set is incomplete. It does
+run through xtest's pinned interpreter: stdlib-only does not imply that a
+hosted runner's older Python understands the repository's target syntax.
 """
 
 from __future__ import annotations

--- a/xtest/perf/cells.py
+++ b/xtest/perf/cells.py
@@ -6,6 +6,8 @@ the reporting layer can name a cell without importing each other.
 
 from __future__ import annotations
 
+import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
 
@@ -22,22 +24,100 @@ class Payload:
     32 MiB the crypto and IO dominate and a startup regression is invisible.
     A benchmark at one size only will miss half the regressions it claims to
     cover.
+
+    "Dominate" is relative, and at 32 MiB it is not yet true. On a 4-core
+    Linux runner a go encrypt costs ~450 ms of fixed startup against ~72 ms
+    that scales with the payload, so payload work is ~14% of the cell and the
+    default 1.15x gate is wider than the whole of it -- a candidate that
+    doubled every per-segment cost would still report PASS. Gating throughput
+    needs a size where the ratio inverts, which is what ``--bench-payloads``
+    is for: at 1 GiB the payload term is ~2.3 s against the same ~450 ms.
     """
 
     label: str
     n_bytes: int
 
 
-PAYLOADS: tuple[Payload, ...] = (
-    Payload("1KiB", 1024),
-    Payload("1MiB", 2**20),
-    Payload("32MiB", 32 * 2**20),
+#: Binary units only. A label is a filename and a cell id, and "1MB" sitting
+#: next to "1MiB" in a report is a misreading waiting to happen.
+_UNITS: tuple[tuple[str, int], ...] = (
+    ("B", 1),
+    ("KiB", 2**10),
+    ("MiB", 2**20),
+    ("GiB", 2**30),
 )
+
+_SIZE_RE = re.compile(r"^\s*(\d+)\s*([a-z]+)\s*$", re.IGNORECASE)
+
+
+def parse_payload(spec: str) -> Payload:
+    """Parse one size spec, e.g. ``"32MiB"``, into a :class:`Payload`.
+
+    The unit is matched case-insensitively but the label is rebuilt from the
+    canonical spelling, so ``"1gib"`` and ``"1GiB"`` name the same cell rather
+    than two cells that measure the same thing under different ids.
+    """
+    match = _SIZE_RE.match(spec)
+    units = {name.lower(): (name, mult) for name, mult in _UNITS}
+    if match is None or match.group(2).lower() not in units:
+        raise ValueError(
+            f"{spec!r} is not a payload size; expected a count and one of "
+            f"{', '.join(name for name, _ in _UNITS)}, e.g. '32MiB'"
+        )
+    count = int(match.group(1))
+    name, multiplier = units[match.group(2).lower()]
+    if count <= 0:
+        raise ValueError(f"{spec!r} is not a payload size; it must be above zero")
+    return Payload(f"{count}{name}", count * multiplier)
+
+
+def parse_payloads(spec: str) -> tuple[Payload, ...]:
+    """Parse a comma-separated size list into the run's payload set.
+
+    Sorted ascending and deduplicated *by byte count*, not by label: ``1024B``
+    and ``1KiB`` are one size written two ways, and admitting both would run
+    two identically-sized cells whose only difference is the id in the report.
+    """
+    by_size: dict[int, Payload] = {}
+    for part in spec.split(","):
+        if not part.strip():
+            continue
+        payload = parse_payload(part)
+        by_size.setdefault(payload.n_bytes, payload)
+    if not by_size:
+        raise ValueError("no payload sizes given")
+    return tuple(by_size[n] for n in sorted(by_size))
+
+
+#: What a run measures unless ``--bench-payloads`` says otherwise. Anything
+#: larger is opt-in: a 1 GiB cell costs minutes of budget and gigabytes of
+#: scratch disk, which a nightly should not spend without being asked.
+DEFAULT_PAYLOAD_SPEC = "1KiB,1MiB,32MiB"
+
+PAYLOADS: tuple[Payload, ...] = parse_payloads(DEFAULT_PAYLOAD_SPEC)
 
 #: Payload used for the A/A control. Mid-size: large enough that startup noise
 #: does not dominate it, small enough that the control is not a big slice of
 #: the budget.
-CONTROL_PAYLOAD = PAYLOADS[1]
+#:
+#: Fixed rather than picked out of the selected set, because the control's
+#: reported width *is* the run's noise floor and every other cell is judged
+#: against it. Letting it follow ``--bench-payloads`` would move the floor
+#: whenever the matrix changed, so two runs of the same comparison could
+#: disagree about which cells were trustworthy for a reason that has nothing
+#: to do with either build.
+CONTROL_PAYLOAD = Payload("1MiB", 2**20)
+
+
+def payloads_to_generate(payloads: Sequence[Payload]) -> tuple[Payload, ...]:
+    """Every payload file a run needs, including the control's.
+
+    The control's size need not be in the selected set -- ``--bench-payloads
+    1GiB`` is a legitimate ask -- but its file is still required, and a
+    missing one surfaces as a KeyError deep in arm construction.
+    """
+    by_label = {p.label: p for p in (*payloads, CONTROL_PAYLOAD)}
+    return tuple(sorted(by_label.values(), key=lambda p: p.n_bytes))
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,7 +141,9 @@ class BenchCell:
         return self.id
 
 
-def cells_for(sdks: list[str]) -> list[BenchCell]:
+def cells_for(
+    sdks: list[str], payloads: Sequence[Payload] = PAYLOADS
+) -> list[BenchCell]:
     """Build the full cell list for a run, each SDK's control cell first.
 
     One control per SDK rather than one per run: a control measures a
@@ -72,13 +154,17 @@ def cells_for(sdks: list[str]) -> list[BenchCell]:
     whatever is at the end. Losing one comparison leaves the rest
     trustworthy; losing the control leaves nothing trustworthy at all, since
     without a noise floor no cell may report PASS.
+
+    Within an SDK the payloads run smallest first, so that when the budget
+    does run out it is the most expensive cell that is lost rather than an
+    arbitrary one.
     """
     cells: list[BenchCell] = []
     for sdk in sdks:
         cells.append(BenchCell(sdk, "encrypt", CONTROL_PAYLOAD, control=True))
         cells += [
             BenchCell(sdk, op, payload)
+            for payload in payloads
             for op in ("encrypt", "decrypt")
-            for payload in PAYLOADS
         ]
     return cells

--- a/xtest/perf/report.py
+++ b/xtest/perf/report.py
@@ -29,7 +29,7 @@ import pytest
 from perf import stats
 from perf.cells import BenchCell
 from perf.measure import METRIC_LABELS, METRICS, format_metric
-from perf.runner import BenchConfig, CellResult, analyze
+from perf.runner import BenchConfig, CellResult, analyze, contrast_key
 
 #: Cells the session intends to run. Set by the conftest parametrizer, read by
 #: the budget and arm-resolution fixtures.
@@ -69,12 +69,132 @@ class BenchmarkRecorder:
         return analyze(self.results, config)
 
 
+@dataclass(frozen=True, slots=True)
+class BakeOff:
+    """One cell's head-to-head ranking of the non-reference arms.
+
+    The gate answers "did anything get slower than the reference". A bake-off
+    answers a different question -- "of these candidate implementations, which
+    should we merge" -- and it is deliberately kept out of the gate: ranking
+    two candidates against each other says nothing about whether either is a
+    regression, and a build must not go red because the runner-up lost.
+    """
+
+    cell_id: str
+    metric: str
+    #: Candidate arm ids, best first, ordered by ratio against the reference.
+    order: list[str]
+    #: The contrast between the top two candidates, as configured order.
+    head_to_head: str
+    verdict: stats.Verdict
+    #: The winning arm id, or None when the top two could not be separated.
+    winner: str | None
+    detail: str
+
+
+def bake_offs(
+    recorder: BenchmarkRecorder, config: BenchConfig, gate: stats.GateResult
+) -> list[BakeOff]:
+    """Rank the candidates in every cell that ran more than one of them.
+
+    Empty for a two-arm run, which has nothing to rank: there is one candidate
+    and the gate has already said everything there is to say about it.
+
+    A winner is named only when the top pair's own contrast came back FASTER
+    or SLOWER. A TIED top pair reports that the two are indistinguishable,
+    which is a real answer and frequently the correct one -- picking the arm
+    whose point estimate happened to land lower would be reading noise as a
+    result.
+    """
+    out: list[BakeOff] = []
+    for r in recorder.results:
+        candidates = [a for a in r.arm_ids if a != r.reference]
+        if r.control or len(candidates) < 2:
+            continue
+        for metric in config.gated_metrics:
+            ranked = _rank_candidates(r, candidates, metric, gate)
+            if len(ranked) < 2:
+                continue
+            # Head-to-head keys exist in configured order only, so recover
+            # that order for the top two rather than assuming the ranking's.
+            top = [a for a in candidates if a in ranked[:2]]
+            key = contrast_key(r.cell_id, top[0], top[1], metric)
+            c = gate.comparisons.get(key)
+            if c is None:
+                continue
+            winner = {
+                stats.Verdict.FASTER: top[1],
+                stats.Verdict.SLOWER: top[0],
+            }.get(c.verdict)
+            out.append(
+                BakeOff(
+                    cell_id=r.cell_id,
+                    metric=metric,
+                    order=ranked,
+                    head_to_head=f"{top[1]}_vs_{top[0]}",
+                    verdict=c.verdict,
+                    winner=winner,
+                    detail=_bake_off_detail(c, top, winner),
+                )
+            )
+    return out
+
+
+def _rank_candidates(
+    r: CellResult, candidates: list[str], metric: str, gate: stats.GateResult
+) -> list[str]:
+    """Candidate ids ordered by their ratio against the reference, best first.
+
+    Candidates whose reference contrast produced no usable ratio are dropped:
+    an unmeasurable arm has no place in a ranking, and sorting NaN would put
+    it wherever the sort happened to leave it.
+    """
+    ratios: dict[str, float] = {}
+    for arm in candidates:
+        c = gate.comparisons.get(contrast_key(r.cell_id, r.reference, arm, metric))
+        if c is not None and math.isfinite(c.ratio):
+            ratios[arm] = c.ratio
+    return sorted(ratios, key=lambda a: ratios[a])
+
+
+def _bake_off_detail(
+    c: stats.PairedComparison, top: list[str], winner: str | None
+) -> str:
+    interval = (
+        f"{c.ratio:.3f}x [{c.ci_low:.3f}, {c.ci_high:.3f}]"
+        if math.isfinite(c.ci_low) and math.isfinite(c.ci_high)
+        else "no usable interval"
+    )
+    pair = f"`{top[1]}` vs `{top[0]}` {interval}"
+    if winner is not None:
+        return f"`{winner}` wins: {pair}"
+    if c.verdict is stats.Verdict.TIED:
+        return f"no measurable difference between `{top[0]}` and `{top[1]}`: {pair}"
+    return f"cannot separate `{top[0]}` and `{top[1]}`: {pair}"
+
+
+def _bake_off_dict(b: BakeOff) -> dict[str, object]:
+    return {
+        "cell": b.cell_id,
+        "metric": b.metric,
+        "order": b.order,
+        "head_to_head": b.head_to_head,
+        "verdict": str(b.verdict),
+        "winner": b.winner,
+        "detail": b.detail,
+    }
+
+
 def to_dict(
     recorder: BenchmarkRecorder, config: BenchConfig, gate: stats.GateResult
 ) -> dict[str, object]:
     """Serialize a whole run, raw samples included."""
     return {
-        "schema": 1,
+        # 2: cells hold K arms. `samples` is keyed by arm id rather than by
+        # `"baseline"`/`"candidate"`, and per-metric statistics moved under
+        # `contrasts["<b>_vs_<a>"]`. The `baseline`/`candidate` labels stay for
+        # a two-arm run so existing readers keep working.
+        "schema": 2,
         "metadata": recorder.metadata,
         "config": {
             "min_rounds": config.min_rounds,
@@ -97,11 +217,19 @@ def to_dict(
         "trustworthy": gate.trustworthy,
         "regressions": gate.regressions,
         "improvements": gate.improvements,
+        "ranked": gate.ranked,
+        "bake_off": [_bake_off_dict(b) for b in bake_offs(recorder, config, gate)],
         "summary": gate.summary,
         "skipped": recorder.skipped,
         "cells": [
             {
                 "id": r.cell_id,
+                "arms": list(r.arm_ids),
+                "arm_labels": r.arm_labels,
+                "reference": r.reference,
+                # Kept for two-arm readers that predate the K-arm schema; at
+                # K > 2 `arms`/`arm_labels` are the complete picture and these
+                # name only the first candidate.
                 "baseline": r.baseline_label,
                 "candidate": r.candidate_label,
                 "control": r.control,
@@ -111,10 +239,13 @@ def to_dict(
                 "stopped_because": r.stopped_because,
                 "rss_floor_bytes": r.rss_floor_bytes,
                 "samples": r.samples,
-                "metrics": {
-                    m: _comparison_dict(gate.comparisons[f"{r.cell_id}/{m}"])
-                    for m in METRICS
-                    if f"{r.cell_id}/{m}" in gate.comparisons
+                "contrasts": {
+                    f"{b}_vs_{a}": {
+                        m: _comparison_dict(gate.comparisons[key])
+                        for m in METRICS
+                        if (key := contrast_key(r.cell_id, a, b, m)) in gate.comparisons
+                    }
+                    for a, b in r.contrast_pairs()
                 },
             }
             for r in recorder.results
@@ -167,21 +298,75 @@ def write_json(
     return path
 
 
+def underpowered_warning(
+    recorder: BenchmarkRecorder, config: BenchConfig, gate: stats.GateResult
+) -> str | None:
+    """Say so when the run did not buy the precision it was asked for.
+
+    A K-arm round costs K invocations, so at a fixed time budget the round
+    count falls as arms are added and every interval widens by roughly
+    ``sqrt(K/2)``. Asking for three arms on a two-arm budget therefore comes
+    back as a wall of INCONCLUSIVE after burning the whole runner, with
+    nothing in the output saying that more time was the missing ingredient.
+    This says it, and says how much more.
+
+    Returns None when every contrast reached the precision target.
+    """
+    widest = 0.0
+    rounds = 0
+    for r in recorder.results:
+        if r.control:
+            continue
+        for a, b in r.contrast_pairs():
+            for metric in config.gated_metrics:
+                c = gate.comparisons.get(contrast_key(r.cell_id, a, b, metric))
+                if c is None or not math.isfinite(c.ci_half_width_log):
+                    continue
+                if c.ci_half_width_log > widest:
+                    widest, rounds = c.ci_half_width_log, c.n_rounds
+
+    target = config.target_half_width_log
+    if widest <= target or target <= 0:
+        return None
+
+    n_arms = max((len(r.arm_ids) for r in recorder.results), default=2)
+    # Interval width falls as 1/sqrt(n), so closing a factor-f gap costs f^2
+    # times the rounds -- and, at a fixed per-round cost, f^2 times the budget.
+    shortfall = (widest / target) ** 2
+    return (
+        f"Underpowered: the widest contrast reached "
+        f"+/-{(math.exp(widest) - 1) * 100:.1f}% after {rounds} rounds, against "
+        f"a +/-{(math.exp(target) - 1) * 100:.1f}% target. A {n_arms}-arm round "
+        f"costs {n_arms} invocations; holding precision needs about "
+        f"{shortfall:.1f}x the rounds, so roughly "
+        f"{config.budget_seconds * shortfall:.0f}s of budget (currently "
+        f"{config.budget_seconds:.0f}s) and a max-rounds ceiling above "
+        f"{math.ceil(rounds * shortfall)}. Contrasts the interval could not "
+        f"separate are reported INCONCLUSIVE rather than as no difference."
+    )
+
+
 def markdown(
     recorder: BenchmarkRecorder, config: BenchConfig, gate: stats.GateResult
 ) -> str:
     """Render the run as a GitHub step summary."""
     threshold_pct = (config.threshold - 1) * 100
+    n_arms = max((len(r.arm_ids) for r in recorder.results), default=2)
     lines = [
         "## SDK performance regression benchmark",
         "",
-        f"Paired A/B on one runner. A cell fails only if the 95% CI lower "
-        f"bound exceeds **{config.threshold:.2f}x** (+{threshold_pct:.0f}%) "
+        f"Paired {n_arms}-arm comparison, all arms in the same rounds on one "
+        f"runner. A contrast against the reference fails only if the 95% CI "
+        f"lower bound exceeds **{config.threshold:.2f}x** (+{threshold_pct:.0f}%) "
         f"*and* the BH-adjusted p < {stats.DEFAULT_ALPHA}.",
         "",
         f"**{gate.summary}**",
         "",
     ]
+
+    warning = underpowered_warning(recorder, config, gate)
+    if warning:
+        lines += ["> [!WARNING]", f"> {warning}", ""]
 
     noise = gate.noise
     if noise is not None and noise.detail:
@@ -194,23 +379,46 @@ def markdown(
         ]
 
     lines += [
-        "| cell | metric | baseline | candidate | ratio (95% CI) | p (BH) | n | verdict |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+        "| cell | contrast | metric | a | b | ratio (95% CI) | p (BH) | n | verdict |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
     for result in recorder.results:
-        for metric in METRICS:
-            key = f"{result.cell_id}/{metric}"
-            c = gate.comparisons.get(key)
-            if c is None:
-                continue
-            gated = metric in config.gated_metrics and not result.control
-            label = METRIC_LABELS[metric][0] + ("" if gated else " (ungated)")
+        for a, b in result.contrast_pairs():
+            head_to_head = result.reference not in (a, b)
+            for metric in METRICS:
+                c = gate.comparisons.get(contrast_key(result.cell_id, a, b, metric))
+                if c is None:
+                    continue
+                gated = (
+                    metric in config.gated_metrics
+                    and not result.control
+                    and not head_to_head
+                )
+                label = METRIC_LABELS[metric][0] + ("" if gated else " (ungated)")
+                lines.append(
+                    f"| {result.cell_id} | `{b}` vs `{a}` | {label} "
+                    f"| {format_metric(metric, c.baseline_median)} "
+                    f"| {format_metric(metric, c.candidate_median)} "
+                    f"| {_ratio_cell(c)} | {_p_cell(c)} | {c.n_rounds} "
+                    f"| {_verdict_cell(c)} |"
+                )
+
+    rankings = bake_offs(recorder, config, gate)
+    if rankings:
+        lines += [
+            "",
+            "### Bake-off",
+            "",
+            "Head-to-head between candidates, measured in the same rounds as "
+            "everything else. Ranking only -- these contrasts never fail the "
+            "build.",
+            "",
+        ]
+        for bo in rankings:
+            order = " < ".join(f"`{a}`" for a in bo.order)
             lines.append(
-                f"| {result.cell_id} | {label} "
-                f"| {format_metric(metric, c.baseline_median)} "
-                f"| {format_metric(metric, c.candidate_median)} "
-                f"| {_ratio_cell(c)} | {_p_cell(c)} | {c.n_rounds} "
-                f"| {_verdict_cell(c)} |"
+                f"- **{bo.cell_id}** ({METRIC_LABELS[bo.metric][0]}): "
+                f"{order} -- {bo.detail}"
             )
 
     if recorder.skipped:
@@ -246,6 +454,12 @@ _VERDICT_ICONS = {
     stats.Verdict.REGRESSION: "**REGRESSION**",
     stats.Verdict.IMPROVED: "IMPROVED",
     stats.Verdict.INCONCLUSIVE: "inconclusive",
+    # Head-to-head vocabulary. Not bolded: none of these can fail the build,
+    # and a SLOWER that looked like a REGRESSION would invite someone to treat
+    # it as one.
+    stats.Verdict.FASTER: "faster",
+    stats.Verdict.SLOWER: "slower",
+    stats.Verdict.TIED: "tied",
 }
 
 

--- a/xtest/perf/report.py
+++ b/xtest/perf/report.py
@@ -21,8 +21,11 @@ from __future__ import annotations
 import json
 import math
 import os
+import statistics
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import quote
 
 import pytest
 
@@ -37,6 +40,10 @@ CELLS_KEY: pytest.StashKey[list[BenchCell]] = pytest.StashKey()
 
 #: The session's recorder, reachable from both fixtures and session hooks.
 RECORDER_KEY: pytest.StashKey[BenchmarkRecorder] = pytest.StashKey()
+
+# Replaced by the workflow after upload-artifact returns its authenticated URL.
+# Kept conspicuous so a failed substitution cannot look like a real link.
+ARTIFACT_URL_PLACEHOLDER = "@@BENCH_ARTIFACT_URL@@"
 
 
 def recorder_for(config: pytest.Config) -> BenchmarkRecorder:
@@ -90,6 +97,19 @@ class BakeOff:
     #: The winning arm id, or None when the top two could not be separated.
     winner: str | None
     detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReportRow:
+    """One reportable contrast/metric with enough context to render it."""
+
+    result: CellResult
+    a: str
+    b: str
+    metric: str
+    comparison: stats.PairedComparison
+    gated: bool
+    head_to_head: bool
 
 
 def bake_offs(
@@ -214,6 +234,7 @@ def to_dict(
         "noise_floor_by_control": {
             k: _noise_dict(n) for k, n in gate.noise_by_control.items()
         },
+        "nothing_measured": gate.nothing_measured,
         "trustworthy": gate.trustworthy,
         "regressions": gate.regressions,
         "improvements": gate.improvements,
@@ -273,8 +294,13 @@ def _comparison_dict(c: stats.PairedComparison) -> dict[str, object]:
         "ratio": _jsonable(c.ratio),
         "ci_low": _jsonable(c.ci_low),
         "ci_high": _jsonable(c.ci_high),
+        # `p_value`/`p_adjusted` retain their historical meaning: the
+        # one-sided "b is slower than a" tail. The faster tail is separate so
+        # consumers never have to reverse an adjusted upper-tail probability.
         "p_value": _jsonable(c.p_value),
         "p_adjusted": _jsonable(c.p_adjusted),
+        "p_value_faster": _jsonable(c.p_value_faster),
+        "p_adjusted_faster": _jsonable(c.p_adjusted_faster),
         "verdict": str(c.verdict),
         "note": c.note,
     }
@@ -295,6 +321,13 @@ def write_json(
 ) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(to_dict(recorder, config, gate), indent=2))
+    return path
+
+
+def write_markdown(path: Path, text: str) -> Path:
+    """Write a summary template for CI to publish after artifact upload."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
     return path
 
 
@@ -347,41 +380,88 @@ def underpowered_warning(
 
 
 def markdown(
-    recorder: BenchmarkRecorder, config: BenchConfig, gate: stats.GateResult
+    recorder: BenchmarkRecorder,
+    config: BenchConfig,
+    gate: stats.GateResult,
+    *,
+    artifact_url: str = "",
 ) -> str:
-    """Render the run as a GitHub step summary."""
-    threshold_pct = (config.threshold - 1) * 100
+    """Render a decision-first GitHub job summary with progressive disclosure."""
+    rows = _report_rows(recorder, config, gate)
+    gated_rows = [r for r in rows if r.gated]
+    attention = [
+        r
+        for r in gated_rows
+        if r.comparison.verdict
+        in (
+            stats.Verdict.REGRESSION,
+            stats.Verdict.INCONCLUSIVE,
+            stats.Verdict.IMPROVED,
+        )
+    ]
+    attention.sort(key=_attention_sort_key)
+    sdk = next((r.sdk for r in recorder.results if r.sdk), "SDK")
+    status, headline = _headline(gate, gated_rows)
     n_arms = max((len(r.arm_ids) for r in recorder.results), default=2)
+
     lines = [
-        "## SDK performance regression benchmark",
+        f"## {sdk.upper()} SDK performance — {status}",
         "",
-        f"Paired {n_arms}-arm comparison, all arms in the same rounds on one "
-        f"runner. A contrast against the reference fails only if the 95% CI "
-        f"lower bound exceeds **{config.threshold:.2f}x** (+{threshold_pct:.0f}%) "
-        f"*and* the BH-adjusted p < {stats.DEFAULT_ALPHA}.",
+        "### TL;DR",
         "",
-        f"**{gate.summary}**",
+        f"> **{headline}**",
+        ">",
+        f"> {gate.summary}",
         "",
     ]
+    lines += _quick_links(recorder.metadata, artifact_url)
+    lines += _provenance(recorder)
 
     warning = underpowered_warning(recorder, config, gate)
     if warning:
         lines += ["> [!WARNING]", f"> {warning}", ""]
-
     noise = gate.noise
     if noise is not None and noise.detail:
         lines += [f"> {noise.detail}", ""]
-    elif noise is not None and math.isfinite(noise.width_ratio):
+
+    lines += ["### What changed", ""]
+    if attention:
         lines += [
-            f"A/A noise floor: +/-{(noise.width_ratio - 1) * 100:.1f}% "
-            f"(the smallest effect this run could resolve).",
+            "Only gated regressions, unresolved measurements, and confirmed "
+            "improvements are shown here. Clean rows and diagnostic metrics are below.",
+            "",
+            "| measurement | contrast | observed cost | change (95% CI) | gate margin | result |",
+            "| --- | --- | --- | --- | ---: | --- |",
+        ]
+        for row in attention:
+            c = row.comparison
+            lines.append(
+                f"| {_cell_label(row.result)} · {METRIC_LABELS[row.metric][0]} "
+                f"| `{row.b}` vs `{row.a}` | {_cost_change(row.metric, c)} "
+                f"| {_percent_change(c)} | {_gate_margin(c, config.threshold)} "
+                f"| {_verdict_cell(c)} |"
+            )
+        lines += _effect_overview(attention, config.threshold)
+    else:
+        lines += [
+            "No gated comparison requires attention: every measured wall-clock and "
+            "RSS contrast passed with enough precision.",
             "",
         ]
 
-    lines += [
-        "| cell | contrast | metric | a | b | ratio (95% CI) | p (BH) | n | verdict |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
-    ]
+    lines += _bake_off_section(recorder, config, gate)
+    lines += _diagnostics(recorder, attention, config)
+    lines += _full_measurements(rows)
+    lines += _not_measured(recorder)
+    lines += _method(config, n_arms)
+    lines += _run_facts(recorder, config, gate, artifact_url)
+    return "\n".join(lines) + "\n"
+
+
+def _report_rows(
+    recorder: BenchmarkRecorder, config: BenchConfig, gate: stats.GateResult
+) -> list[ReportRow]:
+    rows: list[ReportRow] = []
     for result in recorder.results:
         for a, b in result.contrast_pairs():
             head_to_head = result.reference not in (a, b)
@@ -389,49 +469,441 @@ def markdown(
                 c = gate.comparisons.get(contrast_key(result.cell_id, a, b, metric))
                 if c is None:
                     continue
-                gated = (
-                    metric in config.gated_metrics
-                    and not result.control
-                    and not head_to_head
+                rows.append(
+                    ReportRow(
+                        result=result,
+                        a=a,
+                        b=b,
+                        metric=metric,
+                        comparison=c,
+                        gated=(
+                            metric in config.gated_metrics
+                            and not result.control
+                            and not head_to_head
+                        ),
+                        head_to_head=head_to_head,
+                    )
                 )
-                label = METRIC_LABELS[metric][0] + ("" if gated else " (ungated)")
-                lines.append(
-                    f"| {result.cell_id} | `{b}` vs `{a}` | {label} "
-                    f"| {format_metric(metric, c.baseline_median)} "
-                    f"| {format_metric(metric, c.candidate_median)} "
-                    f"| {_ratio_cell(c)} | {_p_cell(c)} | {c.n_rounds} "
-                    f"| {_verdict_cell(c)} |"
-                )
+    return rows
 
-    rankings = bake_offs(recorder, config, gate)
-    if rankings:
-        lines += [
-            "",
-            "### Bake-off",
-            "",
-            "Head-to-head between candidates, measured in the same rounds as "
-            "everything else. Ranking only -- these contrasts never fail the "
-            "build.",
-            "",
-        ]
-        for bo in rankings:
-            order = " < ".join(f"`{a}`" for a in bo.order)
-            lines.append(
-                f"- **{bo.cell_id}** ({METRIC_LABELS[bo.metric][0]}): "
-                f"{order} -- {bo.detail}"
-            )
 
-    if recorder.skipped:
-        lines += ["", "### Not measured", ""]
-        lines += [f"- `{cid}`: {why}" for cid, why in sorted(recorder.skipped.items())]
+def _headline(gate: stats.GateResult, gated_rows: list[ReportRow]) -> tuple[str, str]:
+    inconclusive = sum(
+        r.comparison.verdict is stats.Verdict.INCONCLUSIVE for r in gated_rows
+    )
+    improvements = sum(
+        r.comparison.verdict is stats.Verdict.IMPROVED for r in gated_rows
+    )
+    if gate.nothing_measured:
+        return "NOTHING MEASURED", "The benchmark produced no comparisons."
+    if not gate.trustworthy:
+        return (
+            "UNTRUSTWORTHY",
+            "The A/A control detected bias; results are visible but cannot fail the build.",
+        )
+    if gate.regressions:
+        return (
+            "REGRESSION",
+            f"{len(gate.regressions)} confirmed regression(s); "
+            f"{inconclusive} unresolved and {improvements} improved gated comparison(s).",
+        )
+    if inconclusive:
+        return (
+            "INCONCLUSIVE",
+            f"No confirmed regressions, but {inconclusive} gated comparison(s) "
+            "could not be resolved.",
+        )
+    return (
+        "PASS",
+        f"No confirmed regressions; {improvements} gated comparison(s) improved.",
+    )
 
-    lines += [
+
+def _quick_links(metadata: Mapping[str, object], artifact_url: str) -> list[str]:
+    links: list[str] = []
+    if artifact_url:
+        links.append(f"[Download raw samples and HTML report]({artifact_url})")
+    run_url = str(metadata.get("github_run_url", ""))
+    if run_url:
+        links.append(f"[Workflow run]({run_url})")
+    return [" · ".join(links), ""] if links else []
+
+
+def _provenance(recorder: BenchmarkRecorder) -> list[str]:
+    result = next((r for r in recorder.results if not r.control), None)
+    if result is None:
+        result = next(iter(recorder.results), None)
+    if result is None:
+        return []
+
+    raw_sources = recorder.metadata.get("arm_sources", [])
+    sources = (
+        {
+            str(s.get("tag", "")): s
+            for s in raw_sources
+            if isinstance(s, dict) and s.get("tag")
+        }
+        if isinstance(raw_sources, list)
+        else {}
+    )
+    lines = [
+        "### Compared builds",
         "",
-        f"<sub>seed {config.seed}; warm-up {config.warmup} rounds; "
-        f"{config.min_rounds}-{config.max_rounds} measured rounds per cell; "
-        "stopping on attained CI width, never on significance.</sub>",
+        "| arm | role | source | commit | compare to reference |",
+        "| --- | --- | --- | --- | --- |",
     ]
-    return "\n".join(lines) + "\n"
+    reference_source = sources.get(result.reference)
+    for arm in result.arm_ids:
+        source = sources.get(arm)
+        role = "**reference**" if arm == result.reference else "candidate"
+        label = result.arm_labels.get(arm, arm)
+        source_link = _source_link(source, label)
+        commit_link = _commit_link(source)
+        compare_link = (
+            "—" if arm == result.reference else _compare_link(reference_source, source)
+        )
+        lines.append(
+            f"| `{_md(arm)}` | {role} | {source_link} | {commit_link} | {compare_link} |"
+        )
+    lines.append("")
+    warning = recorder.metadata.get("arm_sources_warning")
+    if warning:
+        lines += [f"> Provenance unavailable: {_md(str(warning))}", ""]
+    return lines
+
+
+def _source_link(source: object, fallback: str) -> str:
+    if not isinstance(source, dict):
+        return _md(fallback)
+    repo = str(source.get("repo_url", ""))
+    tag = str(source.get("tag", fallback))
+    alias = str(source.get("alias", tag))
+    pr = str(source.get("pr", ""))
+    release = str(source.get("release", ""))
+    sha = str(source.get("sha", ""))
+    if repo and pr:
+        return f"[PR #{_md(pr)}]({repo}/pull/{quote(pr, safe='')}) · `{_md(tag)}`"
+    if repo and release:
+        return f"[{_md(tag)}]({repo}/releases/tag/{quote(release, safe='')}) · release"
+    if repo and sha:
+        kind = "branch" if source.get("head") else "commit"
+        return f"[{_md(alias)}]({repo}/tree/{quote(sha, safe='')}) · {kind}"
+    return _md(fallback)
+
+
+def _commit_link(source: object) -> str:
+    if not isinstance(source, dict):
+        return "—"
+    repo = str(source.get("repo_url", ""))
+    sha = str(source.get("sha", ""))
+    if not (repo and sha):
+        return "—"
+    return f"[`{_md(sha[:7])}`]({repo}/commit/{quote(sha, safe='')})"
+
+
+def _compare_link(reference: object, candidate: object) -> str:
+    if not (isinstance(reference, dict) and isinstance(candidate, dict)):
+        return "—"
+    repo = str(reference.get("repo_url", ""))
+    if not repo or repo != str(candidate.get("repo_url", "")):
+        return "—"
+    a, b = str(reference.get("sha", "")), str(candidate.get("sha", ""))
+    if not (a and b):
+        return "—"
+    return f"[diff]({repo}/compare/{quote(a, safe='')}...{quote(b, safe='')})"
+
+
+def _md(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def _attention_sort_key(row: ReportRow) -> tuple[int, float, str, int]:
+    order = {
+        stats.Verdict.REGRESSION: 0,
+        stats.Verdict.INCONCLUSIVE: 1,
+        stats.Verdict.IMPROVED: 2,
+    }
+    ratio = row.comparison.ratio
+    magnitude = abs(math.log(ratio)) if math.isfinite(ratio) and ratio > 0 else 0
+    return (
+        order.get(row.comparison.verdict, 3),
+        -round(magnitude, 3),
+        row.result.cell_id,
+        METRICS.index(row.metric),
+    )
+
+
+def _cell_label(result: CellResult) -> str:
+    return result.cell_id.removeprefix(f"{result.sdk}-").replace("-", " / ")
+
+
+def _cost_change(metric: str, c: stats.PairedComparison) -> str:
+    if not (math.isfinite(c.baseline_median) and math.isfinite(c.candidate_median)):
+        return "—"
+    delta = c.candidate_median - c.baseline_median
+    sign = "+" if delta >= 0 else "−"
+    return (
+        f"{format_metric(metric, c.baseline_median)} → "
+        f"{format_metric(metric, c.candidate_median)} "
+        f"({sign}{format_metric(metric, abs(delta))})"
+    )
+
+
+def _pct(ratio: float) -> str:
+    if not math.isfinite(ratio):
+        return "—"
+    return f"{(ratio - 1) * 100:+.1f}%"
+
+
+def _percent_change(c: stats.PairedComparison) -> str:
+    point = _pct(c.ratio)
+    if not (math.isfinite(c.ci_low) and math.isfinite(c.ci_high)):
+        return point
+    return f"{point} [{_pct(c.ci_low)}, {_pct(c.ci_high)}]"
+
+
+def _gate_margin(c: stats.PairedComparison, threshold: float) -> str:
+    if c.verdict is stats.Verdict.REGRESSION and math.isfinite(c.ci_low):
+        return f"+{(c.ci_low - threshold) * 100:.1f} pp"
+    if c.verdict is stats.Verdict.IMPROVED and math.isfinite(c.ci_high):
+        return f"+{(1 / threshold - c.ci_high) * 100:.1f} pp"
+    return "—"
+
+
+def _effect_overview(rows: list[ReportRow], threshold: float) -> list[str]:
+    labels = [f"{_cell_label(r.result)} {METRIC_LABELS[r.metric][0]}" for r in rows]
+    label_width = min(30, max(map(len, labels), default=0))
+    width = 57
+    axis = [" "] * width
+    for text, start in (
+        ("← faster", 0),
+        ("no change", (width - len("no change")) // 2),
+        ("slower →", width - len("slower →")),
+    ):
+        axis[start : start + len(text)] = text
+    lines = [
+        "",
+        "#### Effect at a glance",
+        "",
+        "Fixed log-ratio scale; `┆` marks ±the practical threshold and `│` no change.",
+        "",
+        "```text",
+        f"{'measurement':<{label_width}}  {''.join(axis)}",
+    ]
+    for label, row in zip(labels, rows, strict=True):
+        lines.append(
+            f"{label[:label_width]:<{label_width}}  "
+            f"{_effect_strip(row.comparison, threshold, width=width)} "
+            f"{_pct(row.comparison.ratio):>7} {row.comparison.verdict}"
+        )
+    lines += ["```", ""]
+    return lines
+
+
+def _effect_strip(
+    c: stats.PairedComparison, threshold: float, *, width: int = 57
+) -> str:
+    """A fixed-width CI forest strip on a symmetric log-ratio scale."""
+    chars = [" "] * width
+    # Show three threshold-widths in each direction. That keeps the practical
+    # boundary near the center while leaving enough room to draw the interval
+    # of an ordinary 20–40% regression instead of collapsing it to an arrow.
+    span = 3 * math.log(threshold)
+
+    def pos(ratio: float) -> int:
+        value = math.log(ratio) if math.isfinite(ratio) and ratio > 0 else 0.0
+        unit = max(-1.0, min(1.0, value / span))
+        return round((unit + 1) * (width - 1) / 2)
+
+    for ratio, marker in ((1 / threshold, "┆"), (1.0, "│"), (threshold, "┆")):
+        chars[pos(ratio)] = marker
+    if math.isfinite(c.ci_low) and math.isfinite(c.ci_high):
+        lo, hi = sorted((pos(c.ci_low), pos(c.ci_high)))
+        for i in range(lo, hi + 1):
+            if chars[i] == " ":
+                chars[i] = "━"
+        chars[lo], chars[hi] = "[", "]"
+    if math.isfinite(c.ratio) and c.ratio > 0:
+        chars[pos(c.ratio)] = "●"
+        if math.log(c.ratio) < -span:
+            chars[0] = "◀"
+        elif math.log(c.ratio) > span:
+            chars[-1] = "▶"
+    return "".join(chars)
+
+
+def _bake_off_section(
+    recorder: BenchmarkRecorder, config: BenchConfig, gate: stats.GateResult
+) -> list[str]:
+    rankings = bake_offs(recorder, config, gate)
+    if not rankings:
+        return []
+    lines = [
+        "### Bake-off",
+        "",
+        "Candidate-to-candidate ranking only; these contrasts never fail the build.",
+        "",
+    ]
+    for bo in rankings:
+        order = " < ".join(f"`{a}`" for a in bo.order)
+        lines.append(
+            f"- **{_cell_label(next(r for r in recorder.results if r.cell_id == bo.cell_id))}** "
+            f"({METRIC_LABELS[bo.metric][0]}): {order} — {bo.detail}"
+        )
+    return lines + [""]
+
+
+def _diagnostics(
+    recorder: BenchmarkRecorder,
+    attention: list[ReportRow],
+    config: BenchConfig,
+) -> list[str]:
+    if not attention:
+        return []
+    lines = [
+        "<details>",
+        "<summary><strong>Round stability for attention rows</strong></summary>",
+        "",
+        "Each Braille glyph carries two rounds at four vertical levels. The scale "
+        "is centered on 1.0 and is never tighter than the practical threshold.",
+        "",
+        "```text",
+    ]
+    for row in attention:
+        values = _paired_ratios(row)
+        if not values:
+            continue
+        slower = sum(v > 1 for v in values)
+        label = f"{_cell_label(row.result)} {METRIC_LABELS[row.metric][0]}"
+        lines.append(
+            f"{label[:28]:<28} {_braille_sparkline(values, config.threshold):<24} "
+            f"{slower}/{len(values)} rounds slower; median {_pct(statistics.median(values))}"
+        )
+    lines += ["```", "", "</details>", ""]
+    return lines
+
+
+def _paired_ratios(row: ReportRow) -> list[float]:
+    baseline = row.result.samples.get(row.a, {}).get(row.metric, [])
+    candidate = row.result.samples.get(row.b, {}).get(row.metric, [])
+    return [c / b for b, c in zip(baseline, candidate, strict=True) if b > 0 and c > 0]
+
+
+def _braille_sparkline(
+    values: Iterable[float], threshold: float, *, max_chars: int = 24
+) -> str:
+    """Render positive ratios as a compact two-samples-per-glyph trace."""
+    logs = [math.log(v) for v in values if math.isfinite(v) and v > 0]
+    if not logs:
+        return "—"
+    limit = max_chars * 2
+    if len(logs) > limit:
+        # Median bins retain the robust character of the reported estimator.
+        logs = [
+            statistics.median(
+                logs[round(i * len(logs) / limit) : round((i + 1) * len(logs) / limit)]
+            )
+            for i in range(limit)
+        ]
+    span = max(math.log(threshold), max(abs(v) for v in logs), 1e-12)
+    dot_bits = ((0, 1, 2, 6), (3, 4, 5, 7))
+    glyphs: list[str] = []
+    for i in range(0, len(logs), 2):
+        bits = 0
+        for column, value in enumerate(logs[i : i + 2]):
+            # Braille rows run top to bottom; positive/slower belongs at top.
+            row = round((span - value) / (2 * span) * 3)
+            row = max(0, min(3, row))
+            bits |= 1 << dot_bits[column][row]
+        glyphs.append(chr(0x2800 + bits))
+    return "".join(glyphs)
+
+
+def _full_measurements(rows: list[ReportRow]) -> list[str]:
+    lines = [
+        "<details>",
+        "<summary><strong>All measurements, controls, and statistical details</strong></summary>",
+        "",
+        "| cell | contrast | metric | a | b | ratio (95% CI) | p (BH) | n | verdict |",
+        "| --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
+    ]
+    for row in rows:
+        c = row.comparison
+        label = METRIC_LABELS[row.metric][0] + ("" if row.gated else " (ungated)")
+        lines.append(
+            f"| {row.result.cell_id} | `{row.b}` vs `{row.a}` | {label} "
+            f"| {format_metric(row.metric, c.baseline_median)} "
+            f"| {format_metric(row.metric, c.candidate_median)} "
+            f"| {_ratio_cell(c)} | {_p_cell(c)} | {c.n_rounds} "
+            f"| {_verdict_cell(c)} |"
+        )
+    return lines + ["", "</details>", ""]
+
+
+def _not_measured(recorder: BenchmarkRecorder) -> list[str]:
+    if not recorder.skipped:
+        return []
+    lines = [
+        "<details open>",
+        "<summary><strong>Not measured</strong></summary>",
+        "",
+    ]
+    lines += [f"- `{cid}`: {why}" for cid, why in sorted(recorder.skipped.items())]
+    return lines + ["", "</details>", ""]
+
+
+def _method(config: BenchConfig, n_arms: int) -> list[str]:
+    threshold_pct = (config.threshold - 1) * 100
+    return [
+        "<details>",
+        "<summary><strong>How to read this gate</strong></summary>",
+        "",
+        f"This is a paired {n_arms}-arm comparison: every arm ran in the same "
+        "randomized rounds on one runner. A reference contrast regresses only "
+        f"when its 95% CI is wholly beyond +{threshold_pct:.0f}% "
+        f"and its directional BH-adjusted p-value is below {stats.DEFAULT_ALPHA}. "
+        "The loop stops on attained interval width, never significance.",
+        "",
+        "PASS means the run was precise enough to have found an effect at the "
+        "threshold; INCONCLUSIVE does not mean no change.",
+        "",
+        "</details>",
+        "",
+    ]
+
+
+def _run_facts(
+    recorder: BenchmarkRecorder,
+    config: BenchConfig,
+    gate: stats.GateResult,
+    artifact_url: str,
+) -> list[str]:
+    rounds = [r.n_rounds for r in recorder.results if not r.control]
+    elapsed = sum(r.elapsed_s for r in recorder.results)
+    noise = gate.noise
+    noise_text = (
+        f"±{(noise.width_ratio - 1) * 100:.1f}%"
+        if noise is not None and math.isfinite(noise.width_ratio)
+        else "unavailable"
+    )
+    metadata = recorder.metadata
+    artifact = f"[JSON + HTML]({artifact_url})" if artifact_url else "local output"
+    round_text = f"{min(rounds)}–{max(rounds)}" if rounds else "0"
+    return [
+        "### Run facts",
+        "",
+        "| result cells | rounds/cell | elapsed | A/A noise | platform | runner | evidence |",
+        "| ---: | ---: | ---: | ---: | --- | --- | --- |",
+        f"| {sum(not r.control for r in recorder.results)} "
+        f"| {round_text} | {elapsed:.0f}s | {noise_text} "
+        f"| {_md(str(metadata.get('platform_version', 'unknown')))} "
+        f"| {_md(str(metadata.get('runner_os') or metadata.get('platform', 'unknown')))} "
+        f"| {artifact} |",
+        "",
+        f"<sub>seed {config.seed}; {config.warmup} warm-up rounds; "
+        f"{config.min_rounds}–{config.max_rounds} measured rounds allowed; "
+        f"{len(recorder.skipped)} cells skipped.</sub>",
+    ]
 
 
 def _ratio_cell(c: stats.PairedComparison) -> str:
@@ -443,7 +915,13 @@ def _ratio_cell(c: stats.PairedComparison) -> str:
 
 
 def _p_cell(c: stats.PairedComparison) -> str:
-    p = c.p_adjusted if c.p_adjusted is not None else c.p_value
+    # Show the one-sided tail matching the observed effect. For a ratio below
+    # one that is the explicit faster-tail test; adjusted upper-tail p-values
+    # cannot be interpreted backwards after BH correction.
+    if c.ratio < 1:
+        p = c.p_adjusted_faster if c.p_adjusted_faster is not None else c.p_value_faster
+    else:
+        p = c.p_adjusted if c.p_adjusted is not None else c.p_value
     if p is None or not math.isfinite(p):
         return "-"
     return f"{p:.3f}" if p >= 0.001 else "<0.001"

--- a/xtest/perf/report.py
+++ b/xtest/perf/report.py
@@ -555,7 +555,8 @@ def _provenance(recorder: BenchmarkRecorder) -> list[str]:
     reference_source = sources.get(result.reference)
     for arm in result.arm_ids:
         source = sources.get(arm)
-        role = "**reference**" if arm == result.reference else "candidate"
+        role_name = _arm_role(result, arm)
+        role = f"**{role_name}**" if arm == result.reference else role_name
         label = result.arm_labels.get(arm, arm)
         source_link = _source_link(source, label)
         commit_link = _commit_link(source)
@@ -637,6 +638,19 @@ def _cell_label(result: CellResult) -> str:
     return result.cell_id.removeprefix(f"{result.sdk}-").replace("-", " / ")
 
 
+def _arm_role(result: CellResult, arm: str) -> str:
+    """A short, stable role that maps plot rows back to the build table."""
+    if arm == result.reference:
+        return "reference"
+    candidates = [
+        candidate for candidate in result.arm_ids if candidate != result.reference
+    ]
+    try:
+        return f"candidate {chr(ord('A') + candidates.index(arm))}"
+    except ValueError:
+        return arm
+
+
 def _cost_change(metric: str, c: stats.PairedComparison) -> str:
     if not (math.isfinite(c.baseline_median) and math.isfinite(c.candidate_median)):
         return "—"
@@ -672,8 +686,26 @@ def _gate_margin(c: stats.PairedComparison, threshold: float) -> str:
 
 def _effect_overview(rows: list[ReportRow], threshold: float) -> list[str]:
     labels = [f"{_cell_label(r.result)} {METRIC_LABELS[r.metric][0]}" for r in rows]
+    roles = [_arm_role(row.result, row.b) for row in rows]
     label_width = min(30, max(map(len, labels), default=0))
+    role_width = max(map(len, roles), default=0)
     width = 57
+    threshold_log = math.log(threshold)
+    observed_logs = [
+        abs(math.log(value))
+        for row in rows
+        for value in (
+            row.comparison.ratio,
+            row.comparison.ci_low,
+            row.comparison.ci_high,
+        )
+        if math.isfinite(value) and value > 0
+    ]
+    # Preserve room around the practical band, but expand far enough that the
+    # largest interval gets brackets rather than an off-scale arrow. The tail
+    # transform in `_effect_strip` prevents an epic result from squeezing the
+    # gate markers and every merely-large result into the center character.
+    span = max(3 * threshold_log, max(observed_logs, default=0) * 1.05)
     axis = [" "] * width
     for text, start in (
         ("← faster", 0),
@@ -685,15 +717,18 @@ def _effect_overview(rows: list[ReportRow], threshold: float) -> list[str]:
         "",
         "#### Effect at a glance",
         "",
-        "Fixed log-ratio scale; `┆` marks ±the practical threshold and `│` no change.",
+        "Shared tail-compressed log-ratio scale; `┆` marks ±the practical "
+        "threshold and `│` no change. Candidate letters match the build table; "
+        "exact changes are printed at right, and `◆` means the CI is narrower "
+        "than one character.",
         "",
         "```text",
-        f"{'measurement':<{label_width}}  {''.join(axis)}",
+        f"{'arm':<{role_width}}  {'measurement':<{label_width}}  {''.join(axis)}",
     ]
-    for label, row in zip(labels, rows, strict=True):
+    for role, label, row in zip(roles, labels, rows, strict=True):
         lines.append(
-            f"{label[:label_width]:<{label_width}}  "
-            f"{_effect_strip(row.comparison, threshold, width=width)} "
+            f"{role:<{role_width}}  {label[:label_width]:<{label_width}}  "
+            f"{_effect_strip(row.comparison, threshold, width=width, span=span)} "
             f"{_pct(row.comparison.ratio):>7} {row.comparison.verdict}"
         )
     lines += ["```", ""]
@@ -701,30 +736,53 @@ def _effect_overview(rows: list[ReportRow], threshold: float) -> list[str]:
 
 
 def _effect_strip(
-    c: stats.PairedComparison, threshold: float, *, width: int = 57
+    c: stats.PairedComparison,
+    threshold: float,
+    *,
+    width: int = 57,
+    span: float | None = None,
 ) -> str:
-    """A fixed-width CI forest strip on a symmetric log-ratio scale."""
+    """A fixed-width CI forest strip on a symmetric compressed-log scale."""
     chars = [" "] * width
-    # Show three threshold-widths in each direction. That keeps the practical
-    # boundary near the center while leaving enough room to draw the interval
-    # of an ordinary 20–40% regression instead of collapsing it to an arrow.
-    span = 3 * math.log(threshold)
+    threshold_log = math.log(threshold)
+    span = span or 3 * threshold_log
+
+    def unit(value: float) -> float:
+        """Keep the gate at 1/3 width and compress the dynamic tails."""
+        magnitude = abs(value)
+        if magnitude <= threshold_log:
+            scaled = magnitude / threshold_log / 3
+        else:
+            tail = max(span - threshold_log, 1e-12)
+            # Keep ten percent of either edge as breathing room: the largest
+            # observed effect should look extreme without masquerading as a
+            # clipped value.
+            scaled = 1 / 3 + (0.9 - 1 / 3) * (
+                math.log1p((magnitude - threshold_log) / threshold_log)
+                / math.log1p(tail / threshold_log)
+            )
+        return math.copysign(max(-1.0, min(1.0, scaled)), value)
 
     def pos(ratio: float) -> int:
         value = math.log(ratio) if math.isfinite(ratio) and ratio > 0 else 0.0
-        unit = max(-1.0, min(1.0, value / span))
-        return round((unit + 1) * (width - 1) / 2)
+        return round((unit(value) + 1) * (width - 1) / 2)
 
     for ratio, marker in ((1 / threshold, "┆"), (1.0, "│"), (threshold, "┆")):
         chars[pos(ratio)] = marker
+    collapsed_ci_at: int | None = None
     if math.isfinite(c.ci_low) and math.isfinite(c.ci_high):
         lo, hi = sorted((pos(c.ci_low), pos(c.ci_high)))
-        for i in range(lo, hi + 1):
-            if chars[i] == " ":
-                chars[i] = "━"
-        chars[lo], chars[hi] = "[", "]"
+        if lo == hi:
+            collapsed_ci_at = lo
+            chars[lo] = "◆"
+        else:
+            for i in range(lo, hi + 1):
+                if chars[i] == " ":
+                    chars[i] = "━"
+            chars[lo], chars[hi] = "[", "]"
     if math.isfinite(c.ratio) and c.ratio > 0:
-        chars[pos(c.ratio)] = "●"
+        point = pos(c.ratio)
+        chars[point] = "◆" if point == collapsed_ci_at else "●"
         if math.log(c.ratio) < -span:
             chars[0] = "◀"
         elif math.log(c.ratio) > span:

--- a/xtest/perf/report.py
+++ b/xtest/perf/report.py
@@ -400,9 +400,18 @@ def markdown(
         )
     ]
     attention.sort(key=_attention_sort_key)
-    sdk = next((r.sdk for r in recorder.results if r.sdk), "SDK")
-    status, headline = _headline(gate, gated_rows)
+    sdk = next(
+        (r.sdk for r in recorder.results if r.sdk),
+        str(recorder.metadata.get("sdk") or "SDK"),
+    )
+    equivalent = same_commit(recorder.metadata)
+    status, headline = _headline(gate, gated_rows, recorder.metadata)
     n_arms = max((len(r.arm_ids) for r in recorder.results), default=2)
+    summary = (
+        str(recorder.metadata.get("comparison_note", gate.summary))
+        if equivalent
+        else gate.summary
+    )
 
     lines = [
         f"## {sdk.upper()} SDK performance — {status}",
@@ -411,7 +420,7 @@ def markdown(
         "",
         f"> **{headline}**",
         ">",
-        f"> {gate.summary}",
+        f"> {summary}",
         "",
     ]
     lines += _quick_links(recorder.metadata, artifact_url)
@@ -421,11 +430,17 @@ def markdown(
     if warning:
         lines += ["> [!WARNING]", f"> {warning}", ""]
     noise = gate.noise
-    if noise is not None and noise.detail:
+    if noise is not None and noise.detail and not equivalent:
         lines += [f"> {noise.detail}", ""]
 
     lines += ["### What changed", ""]
-    if attention:
+    if equivalent:
+        lines += [
+            "No performance comparison was necessary: the requested refs identify "
+            "the same source commit.",
+            "",
+        ]
+    elif attention:
         lines += [
             "Only gated regressions, unresolved measurements, and confirmed "
             "improvements are shown here. Clean rows and diagnostic metrics are below.",
@@ -442,6 +457,12 @@ def markdown(
                 f"| {_verdict_cell(c)} |"
             )
         lines += _effect_overview(attention, config.threshold)
+    elif gate.nothing_measured:
+        lines += [
+            "No comparison ran. Expand **Not measured** below for the cell-level "
+            "reasons; this is not a passing performance result.",
+            "",
+        ]
     else:
         lines += [
             "No gated comparison requires attention: every measured wall-clock and "
@@ -451,9 +472,10 @@ def markdown(
 
     lines += _bake_off_section(recorder, config, gate)
     lines += _diagnostics(recorder, attention, config)
-    lines += _full_measurements(rows)
+    lines += _full_measurements(rows, recorder.metadata)
     lines += _not_measured(recorder)
-    lines += _method(config, n_arms)
+    if not equivalent:
+        lines += _method(config, n_arms)
     lines += _run_facts(recorder, config, gate, artifact_url)
     return "\n".join(lines) + "\n"
 
@@ -487,13 +509,24 @@ def _report_rows(
     return rows
 
 
-def _headline(gate: stats.GateResult, gated_rows: list[ReportRow]) -> tuple[str, str]:
+def same_commit(metadata: Mapping[str, object]) -> bool:
+    """Whether multiple requested names resolved to one immutable commit."""
+    return metadata.get("comparison_status") == "same_commit"
+
+
+def _headline(
+    gate: stats.GateResult,
+    gated_rows: list[ReportRow],
+    metadata: Mapping[str, object],
+) -> tuple[str, str]:
     inconclusive = sum(
         r.comparison.verdict is stats.Verdict.INCONCLUSIVE for r in gated_rows
     )
     improvements = sum(
         r.comparison.verdict is stats.Verdict.IMPROVED for r in gated_rows
     )
+    if same_commit(metadata):
+        return "SAME COMMIT", "No code difference to benchmark."
     if gate.nothing_measured:
         return "NOTHING MEASURED", "The benchmark produced no comparisons."
     if not gate.trustworthy:
@@ -533,25 +566,29 @@ def _provenance(recorder: BenchmarkRecorder) -> list[str]:
     result = next((r for r in recorder.results if not r.control), None)
     if result is None:
         result = next(iter(recorder.results), None)
-    if result is None:
-        return []
-
-    raw_sources = recorder.metadata.get("arm_sources", [])
-    sources = (
-        {
-            str(s.get("tag", "")): s
-            for s in raw_sources
-            if isinstance(s, dict) and s.get("tag")
-        }
-        if isinstance(raw_sources, list)
-        else {}
-    )
+    sources = _sources_by_tag(recorder.metadata)
     lines = [
         "### Compared builds",
         "",
         "| arm | role | source | commit | compare to reference |",
         "| --- | --- | --- | --- | --- |",
     ]
+    if result is None:
+        if not (same_commit(recorder.metadata) and sources):
+            return []
+        source = next(iter(sources.values()))
+        requested = recorder.metadata.get("requested_refs", [])
+        arms = [str(arm) for arm in requested] if isinstance(requested, list) else []
+        for index, arm in enumerate(arms):
+            resolution = (
+                _source_link(source, arm) if index == 0 else "same resolved source"
+            )
+            lines.append(
+                f"| {_linked_arm(arm, sources, fallback_source=source)} "
+                f"| **same commit** | {resolution} | {_commit_link(source)} | — |"
+            )
+        return lines + [""]
+
     reference_source = sources.get(result.reference)
     for arm in result.arm_ids:
         source = sources.get(arm)
@@ -564,13 +601,57 @@ def _provenance(recorder: BenchmarkRecorder) -> list[str]:
             "—" if arm == result.reference else _compare_link(reference_source, source)
         )
         lines.append(
-            f"| `{_md(arm)}` | {role} | {source_link} | {commit_link} | {compare_link} |"
+            f"| {_linked_arm(arm, sources)} | {role} | {source_link} "
+            f"| {commit_link} | {compare_link} |"
         )
     lines.append("")
     warning = recorder.metadata.get("arm_sources_warning")
     if warning:
         lines += [f"> Provenance unavailable: {_md(str(warning))}", ""]
     return lines
+
+
+def _sources_by_tag(metadata: Mapping[str, object]) -> dict[str, dict[str, object]]:
+    raw_sources = metadata.get("arm_sources", [])
+    if not isinstance(raw_sources, list):
+        return {}
+    sources: dict[str, dict[str, object]] = {}
+    for source in raw_sources:
+        if not isinstance(source, dict) or not source.get("tag"):
+            continue
+        normalized = {str(key): value for key, value in source.items()}
+        sources[str(normalized["tag"])] = normalized
+    return sources
+
+
+def _source_url(source: object) -> str:
+    if not isinstance(source, dict):
+        return ""
+    repo = str(source.get("repo_url", ""))
+    pr = str(source.get("pr", ""))
+    release = str(source.get("release", ""))
+    sha = str(source.get("sha", ""))
+    if repo and pr:
+        return f"{repo}/pull/{quote(pr, safe='')}"
+    if repo and release:
+        return f"{repo}/releases/tag/{quote(release, safe='')}"
+    if repo and sha:
+        return f"{repo}/tree/{quote(sha, safe='')}"
+    return ""
+
+
+def _linked_arm(
+    arm: str,
+    sources: Mapping[str, object],
+    *,
+    fallback_source: object = None,
+) -> str:
+    base, separator, copy = arm.partition("#")
+    label = f"{base} copy {copy}" if separator else arm
+    source = sources.get(base, fallback_source)
+    url = _source_url(source)
+    code = f"`{_md(label)}`"
+    return f"[{code}]({url})" if url else code
 
 
 def _source_link(source: object, fallback: str) -> str:
@@ -877,19 +958,44 @@ def _braille_sparkline(
     return "".join(glyphs)
 
 
-def _full_measurements(rows: list[ReportRow]) -> list[str]:
+def _full_measurements(
+    rows: list[ReportRow], metadata: Mapping[str, object]
+) -> list[str]:
+    if not rows:
+        return []
+    sources = _sources_by_tag(metadata)
     lines = [
         "<details>",
         "<summary><strong>All measurements, controls, and statistical details</strong></summary>",
         "",
-        "| cell | contrast | metric | a | b | ratio (95% CI) | p (BH) | n | verdict |",
+    ]
+    if any(row.result.control for row in rows):
+        lines += [
+            "**A/A control** rows intentionally run multiple copies of the reference "
+            "build against itself on a fixed 1 MiB encrypt operation. They measure "
+            "runner noise; they are not candidate comparisons.",
+            "",
+        ]
+    lines += [
+        "| cell | contrast | metric | a median | b median | ratio b/a (95% CI) | p (BH) | n | verdict |",
         "| --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
     ]
     for row in rows:
         c = row.comparison
-        label = METRIC_LABELS[row.metric][0] + ("" if row.gated else " (ungated)")
+        qualifier = (
+            "A/A control"
+            if row.result.control
+            else "head-to-head"
+            if row.head_to_head
+            else ""
+            if row.gated
+            else "ungated"
+        )
+        label = METRIC_LABELS[row.metric][0] + (f" ({qualifier})" if qualifier else "")
         lines.append(
-            f"| {row.result.cell_id} | `{row.b}` vs `{row.a}` | {label} "
+            f"| {_detail_cell_label(row.result)} "
+            f"| {_linked_arm(row.b, sources)} vs {_linked_arm(row.a, sources)} "
+            f"| {label} "
             f"| {format_metric(row.metric, c.baseline_median)} "
             f"| {format_metric(row.metric, c.candidate_median)} "
             f"| {_ratio_cell(c)} | {_p_cell(c)} | {c.n_rounds} "
@@ -898,12 +1004,26 @@ def _full_measurements(rows: list[ReportRow]) -> list[str]:
     return lines + ["", "</details>", ""]
 
 
+def _detail_cell_label(result: CellResult) -> str:
+    label = _cell_label(result)
+    if result.control:
+        operation = label.removesuffix(" / control").replace("1MiB", "1 MiB")
+        return f"**A/A control** · {operation}"
+    return label
+
+
 def _not_measured(recorder: BenchmarkRecorder) -> list[str]:
     if not recorder.skipped:
         return []
     lines = [
         "<details open>",
-        "<summary><strong>Not measured</strong></summary>",
+        "<summary><strong>"
+        + (
+            "Cells not run (same commit)"
+            if same_commit(recorder.metadata)
+            else "Not measured"
+        )
+        + "</strong></summary>",
         "",
     ]
     lines += [f"- `{cid}`: {why}" for cid, why in sorted(recorder.skipped.items())]
@@ -960,7 +1080,8 @@ def _run_facts(
         "",
         f"<sub>seed {config.seed}; {config.warmup} warm-up rounds; "
         f"{config.min_rounds}–{config.max_rounds} measured rounds allowed; "
-        f"{len(recorder.skipped)} cells skipped.</sub>",
+        f"{len(recorder.skipped)} "
+        f"{'cell' if len(recorder.skipped) == 1 else 'cells'} skipped.</sub>",
     ]
 
 

--- a/xtest/perf/runner.py
+++ b/xtest/perf/runner.py
@@ -1,19 +1,28 @@
 """The paired round loop that produces comparable samples for one cell.
 
-A *cell* is one operation at one payload size, measured for two SDK builds.
-The loop runs both arms once per round, in a randomized order, until it has
-either enough precision or no more time.
+A *cell* is one operation at one payload size, measured for K SDK builds
+(2 to 4). The loop runs every arm once per round, in a randomized order, until
+it has either enough precision or no more time.
 
 Why rounds rather than "run A 30 times, then B 30 times"
 --------------------------------------------------------
 A shared runner drifts: a noisy neighbour arrives, the CPU thermally throttles,
 the page cache warms. Run all of A and then all of B and every one of those
 effects lands entirely on one arm and shows up as a difference between builds.
-Interleaving means both arms see the same conditions within a round, and the
+Interleaving means every arm sees the same conditions within a round, and the
 per-round ratio differences it out.
 
 The order *within* a round is randomized because a fixed order is itself a
 confounder -- whichever arm runs second inherits the first one's cache state.
+
+Why every arm shares a round, and why that is the whole point at K > 2
+----------------------------------------------------------------------
+Because all K arms are measured in the same round on the same runner, *every*
+pairwise contrast is a within-run ratio -- not just each candidate against the
+reference, but candidate-against-candidate too. That is what makes a bake-off
+between two competing implementations answerable at all. Running them as two
+separate 2-arm jobs puts them on different runners, and this harness's founding
+premise is that timings from different runners are not comparable.
 
 Why stopping on precision and not on significance
 -------------------------------------------------
@@ -124,11 +133,17 @@ class Invocation:
 
 @dataclass(frozen=True, slots=True)
 class Arm:
-    """One side of a comparison."""
+    """One build participating in a cell.
 
-    #: ``"baseline"`` or ``"candidate"``; identifies the role, not the build.
+    At K > 2 there is no such thing as "the candidate", so arms are keyed by
+    identity rather than by role: ``name`` is the arm id, and which arm is the
+    reference is a property of the cell, not of the arm.
+    """
+
+    #: Arm id, unique within a cell -- the flattened dist tag, e.g. ``"main"``
+    #: or ``"fix--otdfctl-streaming-encrypt-writer"``.
     name: str
-    #: The build under this role, e.g. ``"go@v0.29.0"``.
+    #: The build this arm runs, e.g. ``"go@v0.29.0"``.
     label: str
     invocation: Invocation
 
@@ -143,14 +158,18 @@ class CellResult:
     """
 
     cell_id: str
-    baseline_label: str
-    candidate_label: str
-    #: ``samples[arm_name][metric]`` is the per-round vector, warm-up excluded.
+    #: Arm ids in the order they were configured. ``arm_ids[0]`` is the
+    #: reference by convention, and ``reference`` names it explicitly.
+    arm_ids: tuple[str, ...]
+    #: Arm id -> the build it ran, e.g. ``"go@v0.29.0"``.
+    arm_labels: dict[str, str]
+    reference: str
+    #: ``samples[arm_id][metric]`` is the per-round vector, warm-up excluded.
     samples: dict[str, dict[str, list[float]]]
     n_warmup: int
     elapsed_s: float
     stopped_because: str
-    #: True for the A/A control, where both arms are the same build.
+    #: True for the A/A control, where every arm is the same build.
     control: bool = False
     #: Which SDK's control cell assesses this cell's noise floor. A run may
     #: measure several SDKs, and each has its own harness path and its own
@@ -161,11 +180,31 @@ class CellResult:
     rss_floor_bytes: int = 0
 
     @property
+    def baseline_label(self) -> str:
+        """The reference build's label.
+
+        Kept alongside :attr:`candidate_label` so that the two-arm shape of the
+        JSON artifact -- which predates K arms and which people have scripts
+        pointed at -- still reads correctly for a two-arm run.
+        """
+        return self.arm_labels[self.reference]
+
+    @property
+    def candidate_label(self) -> str:
+        """The second arm's build label; see :attr:`baseline_label`.
+
+        At K > 2 this is one candidate among several and says nothing about the
+        rest, which is why the artifact also carries the full ``arm_labels``.
+        """
+        others = [a for a in self.arm_ids if a != self.reference]
+        return self.arm_labels[others[0]] if others else self.baseline_label
+
+    @property
     def rss_censored_reason(self) -> str | None:
         """Why this cell's peak RSS cannot be compared, or None if it can.
 
         A command whose peak sits at the floor was not measured, it was
-        clipped, and both arms clip to the same value. The resulting ratio is
+        clipped, and every arm clips to the same value. The resulting ratio is
         1.000 with a tight interval, which is the most convincing-looking
         PASS the harness can emit and means nothing at all.
         """
@@ -176,7 +215,7 @@ class CellResult:
             return None
         return (
             f"peak rss reaches the {self.rss_floor_bytes / 2**20:.0f} MiB "
-            "measurement floor, so the two arms are not distinguishable"
+            "measurement floor, so the arms are not distinguishable"
         )
 
     @property
@@ -184,31 +223,54 @@ class CellResult:
         first = next(iter(self.samples.values()), {})
         return len(next(iter(first.values()), []))
 
-    def metric_pair(self, metric: str) -> tuple[list[float], list[float]]:
-        """Return ``(baseline, candidate)`` vectors for one metric."""
-        return self.samples["baseline"][metric], self.samples["candidate"][metric]
+    def contrast(
+        self, a: str, b: str, metric: str, config: BenchConfig
+    ) -> stats.PairedComparison:
+        """Compare arm ``b`` against arm ``a`` -- a ratio of b over a.
 
-    def compare(self, metric: str, config: BenchConfig) -> stats.PairedComparison:
-        baseline, candidate = self.metric_pair(metric)
+        The argument order matches the reading of the result:
+        ``contrast(reference, candidate, ...)`` answers "how much slower is the
+        candidate than the reference", which is the direction every ratio in
+        the report is quoted in.
+        """
         return stats.compare(
-            baseline,
-            candidate,
+            self.samples[a][metric],
+            self.samples[b][metric],
             confidence=config.confidence,
             seed=config.seed,
             n_resamples=config.n_resamples,
         )
 
+    def contrast_pairs(self) -> list[tuple[str, str]]:
+        """Every ordered ``(a, b)`` pair to report, reference contrasts first.
 
-def _empty_samples() -> dict[str, dict[str, list[float]]]:
-    return {arm: {m: [] for m in METRICS} for arm in ("baseline", "candidate")}
+        Reference contrasts are quoted as ``(reference, candidate)`` so they
+        read as "candidate vs reference". Head-to-head pairs are emitted in
+        configured order, once each -- a pair and its inverse are the same
+        measurement read two ways, and reporting both would double-count it in
+        the multiplicity correction.
+        """
+        others = [a for a in self.arm_ids if a != self.reference]
+        pairs = [(self.reference, b) for b in others]
+        pairs += [(a, b) for i, a in enumerate(others) for b in others[i + 1 :]]
+        return pairs
+
+
+def contrast_key(cell_id: str, a: str, b: str, metric: str) -> str:
+    """The stable key for one contrast, as used throughout the analysis."""
+    return f"{cell_id}/{b}_vs_{a}/{metric}"
+
+
+def _empty_samples(arm_ids: Sequence[str]) -> dict[str, dict[str, list[float]]]:
+    return {arm: {m: [] for m in METRICS} for arm in arm_ids}
 
 
 def run_cell(
     cell_id: str,
-    baseline: Arm,
-    candidate: Arm,
+    arms: Sequence[Arm],
     config: BenchConfig,
     *,
+    reference: str | None = None,
     deadline: float | None = None,
     control: bool = False,
     sdk: str = "",
@@ -220,9 +282,11 @@ def run_cell(
     Args:
         cell_id: stable identifier, also the per-cell RNG seed material so
             that two cells do not share an interleaving order.
-        baseline: the arm the candidate is compared against.
-        candidate: the arm under test. For an A/A control this is the same
-            build as ``baseline``, running through the identical path.
+        arms: the 2 to 4 builds to measure, all in every round. For an A/A
+            control these are the same build running through identical paths.
+        config: round-loop knobs.
+        reference: id of the arm every gated contrast is taken against;
+            defaults to ``arms[0]``.
         deadline: absolute ``clock()`` value past which no new round starts.
         control: records that this is the A/A cell; does not change the loop.
         sdk: which SDK this cell belongs to, so that the analysis can pair it
@@ -231,16 +295,28 @@ def run_cell(
         run: injectable measurement function, for testing the loop itself.
 
     Raises:
+        ValueError: if fewer than two arms were given, or their ids collide.
         MeasurementError: if any invocation fails. A benchmark over an
             operation that errors out is measuring the error path.
         BudgetExhausted: if the deadline passed before ``min_rounds``, or
             during warm-up.
     """
-    arms = (baseline, candidate)
+    arms = tuple(arms)
+    if len(arms) < 2:
+        raise ValueError(f"{cell_id}: a cell needs at least two arms to compare")
+    arm_ids = tuple(a.name for a in arms)
+    if len(set(arm_ids)) != len(arm_ids):
+        # Ids key the sample vectors, so a collision would silently interleave
+        # two builds' measurements into one arm and compare it with itself.
+        raise ValueError(f"{cell_id}: arm ids must be unique, got {list(arm_ids)}")
+    reference = arm_ids[0] if reference is None else reference
+    if reference not in arm_ids:
+        raise ValueError(f"{cell_id}: reference {reference!r} is not one of the arms")
+
     # Seeded per cell so a rerun reproduces the interleaving exactly, but the
     # cells do not all share one order (which would correlate their noise).
     rng = random.Random(f"{config.seed}:{cell_id}")
-    samples = _empty_samples()
+    samples = _empty_samples(arm_ids)
     round_durations: list[float] = []
     rss_floor = 0
     started = clock()
@@ -280,7 +356,7 @@ def run_cell(
                     f"warm-up rounds ({clock() - started:.0f}s), "
                     "before any measurement began"
                 )
-            one_round(_empty_samples())
+            one_round(_empty_samples(arm_ids))
 
         stopped_because = "max_rounds"
         for _ in range(config.max_rounds):
@@ -299,13 +375,15 @@ def run_cell(
             one_round(samples)
             round_durations.append(clock() - round_start)
 
-            n = len(samples["baseline"]["wall"])
-            if n >= config.min_rounds and _precise_enough(samples, config):
+            n = len(samples[reference]["wall"])
+            if n >= config.min_rounds and _precise_enough(
+                samples, config, reference=reference
+            ):
                 stopped_because = "precision"
                 break
 
         elapsed = clock() - started
-        n = len(samples["baseline"]["wall"])
+        n = len(samples[reference]["wall"])
         if n < stats.MIN_USABLE_ROUNDS:
             raise BudgetExhausted(
                 f"{cell_id}: only {n} rounds completed in {elapsed:.0f}s, "
@@ -313,8 +391,9 @@ def run_cell(
             )
         return CellResult(
             cell_id=cell_id,
-            baseline_label=baseline.label,
-            candidate_label=candidate.label,
+            arm_ids=arm_ids,
+            arm_labels={a.name: a.label for a in arms},
+            reference=reference,
             samples=samples,
             n_warmup=config.warmup,
             elapsed_s=elapsed,
@@ -325,7 +404,7 @@ def run_cell(
         )
     finally:
         # Each arm leaves behind an output the size of the payload, and
-        # nothing reads it once the cell is done. Keeping them costs 2 GiB per
+        # nothing reads it once the cell is done. Keeping them costs K GiB per
         # 1 GiB cell, which every later cell then has to fit around -- so the
         # cell that fails on disk is not the one that filled it.
         for arm in arms:
@@ -334,26 +413,38 @@ def run_cell(
 
 
 def _precise_enough(
-    samples: dict[str, dict[str, list[float]]], config: BenchConfig
+    samples: dict[str, dict[str, list[float]]],
+    config: BenchConfig,
+    *,
+    reference: str,
 ) -> bool:
-    """True once every gated metric's CI is narrow enough to decide on.
+    """True once every gated contrast's CI is narrow enough to decide on.
+
+    Every non-reference arm must be resolved on every gated metric, not just
+    the first one: stopping as soon as *some* contrast is precise would leave
+    the rest INCONCLUSIVE while the budget was still there to spend on them,
+    and at K arms the slowest contrast to converge is the one that matters.
 
     Deliberately looks only at interval *width*, never at where the interval
     sits or at any p-value -- see the module docstring.
     """
     for metric in config.gated_metrics:
-        c = stats.compare(
-            samples["baseline"][metric],
-            samples["candidate"][metric],
-            confidence=config.confidence,
-            seed=config.seed,
-            n_resamples=_INTERIM_RESAMPLES,
-        )
-        # `not (a <= b)` rather than `a > b`, which is not the same thing when
-        # a is NaN: an unusable interval must read as "keep going", and
-        # `NaN > b` is False, which would end the loop and call it precise.
-        if not c.ci_half_width_log <= config.target_half_width_log:  # NOSONAR
-            return False
+        for arm, vectors in samples.items():
+            if arm == reference:
+                continue
+            c = stats.compare(
+                samples[reference][metric],
+                vectors[metric],
+                confidence=config.confidence,
+                seed=config.seed,
+                n_resamples=_INTERIM_RESAMPLES,
+            )
+            # `not (a <= b)` rather than `a > b`, which is not the same thing
+            # when a is NaN: an unusable interval must read as "keep going",
+            # and `NaN > b` is False, which would end the loop and call it
+            # precise.
+            if not c.ci_half_width_log <= config.target_half_width_log:  # NOSONAR
+                return False
     return True
 
 
@@ -393,12 +484,24 @@ class Budget:
 def analyze(results: Sequence[CellResult], config: BenchConfig) -> stats.GateResult:
     """Turn every cell's raw samples into one gate decision.
 
-    ``GateResult.comparisons`` is keyed by ``"<cell_id>/<metric>"`` and holds
-    the *finalized* comparisons -- the ones carrying adjusted p-values and
-    verdicts. Ungated metrics are included so they appear in the report, but
-    they cannot fail the build, and they are corrected separately from the
-    gated ones: adjusting across tests nobody gates on only makes a real
-    regression harder to confirm.
+    ``GateResult.comparisons`` is keyed by ``"<cell_id>/<b>_vs_<a>/<metric>"``
+    and holds the *finalized* comparisons -- the ones carrying adjusted
+    p-values and verdicts. Every pairwise contrast in every cell is here, but
+    they fall into three groups that are judged and corrected separately:
+
+    - **Gated**: a non-reference arm against the reference, on a gated metric.
+      One-sided; only these can fail the build. At K arms there are K-1 of
+      them per cell and metric rather than one.
+    - **Symmetric**: a head-to-head between two non-reference arms -- the
+      bake-off question. Judged two-sided against an equivalence band, ranked
+      and reported, never gated. See invariant #9 in ``README.md``.
+    - **Ungated**: everything else, reported for context only.
+
+    They get separate BH families for the reason documented in
+    :func:`stats.apply_multiplicity_control`: adjusting the gate against tests
+    nobody gates on only makes a real regression harder to confirm. A bake-off
+    is a question of interest, not a build gate, so it must not dilute the
+    gate either.
 
     Each SDK's cells are paired with *that SDK's* control. A run measuring go
     and java has two harness paths and two noise floors, and judging java's
@@ -407,32 +510,60 @@ def analyze(results: Sequence[CellResult], config: BenchConfig) -> stats.GateRes
     """
     comparisons: dict[str, stats.PairedComparison] = {}
     gated: set[str] = set()
+    symmetric: set[str] = set()
     censored: dict[str, str] = {}
     control_keys: set[str] = set()
     controls: dict[str, str] = {}
-    control_for_sdk = {
-        r.sdk: f"{r.cell_id}/{_CONTROL_METRIC}" for r in results if r.control
-    }
 
     for result in results:
         floored = result.rss_censored_reason
-        for metric in METRICS:
-            key = f"{result.cell_id}/{metric}"
-            comparisons[key] = result.compare(metric, config)
-            control_key = control_for_sdk.get(result.sdk)
-            if control_key is not None:
-                controls[key] = control_key
-            if metric == "rss" and floored is not None:
-                censored[key] = floored
-                continue
-            if result.control:
-                control_keys.add(key)
-            elif metric in config.gated_metrics:
-                gated.add(key)
+        for a, b in result.contrast_pairs():
+            head_to_head = result.reference not in (a, b)
+            for metric in METRICS:
+                key = contrast_key(result.cell_id, a, b, metric)
+                comparisons[key] = result.contrast(a, b, metric, config)
+                if metric == "rss" and floored is not None:
+                    censored[key] = floored
+                    continue
+                if result.control:
+                    control_keys.add(key)
+                elif head_to_head:
+                    # Every head-to-head is judged symmetrically, on gated and
+                    # ungated metrics alike: "which arm is faster" has no
+                    # privileged direction, and the one-sided PASS/REGRESSION
+                    # vocabulary would misdescribe it. None of them gate, so
+                    # sharing one BH family costs the gate nothing -- the
+                    # separation that matters is keeping them *out* of it.
+                    symmetric.add(key)
+                elif metric in config.gated_metrics:
+                    gated.add(key)
+
+    # Pick each SDK's noise floor only once every control contrast exists: a
+    # K-arm control produces C(K,2) of them and the worst one is the floor.
+    assessor_for_sdk = {
+        r.sdk: stats.worst_control_key(
+            comparisons,
+            [
+                contrast_key(r.cell_id, a, b, _CONTROL_METRIC)
+                for a, b in r.contrast_pairs()
+            ],
+            threshold=config.threshold,
+        )
+        for r in results
+        if r.control
+    }
+    for result in results:
+        assessor = assessor_for_sdk.get(result.sdk)
+        if assessor is None:
+            continue
+        for a, b in result.contrast_pairs():
+            for metric in METRICS:
+                controls[contrast_key(result.cell_id, a, b, metric)] = assessor
 
     return stats.apply_multiplicity_control(
         comparisons,
         gated=gated,
+        symmetric=symmetric,
         controls=controls,
         control_keys=control_keys,
         censored=censored,

--- a/xtest/perf/runner.py
+++ b/xtest/perf/runner.py
@@ -261,66 +261,76 @@ def run_cell(
             for metric in METRICS:
                 into[arm.name][metric].append(sample.metric(metric))
 
-    for i in range(config.warmup):
-        # Warm-up rounds pay the one-time costs -- page cache, `go build`
-        # cache, npx package resolution, JIT warm-up -- that would otherwise
-        # land unevenly and show up as a difference between builds. Their
-        # samples are collected into a throwaway dict and dropped.
-        #
-        # The deadline is checked here too, and not only in the measured loop
-        # below. The budget's end is absolute, so warm-ups that overrun it
-        # spend the *following* cells' time and then reach the measured loop
-        # with nothing left -- paying the full cost of the cell and producing
-        # no data. Better to give up here and say why.
-        if deadline is not None and clock() >= deadline:
-            raise BudgetExhausted(
-                f"{cell_id}: budget ran out after {i} of {config.warmup} "
-                f"warm-up rounds ({clock() - started:.0f}s), "
-                "before any measurement began"
-            )
-        one_round(_empty_samples())
+    try:
+        for i in range(config.warmup):
+            # Warm-up rounds pay the one-time costs -- page cache, `go build`
+            # cache, npx package resolution, JIT warm-up -- that would
+            # otherwise land unevenly and show up as a difference between
+            # builds. Their samples are collected into a throwaway dict and
+            # dropped.
+            #
+            # The deadline is checked here too, and not only in the measured
+            # loop below. The budget's end is absolute, so warm-ups that
+            # overrun it spend the *following* cells' time and then reach the
+            # measured loop with nothing left -- paying the full cost of the
+            # cell and producing no data. Better to give up here and say why.
+            if deadline is not None and clock() >= deadline:
+                raise BudgetExhausted(
+                    f"{cell_id}: budget ran out after {i} of {config.warmup} "
+                    f"warm-up rounds ({clock() - started:.0f}s), "
+                    "before any measurement began"
+                )
+            one_round(_empty_samples())
 
-    stopped_because = "max_rounds"
-    for _ in range(config.max_rounds):
-        round_start = clock()
-        if deadline is not None and round_start >= deadline:
-            stopped_because = "budget"
-            break
-        if deadline is not None and round_durations:
-            # Do not start a round we cannot finish: a half-measured round is
-            # unpaired data, and unpaired data is exactly what this design
-            # exists to avoid.
-            expected = float(np.median(round_durations))
-            if round_start + expected > deadline:
+        stopped_because = "max_rounds"
+        for _ in range(config.max_rounds):
+            round_start = clock()
+            if deadline is not None and round_start >= deadline:
                 stopped_because = "budget"
                 break
-        one_round(samples)
-        round_durations.append(clock() - round_start)
+            if deadline is not None and round_durations:
+                # Do not start a round we cannot finish: a half-measured round
+                # is unpaired data, and unpaired data is exactly what this
+                # design exists to avoid.
+                expected = float(np.median(round_durations))
+                if round_start + expected > deadline:
+                    stopped_because = "budget"
+                    break
+            one_round(samples)
+            round_durations.append(clock() - round_start)
 
+            n = len(samples["baseline"]["wall"])
+            if n >= config.min_rounds and _precise_enough(samples, config):
+                stopped_because = "precision"
+                break
+
+        elapsed = clock() - started
         n = len(samples["baseline"]["wall"])
-        if n >= config.min_rounds and _precise_enough(samples, config):
-            stopped_because = "precision"
-            break
-
-    elapsed = clock() - started
-    n = len(samples["baseline"]["wall"])
-    if n < stats.MIN_USABLE_ROUNDS:
-        raise BudgetExhausted(
-            f"{cell_id}: only {n} rounds completed in {elapsed:.0f}s, "
-            f"below the {stats.MIN_USABLE_ROUNDS} needed for any verdict"
+        if n < stats.MIN_USABLE_ROUNDS:
+            raise BudgetExhausted(
+                f"{cell_id}: only {n} rounds completed in {elapsed:.0f}s, "
+                f"below the {stats.MIN_USABLE_ROUNDS} needed for any verdict"
+            )
+        return CellResult(
+            cell_id=cell_id,
+            baseline_label=baseline.label,
+            candidate_label=candidate.label,
+            samples=samples,
+            n_warmup=config.warmup,
+            elapsed_s=elapsed,
+            stopped_because=stopped_because,
+            control=control,
+            sdk=sdk,
+            rss_floor_bytes=rss_floor,
         )
-    return CellResult(
-        cell_id=cell_id,
-        baseline_label=baseline.label,
-        candidate_label=candidate.label,
-        samples=samples,
-        n_warmup=config.warmup,
-        elapsed_s=elapsed,
-        stopped_because=stopped_because,
-        control=control,
-        sdk=sdk,
-        rss_floor_bytes=rss_floor,
-    )
+    finally:
+        # Each arm leaves behind an output the size of the payload, and
+        # nothing reads it once the cell is done. Keeping them costs 2 GiB per
+        # 1 GiB cell, which every later cell then has to fit around -- so the
+        # cell that fails on disk is not the one that filled it.
+        for arm in arms:
+            if arm.invocation.output is not None:
+                arm.invocation.output.unlink(missing_ok=True)
 
 
 def _precise_enough(

--- a/xtest/perf/stats.py
+++ b/xtest/perf/stats.py
@@ -1,4 +1,4 @@
-"""Paired statistical comparison of two SDK builds.
+"""Paired statistical comparison of SDK builds.
 
 Why this shape
 --------------
@@ -38,6 +38,24 @@ Requiring both is deliberate, and neither clause is redundant:
 
 Together they answer the only question worth gating on: is the slowdown both
 real and large enough to care about?
+
+Head-to-head contrasts
+----------------------
+A run may measure more than two arms. Every arm runs once per round, so any
+*pair* of them is a valid within-round comparison -- which is what makes a
+bake-off between two competing implementations possible at all, and what two
+separate two-arm runs on two different runners could never give you.
+
+Contrasts against the run's designated reference keep the rule above and can
+fail the build. Contrasts between two non-reference arms are judged by
+:func:`_symmetric_verdict_for` instead, which reads the same threshold as a
+two-sided equivalence band and returns FASTER, SLOWER, or TIED. They never
+gate: a bake-off ranks candidates, it does not decide whether the build is
+broken, and there is no incumbent for "regression" to be relative to.
+
+The three families -- gated, head-to-head, and ungated -- are BH-corrected
+separately, so adding candidates to a bake-off does not cost the regression
+gate any power.
 """
 
 from __future__ import annotations
@@ -67,12 +85,27 @@ DEFAULT_BOOTSTRAP_RESAMPLES = 10000
 
 
 class Verdict(StrEnum):
-    """Outcome for a single comparison cell."""
+    """Outcome for a single comparison.
+
+    The first four are the *gated* vocabulary, used for a contrast against the
+    run's reference build: the question is one-sided ("did the candidate get
+    slower?") and only REGRESSION can turn the build red.
+
+    The last three are the *symmetric* vocabulary, used for a head-to-head
+    between two non-reference arms in a bake-off. There the question has no
+    privileged direction -- neither arm is the incumbent -- and "no measurable
+    difference" is a real answer rather than the absence of one, so TIED exists
+    instead of reusing PASS.
+    """
 
     PASS = "PASS"
     REGRESSION = "REGRESSION"
     IMPROVED = "IMPROVED"
     INCONCLUSIVE = "INCONCLUSIVE"
+
+    FASTER = "FASTER"
+    SLOWER = "SLOWER"
+    TIED = "TIED"
 
 
 @dataclass(frozen=True, slots=True)
@@ -312,6 +345,13 @@ def assess_noise_floor(
     )
 
 
+def _noise_rank(n: NoiseFloor) -> tuple[bool, bool, float]:
+    """Order noise floors from most to least reassuring."""
+    # A NaN width is an unusable interval, which is worse than any real one.
+    width = n.width_ratio if math.isfinite(n.width_ratio) else math.inf
+    return (n.tripped, n.underpowered, width)
+
+
 def _worst_noise(noises: Iterable[NoiseFloor]) -> NoiseFloor | None:
     """The least reassuring control in the run, or None if there were none.
 
@@ -319,13 +359,31 @@ def _worst_noise(noises: Iterable[NoiseFloor]) -> NoiseFloor | None:
     harness may be biased on this runner, and averaging that away with two
     quiet ones is exactly the reassurance the control exists to withhold.
     """
+    return max(noises, key=_noise_rank, default=None)
 
-    def rank(n: NoiseFloor) -> tuple[bool, bool, float]:
-        # A NaN width is an unusable interval, which is worse than any real one.
-        width = n.width_ratio if math.isfinite(n.width_ratio) else math.inf
-        return (n.tripped, n.underpowered, width)
 
-    return max(noises, key=rank, default=None)
+def worst_control_key(
+    comparisons: Mapping[str, PairedComparison],
+    keys: Sequence[str],
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> str | None:
+    """Which of several A/A contrasts should stand as the noise floor.
+
+    A K-arm control cell yields C(K,2) A/A contrasts rather than one, and they
+    are not interchangeable: arm 3 runs two invocations after arm 1, so it
+    carries more within-round drift than an adjacent pair does. Taking the
+    worst of them keeps the floor honest for the widest-spaced contrast the
+    run actually judges. Taking whichever came first would let dict ordering
+    decide how noisy the run is allowed to look.
+
+    Ties break on input order, so the choice is reproducible across runs.
+    """
+    ranked = [
+        (_noise_rank(assess_noise_floor(comparisons.get(k), threshold=threshold)), i, k)
+        for i, k in enumerate(keys)
+    ]
+    return max(ranked, key=lambda r: (r[0], -r[1]))[2] if ranked else None
 
 
 def benjamini_hochberg(p_values: Sequence[float]) -> list[float]:
@@ -359,6 +417,12 @@ class GateResult:
     #: Keys of cells that are confirmed regressions on a gated metric.
     regressions: list[str] = field(default_factory=list)
     improvements: list[str] = field(default_factory=list)
+    #: Head-to-head keys that came back FASTER or SLOWER -- a bake-off contrast
+    #: between two non-reference arms that the run was able to decide. Never
+    #: gates anything; this is the material a caller ranks arms from. Naming a
+    #: winner needs to know which arm is which, and a key is opaque here, so
+    #: that lives in the reporting layer.
+    ranked: list[str] = field(default_factory=list)
     #: True if the run may fail the build. False when the A/A control tripped:
     #: we still report, but a gate we cannot trust must not turn the build red.
     trustworthy: bool = True
@@ -386,6 +450,7 @@ def apply_multiplicity_control(
     comparisons: dict[str, PairedComparison],
     *,
     gated: set[str] | None = None,
+    symmetric: set[str] | None = None,
     controls: Mapping[str, str] | None = None,
     control_keys: set[str] | None = None,
     censored: dict[str, str] | None = None,
@@ -399,6 +464,11 @@ def apply_multiplicity_control(
         gated: keys allowed to fail the build. Keys outside this set are still
             given a verdict and reported, but never counted as a regression.
             ``None`` means every key is gated.
+        symmetric: keys judged by the two-sided FASTER/SLOWER/TIED rule instead
+            of the one-sided regression rule -- head-to-head contrasts between
+            two arms neither of which is the run's reference. They are reported
+            and ranked but never gate, so a bake-off cannot turn the build red
+            on the strength of a comparison that has no incumbent.
         controls: comparison key -> the A/A control key that assesses *its*
             noise floor. A run measuring several SDKs has one control each,
             and a cell judged against another SDK's control is judged against
@@ -421,6 +491,7 @@ def apply_multiplicity_control(
     """
     keys = list(comparisons)
     controls = controls or {}
+    symmetric = symmetric or set()
     # The keys actually doing the assessing: one metric of one control cell
     # per SDK. A control cell's other metrics are still control keys -- kept
     # out of the gate -- but they are not anybody's noise floor.
@@ -444,11 +515,22 @@ def apply_multiplicity_control(
     # reason: adjusting them against metrics nobody gates on only makes a real
     # regression harder to confirm. Ungated metrics still get a family of
     # their own so that they carry a reportable verdict.
+    #
+    # Head-to-head contrasts get a third family on the same argument. A
+    # bake-off between two candidates is a question of interest, not a build
+    # gate, and correcting the gate against it would cost the gate power for
+    # tests that cannot fail the build -- which is the exact trade the
+    # gated/ungated split already refuses to make.
     adjustable = [k for k in keys if k not in control_keys and k not in censored]
     gated_family = [k for k in adjustable if gated is None or k in gated]
-    rest = [k for k in adjustable if k not in set(gated_family)]
+    gated_set = set(gated_family)
+    # Gated wins a tie. A key that is somehow both is a vs-reference contrast,
+    # and the one-sided rule is the one that can fail the build.
+    symmetric_family = [k for k in adjustable if k not in gated_set and k in symmetric]
+    symmetric_set = set(symmetric_family)
+    rest = [k for k in adjustable if k not in gated_set and k not in symmetric_set]
     p_adj: dict[str, float] = {}
-    for family in (gated_family, rest):
+    for family in (gated_family, symmetric_family, rest):
         p_adj.update(
             zip(
                 family,
@@ -461,16 +543,33 @@ def apply_multiplicity_control(
     for key in keys:
         c = comparisons[key]
         pa = p_adj.get(key)
+        key_noise = noise_by_control.get(controls.get(key, ""), uncontrolled)
         if key in censored:
             verdict, note = Verdict.INCONCLUSIVE, censored[key]
+        elif key in control_keys:
+            # A control's own contrast is reported in the gated vocabulary
+            # whatever kind of pair it is: its job is to say what the harness's
+            # error looks like in the same terms the gate uses.
+            verdict, note = _verdict_for(
+                c,
+                pa,
+                threshold=threshold,
+                alpha=alpha,
+                noise=key_noise,
+                is_control=True,
+            )
+        elif key in symmetric_set:
+            verdict, note = _symmetric_verdict_for(
+                c, pa, threshold=threshold, alpha=alpha, noise=key_noise
+            )
         else:
             verdict, note = _verdict_for(
                 c,
                 pa,
                 threshold=threshold,
                 alpha=alpha,
-                noise=noise_by_control.get(controls.get(key, ""), uncontrolled),
-                is_control=key in control_keys,
+                noise=key_noise,
+                is_control=False,
             )
         result.comparisons[key] = PairedComparison(
             n_rounds=c.n_rounds,
@@ -490,6 +589,8 @@ def apply_multiplicity_control(
             result.regressions.append(key)
         elif verdict is Verdict.IMPROVED:
             result.improvements.append(key)
+        elif verdict in (Verdict.FASTER, Verdict.SLOWER):
+            result.ranked.append(key)
 
     result.trustworthy = not noise.tripped
     result.summary = _summarize(result, noise, threshold)
@@ -531,6 +632,67 @@ def _verdict_for(
     return Verdict.PASS, ""
 
 
+def _symmetric_verdict_for(
+    c: PairedComparison,
+    p_adjusted: float | None,
+    *,
+    threshold: float,
+    alpha: float,
+    noise: NoiseFloor,
+) -> tuple[Verdict, str]:
+    """Rank two arms against each other, with no privileged direction.
+
+    Used for a head-to-head between two candidates in a bake-off, where the
+    one-sided regression rule does not apply: neither arm is the incumbent, so
+    there is no "did it get worse" to ask.
+
+    The band is ``[1/threshold, threshold]`` -- the same effect size the gate
+    cares about, read in both directions:
+
+    - interval entirely above the band -> SLOWER
+    - interval entirely below the band -> FASTER
+    - interval entirely *inside* the band -> TIED, meaning any real difference
+      is smaller than the effect anybody has claimed to care about. This is a
+      positive finding and the most likely honest answer for two
+      implementations of the same idea, which is why it is not folded into
+      PASS: PASS is the one-sided claim "did not regress", and reporting a
+      bake-off that way would let a slower arm read as a clean result.
+    - anything straddling a band edge -> INCONCLUSIVE, the run could not rank
+      them.
+
+    A CI-inside-band test at 95% is TOST at 2.5% rather than the nominal 5%,
+    so TIED is the conservative call: harder to earn than the equivalence test
+    it stands in for, never easier.
+    """
+    if c.n_rounds < MIN_USABLE_ROUNDS or not math.isfinite(c.ci_low):
+        return Verdict.INCONCLUSIVE, c.note or "no usable interval"
+
+    # Same precondition as the gated rule: without a noise floor establishing
+    # that an effect of this size was resolvable, neither a ranking nor a tie
+    # is a statement about the arms. Invariant 4 covers TIED too -- a tie
+    # nobody had the power to distinguish from a difference is not a tie.
+    if noise.underpowered:
+        return Verdict.INCONCLUSIVE, noise.detail
+
+    p = p_adjusted
+    if p is None or not math.isfinite(p):
+        return Verdict.INCONCLUSIVE, "no p-value"
+
+    # Direction clauses mirror REGRESSION and IMPROVED exactly, including the
+    # upper-tail read of the one-sided p for the faster direction.
+    if c.ci_low > threshold and p < alpha:
+        return Verdict.SLOWER, ""
+    if c.ci_high < 1 / threshold and p > 1 - alpha:
+        return Verdict.FASTER, ""
+    if c.ci_low > 1 / threshold and c.ci_high < threshold:
+        return Verdict.TIED, ""
+    return (
+        Verdict.INCONCLUSIVE,
+        f"interval [{c.ci_low:.3f}, {c.ci_high:.3f}] straddles the "
+        f"+/-{(threshold - 1) * 100:.0f}% band; the two arms cannot be ranked",
+    )
+
+
 def _summarize(result: GateResult, noise: NoiseFloor, threshold: float) -> str:
     if result.nothing_measured:
         # Before the noise check: with nothing measured there is no control
@@ -550,6 +712,14 @@ def _summarize(result: GateResult, noise: NoiseFloor, threshold: float) -> str:
             f"{len(result.regressions)} confirmed regression(s) past the "
             f"{(threshold - 1) * 100:.0f}% threshold: {', '.join(result.regressions)}"
         )
+    # Appended rather than returned on its own: a bake-off still has a gate
+    # running against the reference, and "which candidate won" must not
+    # displace "did either of them regress".
+    head_to_head = (
+        f" {len(result.ranked)} head-to-head contrast(s) decided."
+        if result.ranked
+        else ""
+    )
     inconclusive = [
         k for k, c in result.comparisons.items() if c.verdict is Verdict.INCONCLUSIVE
     ]
@@ -557,9 +727,11 @@ def _summarize(result: GateResult, noise: NoiseFloor, threshold: float) -> str:
         return (
             f"No confirmed regressions. {len(inconclusive)} cell(s) INCONCLUSIVE "
             f"(runner noise floor +/-{(noise.width_ratio - 1) * 100:.1f}%)."
+            f"{head_to_head}"
         )
     return (
         f"No regressions. All cells resolved within the "
         f"{(threshold - 1) * 100:.0f}% threshold "
         f"(runner noise floor +/-{(noise.width_ratio - 1) * 100:.1f}%)."
+        f"{head_to_head}"
     )

--- a/xtest/perf/stats.py
+++ b/xtest/perf/stats.py
@@ -28,13 +28,12 @@ A cell is a regression iff **both**:
 
 Requiring both is deliberate, and neither clause is redundant:
 
-- Clause 1 alone would fire on a real-but-trivial effect measured precisely
-  enough -- a reproducible 0.5% slowdown is not worth a red build.
-  It cannot fire on pure noise, since that would require the interval to
-  exclude an effect that is not there.
-- Clause 2 alone would fire on noise roughly ``alpha`` of the time per cell,
-  and a run has enough cells that "roughly alpha" becomes "most nights".
-  BH adjustment across cells controls the false discovery rate.
+- Clause 1 establishes that the effect is larger than the practical threshold,
+  but an unadjusted 95% interval on every cell does not control false
+  discoveries across the run.
+- Clause 2 supplies that multiplicity control, but alone would flag both
+  real-but-trivial effects and pure-noise false positives. A reproducible 0.5%
+  slowdown is statistically real and still not worth a red build.
 
 Together they answer the only question worth gating on: is the slowdown both
 real and large enough to care about?
@@ -122,9 +121,15 @@ class PairedComparison:
     ratio: float
     ci_low: float
     ci_high: float
+    #: One-sided p-value for "candidate is slower". Retains the original field
+    #: name for artifact/API compatibility; the opposite direction is explicit.
     p_value: float
+    #: One-sided p-value for "candidate is faster".
+    p_value_faster: float
     #: Set by :func:`apply_multiplicity_control` once every cell is known.
     p_adjusted: float | None = None
+    #: BH-adjusted form of :attr:`p_value_faster`.
+    p_adjusted_faster: float | None = None
     verdict: Verdict = Verdict.INCONCLUSIVE
     note: str = ""
 
@@ -207,18 +212,22 @@ def _bootstrap_ci(
     return float(res.confidence_interval.low), float(res.confidence_interval.high)
 
 
-def _one_sided_p(d: np.ndarray) -> float:
-    """One-sided Wilcoxon signed-rank p-value for "candidate is slower".
+def _one_sided_ps(d: np.ndarray) -> tuple[float, float]:
+    """Wilcoxon signed-rank p-values for slower and faster, respectively.
 
-    Signed-rank rather than a t-test because latency distributions are
-    skewed and occasionally have a stray outlier round; we do not want a
-    single stalled invocation to drive the verdict.
+    Signed-rank does not require normally distributed raw latencies and a
+    single stalled invocation cannot drive it by magnitude alone. Interpreting
+    it as a location test does assume the *paired log differences* are roughly
+    symmetric; the log transform and multiplicative-jitter measurement model
+    are intended to make that a reasonable assumption.
     """
     if np.all(d == 0):
         # No difference whatsoever. Wilcoxon rejects an all-zero input.
-        return 1.0
+        return 1.0, 1.0
     # scipy's stubs type the result as an opaque tuple-like; index and cast.
-    return cast(float, _scipy_stats.wilcoxon(d, alternative="greater")[1])
+    slower = cast(float, _scipy_stats.wilcoxon(d, alternative="greater")[1])
+    faster = cast(float, _scipy_stats.wilcoxon(d, alternative="less")[1])
+    return slower, faster
 
 
 def compare(
@@ -249,12 +258,14 @@ def compare(
             ci_low=math.nan,
             ci_high=math.nan,
             p_value=math.nan,
+            p_value_faster=math.nan,
             note=f"only {n} usable rounds; need at least {MIN_USABLE_ROUNDS}",
         )
 
     lo_log, hi_log = _bootstrap_ci(
         d, confidence=confidence, seed=seed, n_resamples=n_resamples
     )
+    p_slower, p_faster = _one_sided_ps(d)
     return PairedComparison(
         n_rounds=n,
         baseline_median=b_med,
@@ -262,7 +273,8 @@ def compare(
         ratio=math.exp(float(np.median(d))),
         ci_low=math.exp(lo_log),
         ci_high=math.exp(hi_log),
-        p_value=_one_sided_p(d),
+        p_value=p_slower,
+        p_value_faster=p_faster,
     )
 
 
@@ -530,6 +542,7 @@ def apply_multiplicity_control(
     symmetric_set = set(symmetric_family)
     rest = [k for k in adjustable if k not in gated_set and k not in symmetric_set]
     p_adj: dict[str, float] = {}
+    p_adj_faster: dict[str, float] = {}
     for family in (gated_family, symmetric_family, rest):
         p_adj.update(
             zip(
@@ -538,11 +551,23 @@ def apply_multiplicity_control(
                 strict=True,
             )
         )
+        # The opposite direction needs its own lower-tail p-value and its own
+        # adjustment. Reading an adjusted upper-tail value as `p > 1-alpha`
+        # is invalid: BH controls small p-values and generally pushes large
+        # ones toward 1, making that backwards test easier rather than safer.
+        p_adj_faster.update(
+            zip(
+                family,
+                benjamini_hochberg([comparisons[k].p_value_faster for k in family]),
+                strict=True,
+            )
+        )
 
     result = GateResult(noise=noise, noise_by_control=noise_by_control)
     for key in keys:
         c = comparisons[key]
         pa = p_adj.get(key)
+        pa_faster = p_adj_faster.get(key)
         key_noise = noise_by_control.get(controls.get(key, ""), uncontrolled)
         if key in censored:
             verdict, note = Verdict.INCONCLUSIVE, censored[key]
@@ -553,6 +578,7 @@ def apply_multiplicity_control(
             verdict, note = _verdict_for(
                 c,
                 pa,
+                pa_faster,
                 threshold=threshold,
                 alpha=alpha,
                 noise=key_noise,
@@ -560,12 +586,18 @@ def apply_multiplicity_control(
             )
         elif key in symmetric_set:
             verdict, note = _symmetric_verdict_for(
-                c, pa, threshold=threshold, alpha=alpha, noise=key_noise
+                c,
+                pa,
+                pa_faster,
+                threshold=threshold,
+                alpha=alpha,
+                noise=key_noise,
             )
         else:
             verdict, note = _verdict_for(
                 c,
                 pa,
+                pa_faster,
                 threshold=threshold,
                 alpha=alpha,
                 noise=key_noise,
@@ -579,7 +611,9 @@ def apply_multiplicity_control(
             ci_low=c.ci_low,
             ci_high=c.ci_high,
             p_value=c.p_value,
+            p_value_faster=c.p_value_faster,
             p_adjusted=pa,
+            p_adjusted_faster=pa_faster,
             verdict=verdict,
             note=note or c.note,
         )
@@ -600,6 +634,7 @@ def apply_multiplicity_control(
 def _verdict_for(
     c: PairedComparison,
     p_adjusted: float | None,
+    p_adjusted_faster: float | None,
     *,
     threshold: float,
     alpha: float,
@@ -609,13 +644,16 @@ def _verdict_for(
     if c.n_rounds < MIN_USABLE_ROUNDS or not math.isfinite(c.ci_low):
         return Verdict.INCONCLUSIVE, c.note or "no usable interval"
 
-    p = c.p_value if is_control else p_adjusted
-    if p is None or not math.isfinite(p):
+    p_slower = c.p_value if is_control else p_adjusted
+    p_faster = c.p_value_faster if is_control else p_adjusted_faster
+    if p_slower is None or p_faster is None:
+        return Verdict.INCONCLUSIVE, "no p-value"
+    if not (math.isfinite(p_slower) and math.isfinite(p_faster)):
         return Verdict.INCONCLUSIVE, "no p-value"
 
-    if c.ci_low > threshold and p < alpha:
+    if c.ci_low > threshold and p_slower < alpha:
         return Verdict.REGRESSION, ""
-    if c.ci_high < 1 / threshold and p > 1 - alpha:
+    if c.ci_high < 1 / threshold and p_faster < alpha:
         return Verdict.IMPROVED, ""
 
     # Not a regression. But "we looked and found nothing" only counts as PASS
@@ -635,6 +673,7 @@ def _verdict_for(
 def _symmetric_verdict_for(
     c: PairedComparison,
     p_adjusted: float | None,
+    p_adjusted_faster: float | None,
     *,
     threshold: float,
     alpha: float,
@@ -674,15 +713,16 @@ def _symmetric_verdict_for(
     if noise.underpowered:
         return Verdict.INCONCLUSIVE, noise.detail
 
-    p = p_adjusted
-    if p is None or not math.isfinite(p):
+    if p_adjusted is None or p_adjusted_faster is None:
+        return Verdict.INCONCLUSIVE, "no p-value"
+    if not (math.isfinite(p_adjusted) and math.isfinite(p_adjusted_faster)):
         return Verdict.INCONCLUSIVE, "no p-value"
 
-    # Direction clauses mirror REGRESSION and IMPROVED exactly, including the
-    # upper-tail read of the one-sided p for the faster direction.
-    if c.ci_low > threshold and p < alpha:
+    # Direction clauses mirror REGRESSION and IMPROVED exactly. Each direction
+    # uses its own BH-adjusted one-sided p-value.
+    if c.ci_low > threshold and p_adjusted < alpha:
         return Verdict.SLOWER, ""
-    if c.ci_high < 1 / threshold and p > 1 - alpha:
+    if c.ci_high < 1 / threshold and p_adjusted_faster < alpha:
         return Verdict.FASTER, ""
     if c.ci_low > 1 / threshold and c.ci_high < threshold:
         return Verdict.TIED, ""

--- a/xtest/test_bench_aggregate.py
+++ b/xtest/test_bench_aggregate.py
@@ -112,3 +112,53 @@ def test_a_control_without_a_result_cell_is_nothing_measured():
     doc["cells"] = [{"id": "go-control", "control": True, "contrasts": {}}]
 
     assert aggregate.Run("go", doc).status == "NOTHING MEASURED"
+
+
+def test_same_commit_is_neutral_and_names_both_requested_refs():
+    doc = document("java", "PASS")
+    doc["nothing_measured"] = True
+    doc["cells"] = []
+    metadata = doc["metadata"]
+    assert isinstance(metadata, dict)
+    metadata.update(
+        {
+            "comparison_status": "same_commit",
+            "requested_refs": ["main", "latest"],
+            "arm_sources": [
+                {
+                    "tag": "main",
+                    "sha": "a" * 40,
+                    "repo_url": "https://github.com/opentdf/java-sdk",
+                }
+            ],
+        }
+    )
+    run = aggregate.Run("java", doc)
+    md = aggregate.markdown([run], expected_sdks=["java"])
+
+    assert run.status == "SAME COMMIT"
+    assert "roll-up — SAME COMMIT" in md
+    assert "`main`" in md and "`latest`" in md and "same commit" in md
+
+
+def test_rollup_uses_measured_reference_order_and_links_sources():
+    doc = document("go", "PASS")
+    metadata = doc["metadata"]
+    assert isinstance(metadata, dict)
+    metadata["arm_sources"] = [
+        {
+            "tag": "main",
+            "sha": "b" * 40,
+            "repo_url": "https://github.com/opentdf/platform",
+        },
+        {
+            "tag": "v1",
+            "release": "otdfctl/v1.0.0",
+            "sha": "a" * 40,
+            "repo_url": "https://github.com/opentdf/platform",
+        },
+    ]
+    md = aggregate.markdown([aggregate.Run("go", doc)])
+
+    assert "releases/tag/otdfctl%2Fv1.0.0" in md
+    assert md.index("`v1`") < md.index("`main`")

--- a/xtest/test_bench_aggregate.py
+++ b/xtest/test_bench_aggregate.py
@@ -1,0 +1,114 @@
+"""Tests for the final workflow-level benchmark summary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from perf import aggregate
+
+
+def document(
+    sdk: str,
+    verdict: str,
+    *,
+    elapsed: float = 30,
+    skipped: int = 0,
+) -> dict[str, object]:
+    ratio = {
+        "REGRESSION": 1.3,
+        "IMPROVED": 0.7,
+        "INCONCLUSIVE": 1.1,
+        "PASS": 1.0,
+    }[verdict]
+    return {
+        "schema": 2,
+        "metadata": {
+            "sdk": sdk,
+            "platform_version": "v0.4.50",
+            "arm_sources": [{"tag": "v1"}, {"tag": "main"}],
+        },
+        "config": {"gated_metrics": ["wall", "rss"]},
+        "noise_floor": {"assessed": True, "width_ratio": 1.04},
+        "trustworthy": True,
+        "skipped": {f"skipped-{i}": "unsupported" for i in range(skipped)},
+        "cells": [
+            {
+                "id": f"{sdk}-encrypt-1MiB",
+                "control": False,
+                "reference": "v1",
+                "arms": ["v1", "main"],
+                "elapsed_s": elapsed,
+                "contrasts": {
+                    "main_vs_v1": {
+                        "wall": {
+                            "verdict": verdict,
+                            "ratio": ratio,
+                            "ci_low": ratio - 0.02,
+                            "ci_high": ratio + 0.02,
+                        }
+                    }
+                },
+            }
+        ],
+    }
+
+
+def test_load_runs_ignores_unrelated_json_and_uses_stable_sdk_order(tmp_path: Path):
+    (tmp_path / "java.json").write_text(json.dumps(document("java", "PASS")))
+    (tmp_path / "go.json").write_text(json.dumps(document("go", "PASS")))
+    (tmp_path / "unrelated.json").write_text('{"hello": "world"}')
+
+    assert [run.sdk for run in aggregate.load_runs(tmp_path)] == ["go", "java"]
+
+
+def test_rollup_puts_the_cross_sdk_bottom_line_first_and_combines_run_facts():
+    runs = [
+        aggregate.Run("go", document("go", "REGRESSION", elapsed=20)),
+        aggregate.Run("java", document("java", "PASS", elapsed=30, skipped=1)),
+        aggregate.Run("js", document("js", "INCONCLUSIVE", elapsed=40)),
+    ]
+    md = aggregate.markdown(
+        runs,
+        artifact_urls={
+            "go": "https://example.test/go",
+            "java": "https://example.test/java",
+        },
+        run_url="https://example.test/run",
+        expected_sdks=["go", "java", "js"],
+    )
+
+    assert md.startswith("# SDK performance benchmark roll-up — REGRESSION\n")
+    assert "go: REGRESSION, java: PASS, js: INCONCLUSIVE" in md
+    assert md.index("### TL;DR") < md.index("| SDK | outcome")
+    assert md.index("| SDK | outcome") < md.index("### Confirmed regressions")
+    assert "| go | `go-encrypt-1MiB` | wall | +30.0% [+28.0%, +32.0%] |" in md
+    assert "| 3/3 | 3 | 1 | 90s | v0.4.50 |" in md
+    assert "[artifact](https://example.test/go)" in md
+    assert "[Workflow run](https://example.test/run)" in md
+    assert "Absolute timings are not compared across SDKs" in md
+
+
+def test_rollup_explains_when_no_matrix_artifact_survived():
+    md = aggregate.markdown([], run_url="https://example.test/run")
+
+    assert "NO RESULTS" in md
+    assert "No benchmark JSON artifacts were available" in md
+
+
+def test_rollup_makes_a_missing_matrix_result_visible():
+    md = aggregate.markdown(
+        [aggregate.Run("go", document("go", "PASS"))],
+        expected_sdks=["go", "java"],
+    )
+
+    assert "roll-up — INCOMPLETE" in md
+    assert "Missing result(s): java" in md
+    assert "| **java** | **MISSING** |" in md
+
+
+def test_a_control_without_a_result_cell_is_nothing_measured():
+    doc = document("go", "PASS")
+    doc["cells"] = [{"id": "go-control", "control": True, "contrasts": {}}]
+
+    assert aggregate.Run("go", doc).status == "NOTHING MEASURED"

--- a/xtest/test_bench_arms.py
+++ b/xtest/test_bench_arms.py
@@ -10,6 +10,7 @@ No platform and no real SDK; the builds are stub ``cli.sh`` trees in
 ``tmp_path``.
 """
 
+import json
 import shutil
 from collections.abc import Sequence
 from pathlib import Path
@@ -209,6 +210,59 @@ class TestArmOptions:
 
     def test_the_arm_count_follows_the_refs(self):
         assert bench.arm_count(options(bench_refs="go@a,go@b,go@c")) == 3
+
+
+class TestRunnerMetadata:
+    def test_resolver_provenance_is_preserved_and_enriched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv(
+            "BENCH_VERSION_INFO",
+            json.dumps(
+                [
+                    {
+                        "sdk": "go",
+                        "tag": "v0.30.0",
+                        "release": "v0.30.0",
+                        "sha": "a" * 40,
+                    },
+                    {
+                        "sdk": "go",
+                        "tag": "feature",
+                        "pr": 42,
+                        "head": True,
+                        "sha": "b" * 40,
+                    },
+                ]
+            ),
+        )
+
+        sources, warning = bench._arm_sources()
+
+        assert warning == ""
+        assert sources[0]["repo_url"] == "https://github.com/opentdf/otdfctl"
+        assert sources[1]["repo_url"] == "https://github.com/opentdf/platform"
+
+    def test_bad_resolver_metadata_degrades_to_an_explanation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("BENCH_VERSION_INFO", "not-json")
+
+        sources, warning = bench._arm_sources()
+
+        assert sources == []
+        assert "not valid JSON" in warning
+
+    def test_workflow_url_needs_all_three_parts(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "opentdf/tests")
+        monkeypatch.setenv("GITHUB_RUN_ID", "123")
+        assert bench._github_run_url() == (
+            "https://github.com/opentdf/tests/actions/runs/123"
+        )
+
+        monkeypatch.delenv("GITHUB_RUN_ID")
+        assert bench._github_run_url() == ""
 
 
 class TestDefaultBudget:

--- a/xtest/test_bench_arms.py
+++ b/xtest/test_bench_arms.py
@@ -264,6 +264,29 @@ class TestRunnerMetadata:
         monkeypatch.delenv("GITHUB_RUN_ID")
         assert bench._github_run_url() == ""
 
+    def test_requested_names_survive_resolver_deduplication(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("BENCH_REQUESTED_REFS", "main latest")
+
+        assert bench._requested_refs() == ["main", "latest"]
+
+    def test_one_resolved_sha_from_two_names_is_marked_same_commit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("BENCH_REQUESTED_REFS", "main latest")
+        monkeypatch.setattr(
+            bench,
+            "_arm_sources",
+            lambda: ([{"tag": "main", "sha": "a" * 40}], ""),
+        )
+        monkeypatch.setattr(bench, "_platform_version", lambda: "test")
+
+        metadata = bench.runner_metadata(options(bench_seed="0"))
+
+        assert metadata["comparison_status"] == "same_commit"
+        assert "main, latest" in str(metadata["comparison_note"])
+
 
 class TestDefaultBudget:
     def test_two_arms_keep_the_number_the_default_was_chosen_for(self):

--- a/xtest/test_bench_arms.py
+++ b/xtest/test_bench_arms.py
@@ -86,6 +86,38 @@ class TestBaselineSelection:
         with pytest.raises(bench.ArmSelectionError, match="nothing to compare"):
             bench.select_arms("go", baseline_spec="go@main", candidate_spec="go@main")
 
+    def test_two_branch_builds_need_explicit_specs(self, cwd: Path):
+        # What a branch-vs-branch dispatch installs: two heads and no release
+        # at all. Named explicitly it is a fine comparison; left to the default
+        # there is no baseline, and "newest final release" cannot invent one.
+        install(cwd, "go", "main", "feat--DSPX-2604-createtdf-chunked")
+        baseline, candidate = bench.select_arms(
+            "go",
+            baseline_spec="go@main",
+            candidate_spec="go@feat--DSPX-2604-createtdf-chunked",
+        )
+        assert baseline.version == "main"
+        assert candidate.version == "feat--DSPX-2604-createtdf-chunked"
+        with pytest.raises(bench.ArmSelectionError, match="no final go release"):
+            bench.select_arms("go")
+
+
+class TestDistTagShape:
+    def test_a_slashed_tag_breaks_discovery(self, cwd: Path):
+        # Why otdf-sdk-mgr flattens '/' to '--' in a resolved ref. A branch
+        # installed as dist/feat/x/ is listed as a build named "feat", which
+        # has no cli.sh -- and this raises during collection, before any cell
+        # has a chance to report why.
+        install(cwd, "go", "feat/DSPX-2604-createtdf-chunked")
+        with pytest.raises(FileNotFoundError):
+            tdfs.all_versions_of("go")
+
+    def test_a_flattened_tag_is_discovered(self, cwd: Path):
+        install(cwd, "go", "feat--DSPX-2604-createtdf-chunked")
+        assert [s.version for s in tdfs.all_versions_of("go")] == [
+            "feat--DSPX-2604-createtdf-chunked"
+        ]
+
 
 #: The fixture body, called directly: these tests are about the bytes it
 #: writes, not about pytest's fixture wiring.

--- a/xtest/test_bench_arms.py
+++ b/xtest/test_bench_arms.py
@@ -10,8 +10,11 @@ No platform and no real SDK; the builds are stub ``cli.sh`` trees in
 ``tmp_path``.
 """
 
+import shutil
 from collections.abc import Sequence
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -42,6 +45,27 @@ def cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """`SDK.__init__` resolves `cli.sh` relative to the cwd, so move there."""
     monkeypatch.chdir(tmp_path)
     return tmp_path
+
+
+class FakeConfig:
+    """A ``pytest.Config`` stub answering the ``--bench-*`` options named."""
+
+    def __init__(self, **opts: str | None) -> None:
+        self._opts = {name.replace("_", "-"): value for name, value in opts.items()}
+
+    def getoption(self, name: str) -> str | None:
+        return self._opts.get(name.removeprefix("--"))
+
+
+class FakeRequest:
+    """Just enough of ``FixtureRequest``: the fixtures only read ``config``."""
+
+    def __init__(self, config: FakeConfig) -> None:
+        self.config = config
+
+
+def options(**opts: str | None) -> pytest.Config:
+    return cast(pytest.Config, FakeConfig(**opts))
 
 
 class TestFinalRelease:
@@ -85,15 +109,13 @@ class TestBaselineSelection:
 
     def test_explicit_specs_win(self, cwd: Path):
         install(cwd, "go", "main", "v0.28.0", "v0.29.0")
-        baseline, candidate = bench.select_arms(
-            "go", baseline_spec="go@v0.28.0", candidate_spec="go@v0.29.0"
-        )
+        baseline, candidate = bench.select_arms("go", ["go@v0.28.0", "go@v0.29.0"])
         assert (baseline.version, candidate.version) == ("v0.28.0", "v0.29.0")
 
     def test_refuses_to_compare_a_build_against_itself(self, cwd: Path):
         install(cwd, "go", "main", "v0.29.0")
-        with pytest.raises(bench.ArmSelectionError, match="nothing to compare"):
-            bench.select_arms("go", baseline_spec="go@main", candidate_spec="go@main")
+        with pytest.raises(bench.ArmSelectionError, match="same build"):
+            bench.select_arms("go", ["go@main", "go@main"])
 
     def test_two_branch_builds_need_explicit_specs(self, cwd: Path):
         # What a branch-vs-branch dispatch installs: two heads and no release
@@ -101,14 +123,119 @@ class TestBaselineSelection:
         # there is no baseline, and "newest final release" cannot invent one.
         install(cwd, "go", "main", "feat--DSPX-2604-createtdf-chunked")
         baseline, candidate = bench.select_arms(
-            "go",
-            baseline_spec="go@main",
-            candidate_spec="go@feat--DSPX-2604-createtdf-chunked",
+            "go", ["go@main", "go@feat--DSPX-2604-createtdf-chunked"]
         )
         assert baseline.version == "main"
         assert candidate.version == "feat--DSPX-2604-createtdf-chunked"
         with pytest.raises(bench.ArmSelectionError, match="no final go release"):
             bench.select_arms("go")
+
+    def test_the_first_spec_is_the_reference(self, cwd: Path):
+        # Order is the whole interface: every gated contrast is taken against
+        # arms[0], so reversing the list reverses which build is on trial.
+        install(cwd, "go", "main", "a--impl", "b--impl")
+        arms = bench.select_arms("go", ["go@main", "go@a--impl", "go@b--impl"])
+        assert [a.version for a in arms] == ["main", "a--impl", "b--impl"]
+        assert bench.BenchArms(arms).reference.version == "main"
+        assert [a.version for a in bench.BenchArms(arms).candidates] == [
+            "a--impl",
+            "b--impl",
+        ]
+
+    def test_a_missing_arm_names_which_one(self, cwd: Path):
+        install(cwd, "go", "main", "a--impl")
+        with pytest.raises(bench.ArmSelectionError, match="arm 3"):
+            bench.select_arms("go", ["go@main", "go@a--impl", "go@nope"])
+
+
+class TestRefSpecParsing:
+    def test_commas_or_whitespace_both_work(self):
+        assert bench.parse_refs("go@main,go@a") == ("go@main", "go@a")
+        assert bench.parse_refs("go@main go@a") == ("go@main", "go@a")
+
+    def test_a_single_ref_is_refused(self):
+        # One arm is not a comparison, and the harness reports only ratios.
+        with pytest.raises(ValueError, match="need 2 to 4 refs"):
+            bench.parse_refs("go@main")
+
+    def test_more_than_four_is_refused(self):
+        # setup-cli-tool installs four builds side by side; a fifth would be
+        # silently absent at measurement time.
+        with pytest.raises(ValueError, match="need 2 to 4 refs"):
+            bench.parse_refs("go@a,go@b,go@c,go@d,go@e")
+
+    def test_a_repeated_ref_is_refused(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            bench.parse_refs("go@main,go@main")
+
+
+class TestSpecsForSdk:
+    def test_specs_naming_another_sdk_fall_back_to_the_default(self):
+        # A run measuring go and java with refs for go only: java still gets
+        # its own default pair rather than an error or go's builds.
+        assert bench._specs_for(("go@main", "go@a"), "java") is None
+
+    def test_a_mixed_sdk_list_is_an_error(self):
+        with pytest.raises(bench.ArmSelectionError, match="more than one SDK"):
+            bench._specs_for(("go@main", "java@main"), "go")
+
+
+class TestArmOptions:
+    def test_no_options_means_the_default_pair(self):
+        # The nightly passes nothing at all, and must keep getting the
+        # (newest release, branch head) comparison it has always run.
+        assert bench.arm_specs_from_options(options()) is None
+        assert bench.arm_count(options()) == 2
+
+    def test_the_two_arm_shorthand_still_works(self):
+        cfg = options(bench_baseline="go@v0.29.0", bench_candidate="go@main")
+        assert bench.arm_specs_from_options(cfg) == ("go@v0.29.0", "go@main")
+
+    def test_half_a_pair_is_a_usage_error(self):
+        with pytest.raises(pytest.UsageError, match="together"):
+            bench.arm_specs_from_options(options(bench_baseline="go@main"))
+
+    def test_mixing_the_two_forms_is_a_usage_error(self):
+        # There is no reading of "--bench-refs a,b --bench-candidate c" that
+        # is not a mistake, and silently picking one would measure something
+        # nobody asked for.
+        cfg = options(bench_refs="go@a,go@b", bench_candidate="go@c")
+        with pytest.raises(pytest.UsageError, match="cannot be combined"):
+            bench.arm_specs_from_options(cfg)
+
+    def test_a_malformed_refs_list_is_a_usage_error(self):
+        with pytest.raises(pytest.UsageError, match="invalid --bench-refs"):
+            bench.arm_specs_from_options(options(bench_refs="go@main"))
+
+    def test_the_arm_count_follows_the_refs(self):
+        assert bench.arm_count(options(bench_refs="go@a,go@b,go@c")) == 3
+
+
+class TestDefaultBudget:
+    def test_two_arms_keep_the_number_the_default_was_chosen_for(self):
+        assert bench.default_budget_seconds(2) == BenchConfig().budget_seconds
+
+    def test_the_budget_scales_with_the_arm_count(self):
+        # A round costs one invocation per arm, so at a fixed budget the round
+        # count falls as 2/K and every interval widens as sqrt(K/2). Scaling
+        # the default by K/2 buys back the precision instead of quietly
+        # trading it for arms and reporting the loss as INCONCLUSIVE.
+        base = BenchConfig().budget_seconds
+        assert bench.default_budget_seconds(3) == base * 1.5
+        assert bench.default_budget_seconds(4) == base * 2
+
+    def test_an_explicit_budget_is_taken_as_given(self):
+        cfg = FakeConfig(
+            bench_refs="go@a,go@b,go@c",
+            bench_budget_seconds="900",
+            bench_min_rounds="20",
+            bench_max_rounds="60",
+            bench_warmup="5",
+            bench_seed="1",
+            bench_threshold="1.15",
+        )
+        built = bench.config_from_options(cast(pytest.Config, cfg))
+        assert built.budget_seconds == 900.0, "a named number is not scaled"
 
 
 class TestDistTagShape:
@@ -201,15 +328,120 @@ class TestCellMatrix:
             assert control.payload == CONTROL_PAYLOAD
 
 
+def stub_sdk(cwd: Path, version: str, **features: bool) -> tdfs.SDK:
+    """An installed stub build whose feature support is stated, not inferred.
+
+    Real support is derived from the version string, which would make these
+    tests assertions about the version table rather than about arm selection.
+    """
+    install(cwd, "go", version)
+    sdk = tdfs.SDK("go", version)
+    sdk._supports.update(cast(dict[tdfs.feature_type, bool], features))
+    return sdk
+
+
+#: Every comparability feature present, which is the uninteresting case.
+COMPARABLE = {"hexless": True, "hexaflexible": True, "autoconfigure": True}
+
+
+class TestComparability:
+    def test_matching_arms_are_comparable(self, cwd: Path):
+        arms = bench.BenchArms(
+            (
+                stub_sdk(cwd, "main", **COMPARABLE),
+                stub_sdk(cwd, "a--impl", **COMPARABLE),
+                stub_sdk(cwd, "b--impl", **COMPARABLE),
+            )
+        )
+        assert bench.comparability_problem(arms) is None
+
+    def test_every_candidate_is_checked_against_the_reference(self, cwd: Path):
+        # Checking only adjacent pairs would clear a third arm that disagrees
+        # with the reference, and its gated contrast is taken against exactly
+        # that reference -- so it would be timing different work.
+        odd_one_out = bench.BenchArms(
+            (
+                stub_sdk(cwd, "main", **COMPARABLE),
+                stub_sdk(cwd, "a--impl", **COMPARABLE),
+                stub_sdk(cwd, "b--impl", **(COMPARABLE | {"autoconfigure": False})),
+            )
+        )
+        problem = bench.comparability_problem(odd_one_out)
+        assert problem is not None
+        assert "b--impl" in problem and "autoconfigure" in problem
+
+    def test_the_target_mode_is_pinned_only_when_every_arm_can_be_told(self, cwd: Path):
+        # Letting one arm choose its own container version would compare
+        # output formats rather than speed.
+        all_new = (
+            stub_sdk(cwd, "main", **COMPARABLE),
+            stub_sdk(cwd, "a--impl", **COMPARABLE),
+        )
+        assert bench.pinned_target_mode(bench.BenchArms(all_new)) == "4.3.0"
+        one_old = all_new + (
+            stub_sdk(cwd, "b--impl", **(COMPARABLE | {"hexaflexible": False})),
+        )
+        assert bench.pinned_target_mode(bench.BenchArms(one_old)) is None
+
+
+class TestBuildArms:
+    def cell_arms(self, cwd: Path, control: bool, n: int):
+        arms = bench.BenchArms(
+            tuple(
+                stub_sdk(cwd, v, **COMPARABLE)
+                for v in ("main", "a--impl", "b--impl", "c--impl")[:n]
+            )
+        )
+        cells = cells_for(["go"], parse_payloads("1KiB"))
+        cell = next(
+            c for c in cells if c.control is control and c.operation == "encrypt"
+        )
+        pt = cwd / "plain.bin"
+        pt.write_bytes(b"x" * 1024)
+        return bench.build_arms(
+            cell,
+            arms,
+            pt_file=pt,
+            ct_file=None,
+            tmp_dir=cwd,
+            attr_values=[],
+        )
+
+    def test_one_arm_per_build(self, cwd: Path):
+        built = self.cell_arms(cwd, control=False, n=3)
+        assert [a.name for a in built] == ["main", "a--impl", "b--impl"]
+
+    def test_every_arm_writes_its_own_output(self, cwd: Path):
+        # Sharing an output path would have the arms overwrite each other
+        # mid-round, and the second one would be measured deleting the first.
+        built = self.cell_arms(cwd, control=False, n=3)
+        assert len({a.invocation.output for a in built}) == 3
+
+    def test_the_control_is_k_copies_of_the_reference(self, cwd: Path):
+        # Not a cheap pair: in a K-arm round the last arm runs K-1 invocations
+        # after the first, so a two-arm control would measure less drift than
+        # the contrasts it is the noise floor for.
+        built = self.cell_arms(cwd, control=True, n=3)
+        assert len(built) == 3
+        assert {a.label for a in built} == {"go@main"}
+        assert len({a.name for a in built}) == 3, "ids key the sample vectors"
+        assert len({a.invocation.output for a in built}) == 3
+
+
 #: The fixture body, called directly: these tests are about the bytes it
 #: writes, not about pytest's fixture wiring.
 _make_payloads = bench.bench_payloads.__wrapped__  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def make_payloads(
-    tmp_path: Path, config: BenchConfig, payloads: Sequence[Payload] = PAYLOADS
+    tmp_path: Path,
+    config: BenchConfig,
+    payloads: Sequence[Payload] = PAYLOADS,
+    *,
+    refs: str | None = None,
 ) -> dict[str, Path]:
-    return _make_payloads(tmp_path, config, tuple(payloads))
+    request = cast(pytest.FixtureRequest, FakeRequest(FakeConfig(bench_refs=refs)))
+    return _make_payloads(request, tmp_path, config, tuple(payloads))
 
 
 class TestPayloads:
@@ -274,6 +506,21 @@ class TestPayloads:
         huge = Payload("1024GiB", 1024 * 2**30)
         assert bench.disk_shortfall(tmp_path, [huge]) is not None
         assert bench.disk_shortfall(tmp_path, [Payload("1KiB", 1024)]) is None
+
+    def test_the_disk_estimate_grows_with_the_arm_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A cell holds one live output per arm, so a 1 GiB four-arm run needs
+        # two more GiB than the two-arm arithmetic accounts for -- which on a
+        # GitHub runner is the whole margin.
+        gib = 2**30
+        payloads = [Payload("1GiB", gib)]
+        free = 2 * gib + 3 * gib + bench._DISK_HEADROOM_BYTES  # exactly three arms
+        monkeypatch.setattr(
+            shutil, "disk_usage", lambda p: SimpleNamespace(total=0, used=0, free=free)
+        )
+        assert bench.disk_shortfall(tmp_path, payloads, 3) is None
+        assert bench.disk_shortfall(tmp_path, payloads, 4) is not None
 
 
 def read_all(paths: dict[str, Path]) -> dict[str, bytes]:

--- a/xtest/test_bench_arms.py
+++ b/xtest/test_bench_arms.py
@@ -10,13 +10,22 @@ No platform and no real SDK; the builds are stub ``cli.sh`` trees in
 ``tmp_path``.
 """
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
 
 import tdfs
 from fixtures import bench
-from perf.cells import PAYLOADS
+from perf.cells import (
+    CONTROL_PAYLOAD,
+    DEFAULT_PAYLOAD_SPEC,
+    PAYLOADS,
+    Payload,
+    cells_for,
+    parse_payload,
+    parse_payloads,
+)
 from perf.runner import BenchConfig
 
 
@@ -119,9 +128,88 @@ class TestDistTagShape:
         ]
 
 
+class TestPayloadSpec:
+    @pytest.mark.parametrize(
+        ("spec", "n_bytes"),
+        [
+            ("512B", 512),
+            ("1KiB", 1024),
+            ("32MiB", 32 * 2**20),
+            ("1GiB", 2**30),
+            ("4GiB", 4 * 2**30),
+        ],
+    )
+    def test_sizes_parse(self, spec: str, n_bytes: int):
+        assert parse_payload(spec).n_bytes == n_bytes
+
+    def test_the_label_is_canonical_regardless_of_case(self):
+        # The label is a filename and a cell id. '1gib' and '1GiB' naming two
+        # cells would measure one size twice and report it as two results.
+        assert parse_payload("1gib").label == "1GiB"
+        assert parse_payload(" 1 GIB ").label == "1GiB"
+
+    @pytest.mark.parametrize(
+        "spec", ["", "1", "MiB", "1MB", "1.5GiB", "-1GiB", "0GiB", "1GiB extra"]
+    )
+    def test_junk_is_refused(self, spec: str):
+        with pytest.raises(ValueError):
+            parse_payload(spec)
+
+    def test_a_list_is_sorted_ascending(self):
+        labels = [p.label for p in parse_payloads("1GiB,1KiB,32MiB")]
+        assert labels == ["1KiB", "32MiB", "1GiB"]
+
+    def test_one_size_written_two_ways_is_one_payload(self):
+        # Otherwise the run pays for two identical cells and reports them as
+        # independent results, which the multiplicity correction then treats
+        # as two tests.
+        assert [p.label for p in parse_payloads("1KiB,1024B")] == ["1KiB"]
+
+    def test_an_empty_list_is_refused(self):
+        with pytest.raises(ValueError, match="no payload sizes"):
+            parse_payloads(" , ")
+
+
+class TestCellMatrix:
+    def test_the_default_matrix_is_unchanged(self):
+        ids = [c.id for c in cells_for(["go"], parse_payloads(DEFAULT_PAYLOAD_SPEC))]
+        assert ids == [
+            "go-encrypt-1MiB-control",
+            "go-encrypt-1KiB",
+            "go-decrypt-1KiB",
+            "go-encrypt-1MiB",
+            "go-decrypt-1MiB",
+            "go-encrypt-32MiB",
+            "go-decrypt-32MiB",
+        ]
+
+    def test_the_control_comes_first_and_the_biggest_pair_last(self):
+        # The budget is spent in cell order, so whatever is last is what a
+        # short run loses. Losing the control invalidates every other cell;
+        # losing the largest pair costs the most expensive measurement but
+        # leaves the rest readable.
+        cells = cells_for(["go"], parse_payloads("1KiB,1GiB"))
+        assert cells[0].control
+        assert [c.id for c in cells[-2:]] == ["go-encrypt-1GiB", "go-decrypt-1GiB"]
+
+    def test_the_control_size_does_not_follow_the_selection(self):
+        # The control's CI width is the run's noise floor and every cell is
+        # judged against it. If it moved with --bench-payloads, two runs of
+        # the same comparison could disagree on which cells are trustworthy.
+        for spec in ("1KiB", "1GiB", DEFAULT_PAYLOAD_SPEC):
+            control = next(c for c in cells_for(["go"], parse_payloads(spec)))
+            assert control.payload == CONTROL_PAYLOAD
+
+
 #: The fixture body, called directly: these tests are about the bytes it
 #: writes, not about pytest's fixture wiring.
-make_payloads = bench.bench_payloads.__wrapped__  # pyright: ignore[reportAttributeAccessIssue]
+_make_payloads = bench.bench_payloads.__wrapped__  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def make_payloads(
+    tmp_path: Path, config: BenchConfig, payloads: Sequence[Payload] = PAYLOADS
+) -> dict[str, Path]:
+    return _make_payloads(tmp_path, config, tuple(payloads))
 
 
 class TestPayloads:
@@ -155,6 +243,37 @@ class TestPayloads:
         path.write_bytes(b"truncated")
         second = read_all(make_payloads(tmp_path, BenchConfig(seed=1)))
         assert first == second
+
+    def test_the_controls_payload_is_generated_even_when_not_selected(
+        self, tmp_path: Path
+    ):
+        # --bench-payloads 1GiB is a legitimate ask, and the A/A control still
+        # needs its own file. Without it the control cell dies on a KeyError
+        # in arm construction -- and a run with no control can pass nothing.
+        out = make_payloads(tmp_path, BenchConfig(seed=1), [Payload("4KiB", 4096)])
+        assert out[CONTROL_PAYLOAD.label].stat().st_size == CONTROL_PAYLOAD.n_bytes
+
+    def test_chunking_does_not_change_the_bytes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A 1 GiB payload is written in chunks rather than built in RAM. The
+        # chunk size must not be part of the seed contract: a run compared
+        # against an earlier one has to measure the same bytes, and the check
+        # is cheap next to the cost of discovering otherwise.
+        payload = Payload("40KiB", 40 * 1024)
+        whole = subdir(tmp_path, "whole")
+        bench.write_payload(whole / "p.bin", payload, seed=7)
+        monkeypatch.setattr(bench, "_CHUNK_BYTES", 4096)
+        chunked = subdir(tmp_path, "chunked")
+        bench.write_payload(chunked / "p.bin", payload, seed=7)
+        assert (whole / "p.bin").read_bytes() == (chunked / "p.bin").read_bytes()
+
+    def test_a_payload_too_big_for_the_disk_is_refused_up_front(self, tmp_path: Path):
+        # Running out of disk mid-benchmark surfaces as a non-zero exit from
+        # the CLI under measurement, which reads as "this build is broken".
+        huge = Payload("1024GiB", 1024 * 2**30)
+        assert bench.disk_shortfall(tmp_path, [huge]) is not None
+        assert bench.disk_shortfall(tmp_path, [Payload("1KiB", 1024)]) is None
 
 
 def read_all(paths: dict[str, Path]) -> dict[str, bytes]:

--- a/xtest/test_bench_report.py
+++ b/xtest/test_bench_report.py
@@ -250,6 +250,7 @@ class TestMarkdown:
         assert f"{repo}/compare/{'a' * 40}...{'b' * 40}" in md
         assert "actions/runs/42/artifacts/7" in md
         assert "actions/runs/42" in md
+        assert "candidate A" in md
 
     def test_the_primary_table_omits_clean_rows_but_the_full_table_keeps_them(self):
         cfg = config(min_rounds=10, max_rounds=60)
@@ -261,7 +262,7 @@ class TestMarkdown:
         assert "`clean` vs `base`" not in primary
         assert "`clean` vs `base`" in md
 
-    def test_attention_rows_get_fixed_scale_unicode_views(self):
+    def test_attention_rows_get_shared_scale_unicode_views(self):
         cfg = config(max_rounds=40)
         rec = recorder({REF: 1.0, "cand": 1.35}, cfg=cfg, noise=0.01)
         md = report.markdown(rec, cfg, rec.gate(cfg))
@@ -270,6 +271,17 @@ class TestMarkdown:
         assert "┆" in md and "│" in md and "●" in md
         assert "Round stability for attention rows" in md
         assert any("\u2800" <= char <= "\u28ff" for char in md)
+
+    def test_extreme_effects_fit_and_name_their_candidate(self):
+        cfg = config(min_rounds=12, max_rounds=40)
+        rec = recorder({REF: 1.0, "epic": 0.02, "fast": 0.5}, cfg=cfg, noise=0.005)
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+        effect = md.split("#### Effect at a glance", 1)[1].split("### Bake-off", 1)[0]
+
+        assert "candidate A" in effect and "candidate B" in effect
+        assert "-98.0%" in effect and "-49.7%" in effect
+        assert "◀" not in effect
+        assert "◆" in effect
 
     def test_run_facts_end_the_summary_with_reproducibility_context(self):
         cfg = config(max_rounds=40, seed=91)

--- a/xtest/test_bench_report.py
+++ b/xtest/test_bench_report.py
@@ -163,6 +163,15 @@ class TestJsonArtifact:
         wall = next(b for b in doc["bake_off"] if b["metric"] == "wall")
         assert wall["winner"] == "quick"
 
+    def test_both_directional_p_values_are_recorded(self, tmp_path: Path):
+        doc = self.artifact(tmp_path, {REF: 1.0, "cand": 0.7})
+        cell = next(c for c in doc["cells"] if c["id"] == "encrypt")
+        wall = cell["contrasts"][f"cand_vs_{REF}"]["wall"]
+        assert wall["p_value"] is not None
+        assert wall["p_adjusted"] is not None
+        assert wall["p_value_faster"] is not None
+        assert wall["p_adjusted_faster"] is not None
+
     def test_the_file_is_valid_json_despite_nan(self, tmp_path: Path):
         # A cell with no usable interval produces NaN, which `json.dumps`
         # would happily write as a bare `NaN` that no strict parser accepts.
@@ -193,3 +202,103 @@ class TestMarkdown:
         assert "### Bake-off" not in report.markdown(two, cfg, two.gate(cfg))
         three = recorder({REF: 1.0, "a": 1.0, "b": 1.3}, cfg=cfg, noise=0.02)
         assert "### Bake-off" in report.markdown(three, cfg, three.gate(cfg))
+
+    def test_the_bottom_line_precedes_supporting_detail(self):
+        cfg = config(max_rounds=40)
+        rec = recorder({REF: 1.0, "cand": 1.35}, cfg=cfg, noise=0.01)
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+
+        assert md.index("### TL;DR") < md.index("### Compared builds")
+        assert md.index("### Compared builds") < md.index("### What changed")
+        assert md.index("### What changed") < md.index("All measurements")
+        assert md.index("All measurements") < md.index("### Run facts")
+
+    def test_provenance_links_releases_prs_commits_and_the_diff(self):
+        cfg = config(max_rounds=40)
+        rec = recorder({REF: 1.0, "cand": 1.35}, cfg=cfg, noise=0.01)
+        repo = "https://github.com/opentdf/platform"
+        rec.metadata = {
+            "github_run_url": "https://github.com/opentdf/tests/actions/runs/42",
+            "arm_sources": [
+                {
+                    "tag": REF,
+                    "alias": "latest",
+                    "release": "otdfctl/v0.40.0",
+                    "sha": "a" * 40,
+                    "repo_url": repo,
+                },
+                {
+                    "tag": "cand",
+                    "alias": "feature",
+                    "pr": 123,
+                    "head": True,
+                    "sha": "b" * 40,
+                    "repo_url": repo,
+                },
+            ],
+        }
+        md = report.markdown(
+            rec,
+            cfg,
+            rec.gate(cfg),
+            artifact_url="https://github.com/opentdf/tests/actions/runs/42/artifacts/7",
+        )
+
+        assert f"{repo}/releases/tag/otdfctl%2Fv0.40.0" in md
+        assert f"{repo}/pull/123" in md
+        assert f"{repo}/commit/{'b' * 40}" in md
+        assert f"{repo}/compare/{'a' * 40}...{'b' * 40}" in md
+        assert "actions/runs/42/artifacts/7" in md
+        assert "actions/runs/42" in md
+
+    def test_the_primary_table_omits_clean_rows_but_the_full_table_keeps_them(self):
+        cfg = config(min_rounds=10, max_rounds=60)
+        rec = recorder({REF: 1.0, "clean": 1.0, "slow": 1.4}, cfg=cfg, noise=0.005)
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+        primary = md.split("### What changed", 1)[1].split("### Bake-off", 1)[0]
+
+        assert "`slow` vs `base`" in primary
+        assert "`clean` vs `base`" not in primary
+        assert "`clean` vs `base`" in md
+
+    def test_attention_rows_get_fixed_scale_unicode_views(self):
+        cfg = config(max_rounds=40)
+        rec = recorder({REF: 1.0, "cand": 1.35}, cfg=cfg, noise=0.01)
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+
+        assert "#### Effect at a glance" in md
+        assert "┆" in md and "│" in md and "●" in md
+        assert "Round stability for attention rows" in md
+        assert any("\u2800" <= char <= "\u28ff" for char in md)
+
+    def test_run_facts_end_the_summary_with_reproducibility_context(self):
+        cfg = config(max_rounds=40, seed=91)
+        rec = recorder({REF: 1.0, "cand": 1.0}, cfg=cfg, noise=0.01)
+        rec.metadata = {
+            "platform_version": "v0.4.50",
+            "runner_os": "Linux",
+        }
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+
+        assert "### Run facts" in md
+        assert "v0.4.50" in md and "Linux" in md
+        assert "seed 91" in md
+        assert md.rstrip().endswith("cells skipped.</sub>")
+
+    def test_braille_trace_is_compact_and_deterministic(self):
+        values = [0.9, 1.0, 1.1, 1.2] * 20
+        trace = report._braille_sparkline(values, 1.15)
+
+        assert trace == report._braille_sparkline(values, 1.15)
+        assert len(trace) == 24
+        assert all("\u2800" <= char <= "\u28ff" for char in trace)
+
+
+class TestMarkdownTemplate:
+    def test_it_can_be_published_after_the_artifact_url_is_known(self, tmp_path: Path):
+        path = report.write_markdown(
+            tmp_path / "go.summary.md",
+            f"[evidence]({report.ARTIFACT_URL_PLACEHOLDER})\n",
+        )
+
+        assert report.ARTIFACT_URL_PLACEHOLDER in path.read_text()

--- a/xtest/test_bench_report.py
+++ b/xtest/test_bench_report.py
@@ -252,6 +252,70 @@ class TestMarkdown:
         assert "actions/runs/42" in md
         assert "candidate A" in md
 
+    def test_short_arm_names_are_links_and_controls_explain_the_same_build(self):
+        cfg = config(max_rounds=40)
+        rec = recorder({REF: 1.0, "cand": 1.0}, cfg=cfg, noise=0.01)
+        repo = "https://github.com/opentdf/platform"
+        rec.metadata = {
+            "arm_sources": [
+                {
+                    "tag": REF,
+                    "release": "otdfctl/v0.37.0",
+                    "sha": "a" * 40,
+                    "repo_url": repo,
+                },
+                {
+                    "tag": "cand",
+                    "pr": 321,
+                    "sha": "b" * 40,
+                    "repo_url": repo,
+                },
+            ]
+        }
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+
+        assert f"[`{REF}`]({repo}/releases/tag/otdfctl%2Fv0.37.0)" in md
+        assert f"[`cand`]({repo}/pull/321)" in md
+        assert "**A/A control** rows intentionally run multiple copies" in md
+        sources = report._sources_by_tag(rec.metadata)
+        assert report._linked_arm(f"{REF}#2", sources) == (
+            f"[`{REF} copy 2`]({repo}/releases/tag/otdfctl%2Fv0.37.0)"
+        )
+        assert "ratio b/a (95% CI)" in md
+
+    def test_same_commit_is_neutral_and_explains_why_nothing_ran(self):
+        cfg = config(max_rounds=25)
+        rec = report.BenchmarkRecorder(
+            skipped={"java-encrypt-1KiB": "only one build installed"},
+            metadata={
+                "sdk": "java",
+                "comparison_status": "same_commit",
+                "comparison_note": (
+                    "main, latest resolve to the same commit 57d070b; "
+                    "there is no code difference to benchmark."
+                ),
+                "requested_refs": ["main", "latest"],
+                "arm_sources": [
+                    {
+                        "tag": "main",
+                        "head": True,
+                        "sha": "57d070b075a9134a11f8926b8898ac19b8cb6718",
+                        "repo_url": "https://github.com/opentdf/java-sdk",
+                    }
+                ],
+            },
+        )
+        gate = rec.gate(cfg)
+        md = report.markdown(rec, cfg, gate)
+
+        assert gate.nothing_measured
+        assert report.same_commit(rec.metadata)
+        assert md.startswith("## JAVA SDK performance — SAME COMMIT")
+        assert "No performance comparison was necessary" in md
+        assert "every measured wall-clock" not in md
+        assert "### Compared builds" in md
+        assert "[`latest`](https://github.com/opentdf/java-sdk/tree/57d070" in md
+
     def test_the_primary_table_omits_clean_rows_but_the_full_table_keeps_them(self):
         cfg = config(min_rounds=10, max_rounds=60)
         rec = recorder({REF: 1.0, "clean": 1.0, "slow": 1.4}, cfg=cfg, noise=0.005)

--- a/xtest/test_bench_report.py
+++ b/xtest/test_bench_report.py
@@ -1,0 +1,195 @@
+"""Tests for what a benchmark run publishes: the JSON artifact and the summary.
+
+The report is where a K-arm run stops being a pile of ratios and starts being
+an answer, so the things worth pinning down are the ones a reader would act on
+without checking: which arm won a bake-off, whether a tie is reported as a tie,
+and whether a run that could not resolve anything says so instead of returning
+a quiet page of INCONCLUSIVE.
+
+Measurement is simulated exactly as in ``test_bench_runner``; nothing here
+touches a platform or a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from perf import report, stats
+from perf.runner import BenchConfig
+from test_bench_runner import REF, config, run
+
+
+def recorder(
+    costs: Mapping[str, float],
+    *,
+    cfg: BenchConfig | None = None,
+    noise: float = 0.05,
+    control: bool = True,
+) -> report.BenchmarkRecorder:
+    """A recorder holding one measured cell and, by default, its A/A control."""
+    cfg = cfg or config(max_rounds=40)
+    rec = report.BenchmarkRecorder()
+    if control:
+        aa, _ = run(
+            dict.fromkeys(costs, 1.0),
+            cfg=cfg,
+            noise=noise,
+            seed=11,
+            cell_id="aa",
+            control=True,
+            sdk="go",
+        )
+        rec.record(aa)
+    measured, _ = run(costs, cfg=cfg, noise=noise, seed=12, cell_id="encrypt", sdk="go")
+    rec.record(measured)
+    return rec
+
+
+def bake_offs(
+    costs: Mapping[str, float], *, cfg: BenchConfig | None = None, noise: float = 0.05
+) -> tuple[list[report.BakeOff], BenchConfig]:
+    cfg = cfg or config(max_rounds=40)
+    rec = recorder(costs, cfg=cfg, noise=noise)
+    return report.bake_offs(rec, cfg, rec.gate(cfg)), cfg
+
+
+class TestBakeOff:
+    def test_a_two_arm_run_has_nothing_to_rank(self):
+        # One candidate is not a bake-off, and the gate has already said
+        # everything there is to say about it.
+        offs, _ = bake_offs({REF: 1.0, "cand": 1.3})
+        assert offs == []
+
+    def test_the_control_is_never_ranked(self):
+        offs, _ = bake_offs({REF: 1.0, "a": 1.0, "b": 1.3})
+        assert offs and all(b.cell_id == "encrypt" for b in offs)
+
+    def test_the_faster_candidate_wins(self):
+        offs, _ = bake_offs({REF: 1.0, "slow": 1.4, "quick": 1.0}, noise=0.02)
+        wall = next(b for b in offs if b.metric == "wall")
+        assert wall.winner == "quick"
+        assert wall.order == ["quick", "slow"]
+        assert "`quick` wins" in wall.detail
+
+    def test_a_tie_refuses_to_name_a_winner(self):
+        # Picking whichever point estimate landed lower would be reporting
+        # noise as a decision, and a merge would be made on it.
+        offs, _ = bake_offs({REF: 1.0, "a": 1.0, "b": 1.0}, noise=0.01)
+        wall = next(b for b in offs if b.metric == "wall")
+        assert wall.verdict is stats.Verdict.TIED
+        assert wall.winner is None
+        assert "no measurable difference" in wall.detail
+
+    def test_an_unresolvable_pair_says_so_rather_than_guessing(self):
+        offs, _ = bake_offs(
+            {REF: 1.0, "a": 1.0, "b": 1.15},
+            cfg=config(max_rounds=20),
+            noise=0.35,
+        )
+        wall = next(b for b in offs if b.metric == "wall")
+        assert wall.winner is None
+        assert "cannot separate" in wall.detail
+
+    def test_the_ranking_covers_every_gated_metric(self):
+        offs, cfg = bake_offs({REF: 1.0, "a": 1.0, "b": 1.4}, noise=0.02)
+        assert {b.metric for b in offs} == set(cfg.gated_metrics)
+
+
+class TestUnderpoweredWarning:
+    def test_a_precise_run_says_nothing(self):
+        cfg = config(max_rounds=60)
+        rec = recorder({REF: 1.0, "a": 1.0, "b": 1.0}, cfg=cfg, noise=0.005)
+        assert report.underpowered_warning(rec, cfg, rec.gate(cfg)) is None
+
+    def test_a_run_that_could_not_resolve_anything_asks_for_more_budget(self):
+        # Otherwise three arms on a two-arm budget comes back as a wall of
+        # INCONCLUSIVE after burning the whole runner, with nothing in the
+        # output saying that time was the missing ingredient.
+        cfg = config(max_rounds=20)
+        rec = recorder({REF: 1.0, "a": 1.0, "b": 1.0}, cfg=cfg, noise=0.4)
+        warning = report.underpowered_warning(rec, cfg, rec.gate(cfg))
+        assert warning is not None
+        assert "3-arm round costs 3 invocations" in warning
+        assert "INCONCLUSIVE" in warning
+
+    def test_the_warning_reaches_the_summary(self):
+        cfg = config(max_rounds=20)
+        rec = recorder({REF: 1.0, "a": 1.0, "b": 1.0}, cfg=cfg, noise=0.4)
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+        assert "[!WARNING]" in md and "Underpowered" in md
+
+
+class TestJsonArtifact:
+    def artifact(self, tmp_path: Path, costs: Mapping[str, float]) -> dict:
+        cfg = config(max_rounds=40)
+        rec = recorder(costs, cfg=cfg, noise=0.02)
+        path = report.write_json(tmp_path / "bench.json", rec, cfg, rec.gate(cfg))
+        return json.loads(path.read_text())
+
+    def test_arms_and_the_reference_are_recorded(self, tmp_path: Path):
+        # Which arm the ratios are taken against is not recoverable from the
+        # numbers, and every contrast in the file is meaningless without it.
+        doc = self.artifact(tmp_path, {REF: 1.0, "a": 1.0, "b": 1.3})
+        cell = next(c for c in doc["cells"] if c["id"] == "encrypt")
+        assert cell["arms"] == [REF, "a", "b"]
+        assert cell["reference"] == REF
+
+    def test_every_pair_appears_once(self, tmp_path: Path):
+        doc = self.artifact(tmp_path, {REF: 1.0, "a": 1.0, "b": 1.3})
+        cell = next(c for c in doc["cells"] if c["id"] == "encrypt")
+        assert set(cell["contrasts"]) == {f"a_vs_{REF}", f"b_vs_{REF}", "b_vs_a"}
+
+    def test_two_arm_readers_still_find_a_baseline_and_candidate(self, tmp_path: Path):
+        doc = self.artifact(tmp_path, {REF: 1.0, "cand": 1.3})
+        cell = next(c for c in doc["cells"] if c["id"] == "encrypt")
+        assert doc["schema"] == 2
+        assert cell["baseline"] == f"sdk@{REF}"
+        assert cell["candidate"] == "sdk@cand"
+
+    def test_raw_samples_survive_for_every_arm(self, tmp_path: Path):
+        # Re-analysing a surprising result offline is the difference between
+        # understanding a red build and re-running the whole job to see the
+        # same numbers again.
+        doc = self.artifact(tmp_path, {REF: 1.0, "a": 1.0, "b": 1.3})
+        cell = next(c for c in doc["cells"] if c["id"] == "encrypt")
+        assert set(cell["samples"]) == {REF, "a", "b"}
+        for arm in cell["samples"].values():
+            assert len(arm["wall"]) == cell["n_rounds"]
+
+    def test_the_bake_off_is_in_the_artifact(self, tmp_path: Path):
+        doc = self.artifact(tmp_path, {REF: 1.0, "slow": 1.4, "quick": 1.0})
+        wall = next(b for b in doc["bake_off"] if b["metric"] == "wall")
+        assert wall["winner"] == "quick"
+
+    def test_the_file_is_valid_json_despite_nan(self, tmp_path: Path):
+        # A cell with no usable interval produces NaN, which `json.dumps`
+        # would happily write as a bare `NaN` that no strict parser accepts.
+        cfg = config(min_rounds=stats.MIN_USABLE_ROUNDS, max_rounds=40)
+        rec = recorder({REF: 1.0, "a": 1.0, "b": 1.0}, cfg=cfg, control=False)
+        path = report.write_json(tmp_path / "b.json", rec, cfg, rec.gate(cfg))
+        json.loads(path.read_text())  # strict by default: no NaN accepted
+
+
+class TestMarkdown:
+    def test_the_header_names_the_arm_count(self):
+        cfg = config(max_rounds=40)
+        rec = recorder({REF: 1.0, "a": 1.0, "b": 1.0}, cfg=cfg, noise=0.02)
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+        assert "3-arm" in md
+
+    def test_the_table_names_both_sides_of_each_contrast(self):
+        cfg = config(max_rounds=40)
+        rec = recorder({REF: 1.0, "a": 1.0, "b": 1.3}, cfg=cfg, noise=0.02)
+        md = report.markdown(rec, cfg, rec.gate(cfg))
+        assert "| contrast |" in md
+        assert "| `b` vs `a` |" in md, "the head-to-head is the point of a bake-off"
+        assert "| `a` vs `base` |" in md
+
+    def test_a_bake_off_section_appears_only_with_candidates_to_rank(self):
+        cfg = config(max_rounds=40)
+        two = recorder({REF: 1.0, "cand": 1.3}, cfg=cfg, noise=0.02)
+        assert "### Bake-off" not in report.markdown(two, cfg, two.gate(cfg))
+        three = recorder({REF: 1.0, "a": 1.0, "b": 1.3}, cfg=cfg, noise=0.02)
+        assert "### Bake-off" in report.markdown(three, cfg, three.gate(cfg))

--- a/xtest/test_bench_runner.py
+++ b/xtest/test_bench_runner.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import math
 import random
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 import pytest
@@ -27,6 +27,7 @@ from perf.runner import (
     BudgetExhausted,
     Invocation,
     analyze,
+    contrast_key,
     run_cell,
 )
 
@@ -34,14 +35,18 @@ BASELINE_WALL_S = 1.0
 BASELINE_RSS = 100_000_000
 BASELINE_CPU = 0.8
 
+#: Arm id of the reference in every cell built here.
+REF = "base"
 
-def arm(role: str, key: str, output: Path | None = None) -> Arm:
-    """An arm whose argv is a single token, so ``FakeRuns`` can recognize it.
 
-    ``role`` is what the runner keys samples by ("baseline"/"candidate");
-    ``key`` is the stand-in for the build.
-    """
-    return Arm(role, f"sdk@{key}", Invocation([key], {}, output))
+def arm(name: str, output: Path | None = None) -> Arm:
+    """An arm whose argv is its own id, so ``FakeRuns`` can recognize it."""
+    return Arm(name, f"sdk@{name}", Invocation([name], {}, output))
+
+
+def key(cell_id: str, metric: str, *, a: str = REF, b: str = "cand") -> str:
+    """The contrast key for ``b`` against ``a`` -- the default vs-reference."""
+    return contrast_key(cell_id, a, b, metric)
 
 
 def config(**overrides: object) -> BenchConfig:
@@ -108,7 +113,7 @@ def clock_from(runs: FakeRuns) -> Callable[[], float]:
 
 
 def run(
-    ratio: float,
+    ratios: float | Mapping[str, float],
     *,
     cfg: BenchConfig | None = None,
     noise: float = 0.05,
@@ -118,14 +123,21 @@ def run(
     sdk: str = "",
     rss_floor: int = 0,
 ):
-    """Run one cell where the candidate costs ``ratio`` times the baseline."""
-    runs = FakeRuns(
-        {"base": 1.0, "cand": ratio}, noise=noise, seed=seed, rss_floor=rss_floor
+    """Run one cell whose arms cost ``ratios`` times the reference.
+
+    A bare float is the two-arm shorthand: a reference at 1.0 and one
+    candidate at that ratio. A mapping names the arms, and the first key is
+    the reference -- which is how a bake-off is set up here.
+    """
+    costs = (
+        {REF: 1.0, "cand": float(ratios)}
+        if isinstance(ratios, (int, float))
+        else dict(ratios)
     )
+    runs = FakeRuns(costs, noise=noise, seed=seed, rss_floor=rss_floor)
     result = run_cell(
         cell_id,
-        arm("baseline", "base"),
-        arm("candidate", "cand"),
+        [arm(name) for name in costs],
         cfg or config(),
         control=control,
         sdk=sdk,
@@ -138,18 +150,46 @@ def run(
 class TestRoundLoop:
     def test_arms_are_paired_every_round(self):
         _, runs = run(1.0)
-        assert runs.calls.count("base") == runs.calls.count("cand")
+        assert runs.calls.count(REF) == runs.calls.count("cand")
         # Every consecutive pair holds one of each: that is what pairing means.
         pairs = [set(runs.calls[i : i + 2]) for i in range(0, len(runs.calls), 2)]
-        assert all(p == {"base", "cand"} for p in pairs)
+        assert all(p == {REF, "cand"} for p in pairs)
+
+    def test_every_arm_runs_once_per_round_at_three_arms(self):
+        # The whole reason a bake-off is answerable: all three arms share a
+        # round, so the a-vs-b contrast is a within-round ratio like any other.
+        _, runs = run({REF: 1.0, "a": 1.1, "b": 1.2})
+        rounds = [set(runs.calls[i : i + 3]) for i in range(0, len(runs.calls), 3)]
+        assert all(r == {REF, "a", "b"} for r in rounds)
 
     def test_order_within_rounds_is_shuffled(self):
         _, runs = run(1.0)
         firsts = runs.calls[::2]
-        assert "base" in firsts and "cand" in firsts, (
+        assert REF in firsts and "cand" in firsts, (
             "a fixed within-round order lets the second arm inherit the first "
             "one's cache state"
         )
+
+    def test_all_three_arms_take_turns_going_first(self):
+        _, runs = run({REF: 1.0, "a": 1.0, "b": 1.0})
+        assert set(runs.calls[::3]) == {REF, "a", "b"}, (
+            "an arm pinned to one slot in the round inherits the same cache "
+            "state every time, which is a confounder and not a measurement"
+        )
+
+    def test_rejects_a_single_arm(self):
+        with pytest.raises(ValueError, match="at least two arms"):
+            run_cell("cell", [arm(REF)], config())
+
+    def test_rejects_colliding_arm_ids(self):
+        # Ids key the sample vectors, so a collision would interleave two
+        # builds' measurements into one arm and compare it with itself.
+        with pytest.raises(ValueError, match="unique"):
+            run_cell("cell", [arm(REF), arm(REF)], config())
+
+    def test_rejects_a_reference_that_is_not_an_arm(self):
+        with pytest.raises(ValueError, match="reference"):
+            run_cell("cell", [arm(REF), arm("cand")], config(), reference="other")
 
     def test_warmup_rounds_are_discarded(self):
         cfg = config(warmup=3, max_rounds=stats.MIN_USABLE_ROUNDS)
@@ -173,10 +213,10 @@ class TestRoundLoop:
         out = tmp_path / "out.tdf"
         out.write_bytes(b"stale")
         seen: list[bool] = []
-        runs = FakeRuns({"base": 1.0, "cand": 1.0})
+        runs = FakeRuns({REF: 1.0, "cand": 1.0})
 
         def observe(argv: list[str], env: dict[str, str], **kwargs: object) -> Sample:
-            if argv[0] == "base":
+            if argv[0] == REF:
                 # What the arm that owns this output sees when it starts.
                 seen.append(out.exists())
                 out.write_bytes(b"produced")
@@ -184,8 +224,7 @@ class TestRoundLoop:
 
         run_cell(
             "cell",
-            arm("baseline", "base", out),
-            arm("candidate", "cand"),
+            [arm(REF, out), arm("cand")],
             config(max_rounds=stats.MIN_USABLE_ROUNDS),
             clock=clock_from(runs),
             run=observe,
@@ -194,9 +233,31 @@ class TestRoundLoop:
 
     def test_samples_are_collected_for_every_metric(self):
         result, _ = run(1.0)
-        for name in ("baseline", "candidate"):
+        for name in (REF, "cand"):
             for metric in ("wall", "cpu", "rss"):
                 assert len(result.samples[name][metric]) == result.n_rounds
+
+    def test_records_its_arms_and_which_one_is_the_reference(self):
+        result, _ = run({REF: 1.0, "a": 1.0, "b": 1.0})
+        assert result.arm_ids == (REF, "a", "b")
+        assert result.reference == REF
+        assert result.arm_labels == {REF: "sdk@base", "a": "sdk@a", "b": "sdk@b"}
+
+    def test_contrast_pairs_cover_every_pair_once(self):
+        result, _ = run({REF: 1.0, "a": 1.0, "b": 1.0})
+        # Reference contrasts first, then the head-to-head. A pair and its
+        # inverse are the same measurement, so only one of each appears.
+        assert result.contrast_pairs() == [(REF, "a"), (REF, "b"), ("a", "b")]
+
+    def test_contrast_direction_is_b_over_a(self):
+        result, _ = run({REF: 1.0, "slow": 1.5}, noise=0.01)
+        cfg = config()
+        assert result.contrast(REF, "slow", "wall", cfg).ratio == pytest.approx(
+            1.5, rel=0.1
+        )
+        assert result.contrast("slow", REF, "wall", cfg).ratio == pytest.approx(
+            1 / 1.5, rel=0.1
+        )
 
 
 class TestStopping:
@@ -215,13 +276,47 @@ class TestStopping:
         result, _ = run(1.0, cfg=cfg, noise=0.0001)
         assert result.n_rounds >= 25
 
+    def test_precision_waits_for_the_slowest_contrast_to_converge(self):
+        # One quiet candidate and one noisy one. Stopping as soon as *some*
+        # contrast is precise would leave the noisy arm unresolved with budget
+        # still on the table -- and at K arms the slowest contrast to converge
+        # is exactly the one someone is waiting on.
+        cfg = config(max_rounds=40)
+        quiet, _ = run({REF: 1.0, "cand": 1.0}, cfg=cfg, noise=0.005)
+        assert quiet.stopped_because == "precision"
+
+        runs = FakeRuns({REF: 1.0, "quiet": 1.0, "noisy": 1.0}, noise=0.005)
+        real_call = runs.__call__
+
+        def jittery(argv: list[str], env: dict[str, str], **kwargs: object) -> Sample:
+            sample = real_call(argv, env, **kwargs)
+            if argv[0] != "noisy":
+                return sample
+            spike = math.exp(runs.rng.gauss(0.0, 0.5))
+            return Sample(
+                wall_ns=int(sample.wall_ns * spike),
+                cpu_s=sample.cpu_s * spike,
+                max_rss_bytes=int(sample.max_rss_bytes * spike),
+                exit_code=0,
+            )
+
+        mixed = run_cell(
+            "cell",
+            [arm(REF), arm("quiet"), arm("noisy")],
+            cfg,
+            clock=clock_from(runs),
+            run=jittery,
+        )
+        assert mixed.stopped_because == "max_rounds", (
+            "the loop stopped on the quiet contrast and left the noisy one unresolved"
+        )
+
     def test_deadline_stops_the_loop(self):
-        runs = FakeRuns({"base": 1.0, "cand": 1.0}, noise=0.3)
+        runs = FakeRuns({REF: 1.0, "cand": 1.0}, noise=0.3)
         clock = clock_from(runs)
         result = run_cell(
             "cell",
-            arm("baseline", "base"),
-            arm("candidate", "cand"),
+            [arm(REF), arm("cand")],
             config(warmup=0, max_rounds=200),
             deadline=clock() + 60.0,  # each round costs ~2 simulated seconds
             clock=clock,
@@ -230,18 +325,34 @@ class TestStopping:
         assert result.stopped_because == "budget"
         assert result.elapsed_s <= 60.0, "a round we could not finish was started"
 
+    def test_a_three_arm_round_costs_three_invocations_of_budget(self):
+        # Rounds get more expensive as arms are added, which is the whole
+        # reason the default budget scales with K.
+        runs = FakeRuns({REF: 1.0, "a": 1.0, "b": 1.0}, noise=0.3)
+        clock = clock_from(runs)
+        result = run_cell(
+            "cell",
+            [arm(REF), arm("a"), arm("b")],
+            config(warmup=0, max_rounds=200),
+            deadline=clock() + 60.0,  # each round now costs ~3 simulated seconds
+            clock=clock,
+            run=runs,
+        )
+        assert result.stopped_because == "budget"
+        assert len(runs.calls) == 3 * result.n_rounds
+        assert result.n_rounds < 30, "three-arm rounds cost more than two-arm ones"
+
     def test_warmup_gives_up_when_the_budget_runs_out(self):
         # The budget's end is absolute, so warm-ups that run past it are
         # spending the *following* cells' time -- and then reaching the
         # measured loop with nothing left, paying the whole cost of the cell
         # for no data at all. Stop at the deadline and say where it went.
-        runs = FakeRuns({"base": 1.0, "cand": 1.0})
+        runs = FakeRuns({REF: 1.0, "cand": 1.0})
         clock = clock_from(runs)
         with pytest.raises(BudgetExhausted, match="warm-up"):
             run_cell(
                 "cell",
-                arm("baseline", "base"),
-                arm("candidate", "cand"),
+                [arm(REF), arm("cand")],
                 config(warmup=10),
                 deadline=clock() + 4.0,  # each round costs ~2 simulated seconds
                 clock=clock,
@@ -250,13 +361,12 @@ class TestStopping:
         assert len(runs.calls) < 2 * 10, "warm-up ran past its own deadline"
 
     def test_budget_below_min_usable_rounds_refuses_a_verdict(self):
-        runs = FakeRuns({"base": 1.0, "cand": 1.0})
+        runs = FakeRuns({REF: 1.0, "cand": 1.0})
         clock = clock_from(runs)
         with pytest.raises(BudgetExhausted, match="below the"):
             run_cell(
                 "cell",
-                arm("baseline", "base"),
-                arm("candidate", "cand"),
+                [arm(REF), arm("cand")],
                 config(warmup=0),
                 deadline=clock() + 4.0,
                 clock=clock,
@@ -334,8 +444,8 @@ class TestGateOnPlantedEffects:
     def test_planted_25_percent_slowdown_is_caught(self):
         gate = self.gate(1.25)
         assert gate.should_fail
-        assert "encrypt/wall" in gate.regressions
-        c = gate.comparisons["encrypt/wall"]
+        assert key("encrypt", "wall") in gate.regressions
+        c = gate.comparisons[key("encrypt", "wall")]
         assert c.verdict is stats.Verdict.REGRESSION
         assert c.ci_low > 1.15, "the interval must exclude the threshold, not just 1.0"
         assert c.ratio == pytest.approx(1.25, rel=0.1)
@@ -343,7 +453,10 @@ class TestGateOnPlantedEffects:
     def test_planted_3_percent_slowdown_is_ignored(self):
         gate = self.gate(1.03)
         assert not gate.should_fail
-        assert gate.comparisons["encrypt/wall"].verdict is not stats.Verdict.REGRESSION
+        assert (
+            gate.comparisons[key("encrypt", "wall")].verdict
+            is not stats.Verdict.REGRESSION
+        )
 
     def test_no_effect_does_not_fire(self):
         gate = self.gate(1.0)
@@ -353,8 +466,10 @@ class TestGateOnPlantedEffects:
     def test_planted_speedup_is_reported_not_failed(self):
         gate = self.gate(0.7)
         assert not gate.should_fail
-        assert gate.comparisons["encrypt/wall"].verdict is stats.Verdict.IMPROVED
-        assert "encrypt/wall" in gate.improvements
+        assert (
+            gate.comparisons[key("encrypt", "wall")].verdict is stats.Verdict.IMPROVED
+        )
+        assert key("encrypt", "wall") in gate.improvements
 
     def test_the_control_cell_never_fails_the_build(self):
         # Both arms of the control are the same build, so any verdict it
@@ -369,9 +484,11 @@ class TestGateOnPlantedEffects:
         gate = analyze([control, measured], cfg)
         # CPU time moved with everything else and is reported as such; it
         # simply is not allowed to turn the build red.
-        assert gate.comparisons["encrypt/cpu"].verdict is stats.Verdict.REGRESSION
-        assert "encrypt/cpu" not in gate.regressions
-        assert "encrypt/wall" in gate.regressions
+        assert (
+            gate.comparisons[key("encrypt", "cpu")].verdict is stats.Verdict.REGRESSION
+        )
+        assert key("encrypt", "cpu") not in gate.regressions
+        assert key("encrypt", "wall") in gate.regressions
 
     def test_rss_pinned_to_the_measurement_floor_cannot_report_pass(self):
         # A command whose peak sits at the floor is not measured, it is
@@ -384,14 +501,14 @@ class TestGateOnPlantedEffects:
         measured, _ = run(1.25, cfg=cfg, seed=12, cell_id="encrypt", rss_floor=floor)
         gate = analyze([control, measured], cfg)
 
-        rss = gate.comparisons["encrypt/rss"]
+        rss = gate.comparisons[key("encrypt", "rss")]
         assert rss.ratio == pytest.approx(1.0), "the floor clipped both arms"
         assert rss.verdict is stats.Verdict.INCONCLUSIVE
         assert "floor" in rss.note
-        assert "encrypt/rss" not in gate.regressions
-        assert "encrypt/rss" not in gate.improvements
+        assert key("encrypt", "rss") not in gate.regressions
+        assert key("encrypt", "rss") not in gate.improvements
         # Wall clock is untouched by a memory floor and still does its job.
-        assert "encrypt/wall" in gate.regressions
+        assert key("encrypt", "wall") in gate.regressions
 
     def test_rss_above_the_floor_is_still_gated(self):
         cfg = config(max_rounds=40)
@@ -402,7 +519,7 @@ class TestGateOnPlantedEffects:
             1.25, cfg=cfg, seed=12, cell_id="encrypt", rss_floor=BASELINE_RSS // 10
         )
         gate = analyze([control, measured], cfg)
-        assert "encrypt/rss" in gate.regressions
+        assert key("encrypt", "rss") in gate.regressions
 
     def test_each_sdk_is_judged_against_its_own_control(self):
         # One control per SDK: they are different harness paths with different
@@ -433,9 +550,10 @@ class TestGateOnPlantedEffects:
         gate = analyze([go_aa, go_cell, java_aa, java_cell], cfg)
 
         assert len(gate.noise_by_control) == 2, "one noise floor per SDK"
-        assert gate.comparisons["go-encrypt/wall"].verdict is stats.Verdict.PASS
+        assert gate.comparisons[key("go-encrypt", "wall")].verdict is stats.Verdict.PASS
         assert (
-            gate.comparisons["java-encrypt/wall"].verdict is stats.Verdict.INCONCLUSIVE
+            gate.comparisons[key("java-encrypt", "wall")].verdict
+            is stats.Verdict.INCONCLUSIVE
         ), "java's own control had no power, whatever go's control managed"
 
     def test_a_run_with_no_control_cannot_report_pass(self):
@@ -443,5 +561,101 @@ class TestGateOnPlantedEffects:
         measured, _ = run(1.0, cfg=cfg, cell_id="encrypt")
         gate = analyze([measured], cfg)
         assert gate.noise is not None and gate.noise.underpowered
-        assert gate.comparisons["encrypt/wall"].verdict is stats.Verdict.INCONCLUSIVE
+        assert (
+            gate.comparisons[key("encrypt", "wall")].verdict
+            is stats.Verdict.INCONCLUSIVE
+        )
         assert not gate.should_fail, "an unassessed run warns; it does not fail"
+
+
+class TestGateAtThreeArms:
+    """What the extra arms buy, and what they must not be allowed to do.
+
+    Every contrast here is a within-round ratio measured on one runner, which
+    is the only reason a candidate-versus-candidate question is answerable at
+    all. But only the vs-reference contrasts may fail a build: a bake-off
+    ranks implementations, it does not decide whether the branch is shippable.
+    """
+
+    def gate(self, costs: Mapping[str, float], *, noise: float = 0.05, seed: int = 11):
+        cfg = config(max_rounds=40)
+        control_costs = dict.fromkeys(costs, 1.0)
+        control, _ = run(
+            control_costs, cfg=cfg, noise=noise, seed=seed, cell_id="aa", control=True
+        )
+        measured, _ = run(costs, cfg=cfg, noise=noise, seed=seed + 1, cell_id="encrypt")
+        return analyze([control, measured], cfg)
+
+    def test_both_candidates_are_gated_against_the_reference(self):
+        gate = self.gate({REF: 1.0, "slow": 1.3, "quick": 1.0})
+        assert gate.should_fail
+        assert key("encrypt", "wall", b="slow") in gate.regressions
+        assert key("encrypt", "wall", b="quick") not in gate.regressions
+
+    def test_a_head_to_head_gap_never_fails_the_build(self):
+        # Neither candidate regressed against the reference; one is simply
+        # slower than the other. That is a ranking, and rankings do not turn
+        # the build red -- invariant #9.
+        gate = self.gate({REF: 1.3, "slow": 1.3, "quick": 1.0})
+        h2h = key("encrypt", "wall", a="slow", b="quick")
+        assert gate.comparisons[h2h].verdict is stats.Verdict.FASTER
+        assert not gate.should_fail
+        assert h2h not in gate.regressions and h2h not in gate.improvements
+
+    def test_a_head_to_head_is_judged_symmetrically(self):
+        # The one-sided vocabulary would call this PASS or REGRESSION, both of
+        # which presume an incumbent. Between two candidates there is none.
+        gate = self.gate({REF: 1.0, "a": 1.0, "b": 1.3})
+        h2h = gate.comparisons[key("encrypt", "wall", a="a", b="b")]
+        assert h2h.verdict is stats.Verdict.SLOWER
+        assert h2h.verdict not in {stats.Verdict.PASS, stats.Verdict.REGRESSION}
+
+    def test_indistinguishable_candidates_are_tied_not_passed(self):
+        # PASS is a one-sided claim -- "not slower". For a bake-off the answer
+        # worth reporting is that the two are the same, and TIED says so.
+        gate = self.gate({REF: 1.0, "a": 1.0, "b": 1.0}, noise=0.01)
+        assert (
+            gate.comparisons[key("encrypt", "wall", a="a", b="b")].verdict
+            is stats.Verdict.TIED
+        )
+
+    def test_head_to_head_covers_ungated_metrics_too(self):
+        # "Which arm is faster" has no privileged direction on cpu either, and
+        # none of these gate, so they all share the symmetric vocabulary.
+        gate = self.gate({REF: 1.0, "a": 1.0, "b": 1.3})
+        assert gate.comparisons[key("encrypt", "cpu", a="a", b="b")].verdict in {
+            stats.Verdict.FASTER,
+            stats.Verdict.SLOWER,
+            stats.Verdict.TIED,
+            stats.Verdict.INCONCLUSIVE,
+        }
+
+    def test_a_decided_head_to_head_is_recorded_for_ranking(self):
+        gate = self.gate({REF: 1.0, "slow": 1.4, "quick": 1.0})
+        # ``ranked`` carries the material a report turns into a winner; it is
+        # keys only, because at this layer an arm id is opaque.
+        assert key("encrypt", "wall", a="slow", b="quick") in gate.ranked
+        assert not any(
+            k in gate.regressions or k in gate.improvements for k in gate.ranked
+        )
+
+    def test_the_control_yields_one_contrast_per_pair(self):
+        gate = self.gate({REF: 1.0, "a": 1.0, "b": 1.0})
+        aa = [
+            k for k in gate.comparisons if k.startswith("aa/") and k.endswith("/wall")
+        ]
+        assert len(aa) == 3, "C(3,2) pairs, not one -- arm 3 drifts further than arm 2"
+
+    def test_the_noise_floor_is_the_worst_control_pair(self):
+        # A 2-arm control measures adjacent invocations only, and so understates
+        # the drift carried by the widest contrast the run actually judges.
+        gate = self.gate({REF: 1.0, "a": 1.0, "b": 1.0})
+        aa = [
+            k for k in gate.comparisons if k.startswith("aa/") and k.endswith("/wall")
+        ]
+        assert len(gate.noise_by_control) == 1, "exactly one of the pairs is the floor"
+        assert gate.noise is not None
+        widest = max(
+            stats.assess_noise_floor(gate.comparisons[k]).width_ratio for k in aa
+        )
+        assert gate.noise.width_ratio == pytest.approx(widest)

--- a/xtest/test_bench_stats.py
+++ b/xtest/test_bench_stats.py
@@ -338,6 +338,51 @@ class TestMultiplicityControl:
         assert g.comparisons["cpu"].verdict is Verdict.REGRESSION
         assert g.regressions == ["wall"], "cpu is reported but never gates"
 
+    def test_the_three_families_are_corrected_separately(self):
+        # A bake-off adds head-to-head contrasts that cannot fail the build.
+        # Folding them into the gate's family would raise every gated p-value
+        # for the sake of tests nobody gates on, which is precisely the trade
+        # the gated/ungated split already refuses to make.
+        rng = np.random.default_rng(41)
+        b, c = synth(rng, 1.4, n=60)
+        regressed = stats.compare(b, c, seed=41, n_resamples=RESAMPLES)
+        cells = {"wall": regressed, "control": quiet_control()}
+        alone = stats.apply_multiplicity_control(
+            cells, gated={"wall"}, controls=all_under_one_control(cells)
+        )
+
+        crowded = dict(cells)
+        for i in range(10):
+            r = np.random.default_rng(4100 + i)
+            x, y = synth(r, 1.0, n=60)
+            crowded[f"h2h{i}"] = stats.compare(x, y, seed=i, n_resamples=RESAMPLES)
+        with_h2h = stats.apply_multiplicity_control(
+            crowded,
+            gated={"wall"},
+            symmetric={f"h2h{i}" for i in range(10)},
+            controls=all_under_one_control(crowded),
+        )
+        assert with_h2h.comparisons["wall"].p_adjusted == pytest.approx(
+            alone.comparisons["wall"].p_adjusted
+        ), "ten head-to-heads must not dilute the one contrast that can gate"
+        assert with_h2h.regressions == ["wall"]
+
+    def test_a_symmetric_key_that_is_also_gated_stays_gated(self):
+        # Only reachable through a caller bug, and the safe resolution is the
+        # rule that can still fail the build rather than the one that cannot.
+        rng = np.random.default_rng(42)
+        b, c = synth(rng, 1.4, n=60)
+        cells = {"wall": stats.compare(b, c, seed=42, n_resamples=RESAMPLES)}
+        cells["control"] = quiet_control()
+        g = stats.apply_multiplicity_control(
+            cells,
+            gated={"wall"},
+            symmetric={"wall"},
+            controls=all_under_one_control(cells),
+        )
+        assert g.comparisons["wall"].verdict is Verdict.REGRESSION
+        assert g.regressions == ["wall"]
+
     def test_empty_run_reports_no_regressions(self):
         g = stats.apply_multiplicity_control({})
         assert not g.should_fail, "nothing measured is not a regression"
@@ -359,3 +404,119 @@ class TestMultiplicityControl:
             stats.compare(b, c, seed=33, n_resamples=RESAMPLES), control=quiet_control()
         )
         assert not g.nothing_measured
+
+
+class TestSymmetricVerdicts:
+    """The bake-off rule: which of two candidates is faster, if either.
+
+    Neither arm is an incumbent, so the one-sided vocabulary does not apply.
+    PASS would let a slower arm read as a clean result, and REGRESSION would
+    imply the other arm was the thing that changed.
+    """
+
+    def h2h(
+        self,
+        true_ratio: float,
+        *,
+        n: int = 60,
+        seed: int = 51,
+        sigma: float = NOISE_SIGMA,
+    ):
+        rng = np.random.default_rng(seed)
+        a, b = synth(rng, true_ratio, n=n, sigma=sigma)
+        cells = {
+            "h2h": stats.compare(a, b, seed=seed, n_resamples=RESAMPLES),
+            "control": quiet_control(),
+        }
+        g = stats.apply_multiplicity_control(
+            cells,
+            gated=set(),
+            symmetric={"h2h"},
+            controls=all_under_one_control(cells),
+        )
+        return g, g.comparisons["h2h"]
+
+    def test_a_clearly_slower_arm_is_slower(self):
+        _, c = self.h2h(1.5)
+        assert c.verdict is Verdict.SLOWER
+
+    def test_a_clearly_faster_arm_is_faster(self):
+        _, c = self.h2h(1 / 1.5)
+        assert c.verdict is Verdict.FASTER
+
+    def test_indistinguishable_arms_are_tied(self):
+        # A positive finding, and the most likely honest answer for two
+        # implementations of the same idea. Not PASS: that is a one-sided
+        # claim about an incumbent that does not exist here.
+        _, c = self.h2h(1.0, n=120, sigma=0.02)
+        assert c.verdict is Verdict.TIED
+        assert 1 / 1.15 < c.ci_low and c.ci_high < 1.15
+
+    def test_an_interval_straddling_the_band_edge_is_inconclusive(self):
+        # A real but unresolved difference. Calling it TIED would claim an
+        # equivalence the interval does not support.
+        _, c = self.h2h(1.15, n=20, sigma=0.15)
+        assert c.verdict is Verdict.INCONCLUSIVE
+        assert "cannot be ranked" in c.note
+
+    def test_a_head_to_head_never_gates(self):
+        g, c = self.h2h(1.5)
+        assert c.verdict is Verdict.SLOWER
+        assert not g.should_fail, "a bake-off ranks; it does not fail the build"
+        assert g.regressions == [] and g.improvements == []
+
+    def test_a_decided_head_to_head_is_ranked(self):
+        g, _ = self.h2h(1.5)
+        assert g.ranked == ["h2h"]
+
+    def test_a_tie_is_not_ranked(self):
+        # Nothing to rank: naming a winner from a tie is the failure mode this
+        # verdict exists to prevent.
+        g, c = self.h2h(1.0, n=120, sigma=0.02)
+        assert c.verdict is Verdict.TIED
+        assert g.ranked == []
+
+    def test_without_a_noise_floor_nothing_is_ranked(self):
+        # Invariant 4 covers TIED as much as PASS: a tie nobody had the power
+        # to tell from a difference is not a tie.
+        rng = np.random.default_rng(52)
+        a, b = synth(rng, 1.0, n=120, sigma=0.02)
+        cells = {"h2h": stats.compare(a, b, seed=52, n_resamples=RESAMPLES)}
+        g = stats.apply_multiplicity_control(cells, gated=set(), symmetric={"h2h"})
+        assert g.comparisons["h2h"].verdict is Verdict.INCONCLUSIVE
+        assert g.ranked == []
+
+
+class TestWorstControlKey:
+    """A K-arm control yields C(K,2) A/A contrasts, and they are not equal.
+
+    Arm 3 runs two invocations after arm 1, so it carries more within-round
+    drift. Taking whichever came first would let dict ordering decide how
+    noisy the run is allowed to look.
+    """
+
+    def controls(self) -> dict[str, stats.PairedComparison]:
+        rng = np.random.default_rng(61)
+        tight_b, tight_c = synth(rng, 1.0, n=120, sigma=0.02)
+        wide_b, wide_c = synth(rng, 1.0, n=25, sigma=0.25)
+        return {
+            "tight": stats.compare(tight_b, tight_c, seed=61, n_resamples=RESAMPLES),
+            "wide": stats.compare(wide_b, wide_c, seed=62, n_resamples=RESAMPLES),
+        }
+
+    def test_the_widest_contrast_is_the_floor(self):
+        c = self.controls()
+        assert stats.worst_control_key(c, ["tight", "wide"]) == "wide"
+
+    def test_the_answer_does_not_depend_on_input_order(self):
+        c = self.controls()
+        assert stats.worst_control_key(c, ["wide", "tight"]) == "wide"
+
+    def test_a_missing_contrast_is_worse_than_any_real_one(self):
+        # An absent control is not a quiet one; `assess_noise_floor(None)`
+        # calls it underpowered, and that must win over a real interval.
+        c = self.controls()
+        assert stats.worst_control_key(c, ["tight", "absent"]) == "absent"
+
+    def test_no_keys_means_no_floor(self):
+        assert stats.worst_control_key({}, []) is None

--- a/xtest/test_bench_stats.py
+++ b/xtest/test_bench_stats.py
@@ -130,6 +130,7 @@ class TestCompare:
         r = stats.compare(v, v, seed=0, n_resamples=RESAMPLES)
         assert r.ratio == pytest.approx(1.0)
         assert r.p_value == 1.0
+        assert r.p_value_faster == 1.0
 
     def test_constant_offset_has_degenerate_interval(self):
         # Every round shows exactly a 2x slowdown: there is no sampling
@@ -185,7 +186,10 @@ class TestDecisionRule:
         g = gate_one(
             stats.compare(b, c, seed=12, n_resamples=RESAMPLES), control=quiet_control()
         )
-        assert g.comparisons["cell"].verdict is Verdict.IMPROVED
+        result = g.comparisons["cell"]
+        assert result.verdict is Verdict.IMPROVED
+        assert result.p_adjusted_faster is not None
+        assert result.p_adjusted_faster < stats.DEFAULT_ALPHA
         assert not g.should_fail
 
     def test_borderline_effect_without_power_is_inconclusive_not_pass(self):
@@ -300,6 +304,26 @@ class TestMultiplicityControl:
         adj = stats.benjamini_hochberg([0.01, float("nan"), 0.02])
         assert math.isnan(adj[1])
         assert all(math.isfinite(a) for a in (adj[0], adj[2]))
+
+    def test_faster_tail_is_adjusted_directly(self):
+        cells = {}
+        for i, ratio in enumerate((0.70, 0.75, 0.80)):
+            rng = np.random.default_rng(2900 + i)
+            b, c = synth(rng, ratio, n=60)
+            cells[f"cell{i}"] = stats.compare(b, c, seed=i, n_resamples=RESAMPLES)
+        cells["control"] = quiet_control()
+
+        g = stats.apply_multiplicity_control(
+            cells, controls=all_under_one_control(cells)
+        )
+        expected = stats.benjamini_hochberg(
+            [cells[f"cell{i}"].p_value_faster for i in range(3)]
+        )
+        actual = [g.comparisons[f"cell{i}"].p_adjusted_faster for i in range(3)]
+        assert actual == pytest.approx(expected)
+        assert all(
+            g.comparisons[f"cell{i}"].verdict is Verdict.IMPROVED for i in range(3)
+        )
 
     def test_correction_suppresses_lone_lucky_cell(self):
         # 20 pure-noise cells: without BH one of them firing is expected.
@@ -443,6 +467,8 @@ class TestSymmetricVerdicts:
     def test_a_clearly_faster_arm_is_faster(self):
         _, c = self.h2h(1 / 1.5)
         assert c.verdict is Verdict.FASTER
+        assert c.p_adjusted_faster is not None
+        assert c.p_adjusted_faster < stats.DEFAULT_ALPHA
 
     def test_indistinguishable_arms_are_tied(self):
         # A positive finding, and the most likely honest answer for two

--- a/xtest/test_benchmarks.py
+++ b/xtest/test_benchmarks.py
@@ -1,7 +1,8 @@
 """SDK performance regression cells.
 
-One test per cell: an operation at a payload size, measuring the newest
-installed release against the branch build on the same runner, in the same
+One test per cell: an operation at a payload size, measuring every arm of the
+run -- by default the newest installed release against the branch build, and
+in a bake-off several candidates at once -- on the same runner, in the same
 round, in a randomized order.
 
 **These tests do not assert.** Each one records its raw samples and passes.
@@ -66,7 +67,7 @@ def test_sdk_performance(
         if bench_cell.operation == "decrypt"
         else None
     )
-    baseline, candidate = bench.build_arms(
+    cell_arms = bench.build_arms(
         bench_cell,
         arms,
         pt_file=bench_payloads[bench_cell.payload.label],
@@ -78,8 +79,7 @@ def test_sdk_performance(
     try:
         result = runner.run_cell(
             bench_cell.id,
-            baseline,
-            candidate,
+            cell_arms,
             bench_config,
             deadline=bench_budget.next_deadline(),
             control=bench_cell.control,


### PR DESCRIPTION
Stacked on #580 — base is `DSPX-4372`, so review that one first. This PR is
small; most of it is the discussion below, which is the point of opening it.

## What this adds

Two `workflow_dispatch` inputs on X-Test, `bench-baseline-ref` and
`bench-candidate-ref`, that point the existing benchmark harness at two refs
you name instead of its nightly newest-release-vs-branch-head pair. Plus a
resolver fix that a slashed branch name needs, and the bench matrix now
honours `focus-sdk`.

Second commit: three more inputs — `bench-payloads`, `bench-budget-seconds`,
`bench-max-rounds` — because the first dispatch showed the default matrix
cannot resolve a throughput claim at all. See *[Why 32 MiB cannot gate
throughput](#why-32-mib-cannot-gate-throughput)* below. The scheduled nightly
passes no inputs and is unchanged.

To run the comparison this PR is written around:

| Input | Value |
| --- | --- |
| `run-benchmarks` | ✅ |
| `focus-sdk` | `go` |
| `bench-baseline-ref` | `main` |
| `bench-candidate-ref` | `feat/DSPX-2604-createtdf-chunked` |
| `bench-payloads` | `1KiB,1GiB` |
| `bench-budget-seconds` | `5400` |
| `bench-max-rounds` | `200` |

---

## The change under the microscope

opentdf/platform#3865 — *refactor(sdk): rewrite CreateTDF on top of
ChunkedWriter* — rewrites `CreateTDFContext` to delegate payload encryption,
archive framing, and manifest assembly to `ChunkedWriter`. It makes explicit
performance claims, per segment:

> drops one full-segment allocation and copy — `joinSealed` detects that
> `ocrypto.AesGcm.EncryptInPlace` returns two views of the single buffer
> `Seal` allocated and reslices instead. On a 1 GiB payload at 2 MiB segments
> that is ~512 allocations and ~1 GiB of memcpy removed.
>
> computes the CRC in one `crc32.ChecksumIEEE` call over the contiguous
> buffer, rather than two writes into a streaming CRC writer.
>
> The read buffer is sized to `min(segmentSize, inputSize)`, so a small TDF no
> longer allocates 2 MiB.

and states costs: three extra interface dispatches per segment, `io.Copy` over
an `io.MultiReader`, and an `O(n log n)` sort over ~34k map keys at the 68 GiB
maximum.

That is a good test case for the harness precisely because it is *not* a
regression hunt. It is a claim of an improvement, of a size the harness may or
may not be able to see, on a path the harness may or may not exercise. Walking
through what the run would and would not tell us is the clearest way to explain
what the thing does.

## How the harness works, and what it would say here

Full design notes are in [`xtest/perf/README.md`](xtest/perf/README.md); this
is the tour.

### It measures whole CLI invocations, not functions

There is no Go benchmark here and no in-process timing. Each measurement forks
`otdfctl encrypt` (or `decrypt`) and records wall clock, CPU time, and peak RSS
from `os.wait4`. The cell matrix per SDK is `{encrypt, decrypt} × {1 KiB, 1
MiB, 32 MiB}`, plus one A/A control.

The consequence for #3865: **the 1 KiB cells are almost entirely process boot.**
Go runtime start, config load, TLS handshake, token fetch, KAS public key
fetch. Removing one 2 MiB allocation is real, and it is going to be a rounding
error next to a token fetch. The `min(segmentSize, inputSize)` read-buffer
change is exactly the kind of improvement this harness is structurally unable
to resolve at 1 KiB.

### Why 32 MiB cannot gate throughput

I assumed the 32 MiB encrypt cell — 16 segments deep — was where the claim had
room to show. The first dispatch says otherwise, and the arithmetic is worth
stating because it applies to any throughput claim, not just this one.

Fitting the measured go cells against payload size:

| | fixed cost | per-payload | payload share at 32 MiB |
| --- | --- | --- | --- |
| encrypt | ~455 ms | ~2.25 ms/MiB | ~14% |
| decrypt | ~450 ms | ~1.7 ms/MiB | ~11% |

At 32 MiB the payload-dependent part of an encrypt is ~72 ms of a ~527 ms cell.
The 1.15x gate is +79 ms — **wider than the entire portion of the cell that
scales with the payload**. A candidate that doubled every per-segment cost
would report 1.136x and PASS. The default matrix is a startup-cost gate wearing
a throughput gate's clothes.

At 1 GiB the ratio inverts: ~2.3 s of payload work against the same ~450 ms
fixed, ~84% of the cell. That is what `bench-payloads` is for, and why the
second commit exists. If #3865 is visible anywhere it is there, and in **peak
RSS** — a full-segment allocation removed per segment is a memory claim first
and a time claim second.

Cost of asking: a 1 GiB pair is ~3 s per round per arm, so it needs a budget to
match. Manual dispatches are not on the nightly's schedule, which is the whole
argument for letting them spend more; `bench-budget-seconds` and
`bench-max-rounds` are the two knobs, and both have to move — at the default
60, cells were stopping on `max_rounds` with two thirds of the 1500 s budget
unspent.

### It compares two builds on one runner, never against history

Both builds are installed side by side under `sdk/go/dist/`, and every round
runs both, order shuffled within the round. The statistic is the within-round
log-ratio. Runner speed, tenancy, and steal time are shared factors and divide
out. Nothing is stored and nothing is diffed against last week.

This is why "benchmark this branch" has to mean "install both refs on one
runner", which is all the plumbing in this PR really is.

### The verdicts, and which one #3865 should expect

The gate is one-sided: a cell is a **REGRESSION** when the bootstrap CI lower
bound on the ratio exceeds 1.15x *and* the BH-adjusted p < 0.05. An improvement
reports **IMPROVED** and fails nothing.

So the honest expected outcome for this branch is **PASS on every cell, with
maybe an IMPROVED on 32 MiB encrypt**. That is not a disappointing result; the
question the harness is built to answer is "did this rewrite cost anything?",
and for a change that swaps one implementation for another under an unchanged
public entry point, that is the question worth asking. The PR's own risk
section says the same thing: one implementation now serves both entry points.

`IMPROVED` is worth reading with the same suspicion as a regression, though.
The PR says payload output is unchanged and the round-trip matrix pins it —
good, because a candidate that got faster by doing less work is the failure
mode a ratio cannot distinguish from one that got faster by doing the same work
better. The harness has a narrow guard for this (`comparability_problem()`
refuses to compare arms that disagree on `hexless`, `hexaflexible`, or
`autoconfigure`) but it is a feature-flag check, not a correctness check. The
functional xtest suite is what backs the "same work" premise; the benchmark
assumes it.

### Inconclusive is the likely answer, and it is not a pass

Each SDK gets an A/A cell comparing the baseline against itself through the
identical pipeline. Its true ratio is 1.0 by construction, so its CI width is
the run's noise floor — the smallest effect this runner could have resolved. If
the floor is wider than the 15% threshold, cells report **inconclusive** rather
than PASS, because "we looked and found nothing" only counts when we could have
found something.

On a shared GitHub runner the floor is frequently wider than the improvement
#3865 is claiming. A cell that comes back inconclusive means the run could not
tell — not that the change did nothing. Note that this is a *different* failure
from the one above: an inconclusive cell admits it could not resolve the
effect, whereas a 32 MiB PASS does not, because the noise floor can be
perfectly tight around a ratio that is mostly process startup.

Peak RSS has a second trap the harness handles explicitly: readings that sit at
the measurement floor get **censored**. Both arms clip to the same value,
producing a `1.000x` ratio with a tight interval — the most convincing-looking
PASS the harness can emit, and completely meaningless. That floor is why
[`perf/_launcher.py`](xtest/perf/_launcher.py) exists at all: on Linux
`ru_maxrss` comes back as `max(child's true peak, parent's RSS at fork time)`,
so forking from pytest would report pytest's ~165 MiB for every invocation.

### Two caveats specific to *this* comparison

**The baseline includes the parent branch.** #3865 is stacked on #3782 —
its base is `feat/DSPX-2604`, not `main`. Dispatching with
`bench-baseline-ref: main` measures the whole stack: the `ChunkedWriter`
introduced in #3782 *and* the rewrite that puts `CreateTDF` on top of it. To
isolate the top commit, set `bench-baseline-ref: feat/DSPX-2604`. Both
dispatches are worth running and they answer different questions — this is the
generalisation of the existing "anything about your change specifically if the
baseline moved too" caveat in the README, and stacked branches make it sharp.

**The server is pinned to `main` regardless.** The bench job always starts the
platform at `main` with a single KAS — the six extra KAS instances the ABAC
tests need would draw background CPU on the runner doing the measuring. #3865
is a client-side SDK change so that is the right call here, but it means the
harness cannot see a candidate whose speed depends on a matching server change.

## The plumbing, and one bug it turned up

Mostly wiring: resolve the two refs with `otdf-sdk-mgr versions resolve`, hand
the result to `setup-cli-tool` in place of the matrix version-info, and pass
`--bench-baseline` / `--bench-candidate` to pytest so arm selection does not
fall back to "newest final release", which does not exist when both arms are
branches.

Fail-fast checks run in `resolve-versions`, before a runner is spent, because a
matrix cannot be narrowed from inside the job it belongs to: only one arm
named, `focus-sdk` left at `all`, or two refs that resolve to the same commit.
That last one is the same trap the README already documents for java, where
`v0.18.0 == main` made `main latest` install one build and every cell skip.

The bug: `otdf-sdk-mgr` flattened `/` to `--` when it resolved a branch reached
**by SHA**, and left the slashes in when it reached the same branch **by name**
— which is the shape a `workflow_dispatch` input arrives in. A dist tag is one
path component; `tdfs.all_versions_of()` lists `dist/*/` and the go `Makefile`
finds `src/*/`. So `feat/DSPX-2604-createtdf-chunked` would have installed as a
build named `feat` with no `cli.sh` in it, and `all_versions_of()` raises on
that during collection, before any cell can report why. Both paths flatten now,
with a test on each.

## Reviewing

- Does `bench-baseline-ref` / `bench-candidate-ref` read as clearly as the
  `*-ref` inputs beside it, given they mean something different (arms of one
  comparison, not versions of a matrix)?
- Narrowing the bench matrix by `focus-sdk` changes existing dispatch
  behaviour. It seems strictly better — nobody dispatching `focus-sdk: go`
  wanted 90 minutes of java and js — but it is a behaviour change, not just an
  addition.
- Is the fail-fast set the right one? Notably it does *not* refuse a candidate
  older than the baseline, which is a legitimate thing to want.

- The second commit's supporting changes are all consequences of 1 GiB being
  survivable rather than of it being requested: chunked payload generation (no
  1 GiB `bytes` in RAM), arm outputs unlinked in a `finally` (2 GiB per cell
  otherwise, so the cell that fails on disk is not the one that filled it), a
  disk preflight (ENOSPC mid-run reads as "this build is broken"), and
  smallest-cell-first ordering so a short run loses the expensive cell rather
  than an arbitrary one. Each is defensible alone; together they are a fair
  amount of machinery to carry for an opt-in size.
- The A/A control stays pinned at 1 MiB rather than following
  `bench-payloads`, so the reported noise floor means the same thing across
  runs. It does mean a `1GiB`-only run's floor is measured at a size no other
  cell uses.

Once this is in I will dispatch both comparisons — `main` and `feat/DSPX-2604`
as baselines — at 1 GiB, and post the tables here.

